### PR TITLE
Ignore *.nif files in Assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ git_installer.exe
 Tools/Setup/.wget-hsts
 
 Assets/**/*.dds
+Assets/**/*.nif
 
 Sources/cov-int/
 Build/


### PR DESCRIPTION
All `*.nif` files in the `Assets` directory should be ignored because they should be placed in `UnpackedArt` instead.