### PR TITLE
Possible fix for city limit scaling by worldsize

### DIFF
--- a/Sources/CvGameObject.cpp
+++ b/Sources/CvGameObject.cpp
@@ -1994,29 +1994,29 @@ void CvGameObjectPlot::disposePythonArgument(void *pArgument)
 }
 
 
-int CvGameObject::adaptValueToGame(uint uiID, int iValue) const
+int CvGameObject::adaptValueToGame(int iID, int iValue) const
 {
-	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(uiID)) / 100;
-	return (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(uiID)) / 100;
+	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(iID)) / 100;
+	return (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(iID)) / 100;
 }
 
-int CvGameObjectPlayer::adaptValueToGame(uint uiID, int iValue) const
+int CvGameObjectPlayer::adaptValueToGame(int iID, int iValue) const
 {
-	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(uiID)) / 100;
-	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(uiID)) / 100;
-	return (iValue * GC.getHandicapInfo(m_pPlayer->getHandicapType()).getPercent(uiID)) / 100;
+	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(iID)) / 100;
+	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(iID)) / 100;
+	return (iValue * GC.getHandicapInfo(m_pPlayer->getHandicapType()).getPercent(iID)) / 100;
 }
 
-int CvGameObjectCity::adaptValueToGame(uint uiID, int iValue) const
+int CvGameObjectCity::adaptValueToGame(int iID, int iValue) const
 {
-	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(uiID)) / 100;
-	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(uiID)) / 100;
-	return (iValue * GC.getHandicapInfo(GET_PLAYER(m_pCity->getOwnerINLINE()).getHandicapType()).getPercent(uiID)) / 100;
+	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(iID)) / 100;
+	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(iID)) / 100;
+	return (iValue * GC.getHandicapInfo(GET_PLAYER(m_pCity->getOwnerINLINE()).getHandicapType()).getPercent(iID)) / 100;
 }
 
-int CvGameObjectUnit::adaptValueToGame(uint uiID, int iValue) const
+int CvGameObjectUnit::adaptValueToGame(int iID, int iValue) const
 {
-	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(uiID)) / 100;
-	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(uiID)) / 100;
-	return (iValue * GC.getHandicapInfo(GET_PLAYER(m_pUnit->getOwnerINLINE()).getHandicapType()).getPercent(uiID)) / 100;
+	iValue = (iValue * GC.getGameSpeedInfo(GC.getGameINLINE().getGameSpeedType()).getPercent(iID)) / 100;
+	iValue = (iValue * GC.getWorldInfo(GC.getMapINLINE().getWorldSize()).getPercent(iID)) / 100;
+	return (iValue * GC.getHandicapInfo(GET_PLAYER(m_pUnit->getOwnerINLINE()).getHandicapType()).getPercent(iID)) / 100;
 }

--- a/Sources/CvGameObject.h
+++ b/Sources/CvGameObject.h
@@ -63,7 +63,7 @@ public:
 	virtual void* addPythonArgument(CyArgsList* argsList) = 0;
 	virtual void disposePythonArgument(void* pArgument) = 0;
 
-	virtual int adaptValueToGame(uint uiID, int iValue) const;
+	virtual int adaptValueToGame(int iID, int iValue) const;
 };
 
 class CvGameObjectGame : public CvGameObject
@@ -133,7 +133,7 @@ public:
 	virtual void* addPythonArgument(CyArgsList* argsList);
 	virtual void disposePythonArgument(void* pArgument);
 
-	virtual int adaptValueToGame(uint uiID, int iValue) const;
+	virtual int adaptValueToGame(int iID, int iValue) const;
 
 protected:
 	CvPlayer* m_pPlayer;
@@ -164,7 +164,7 @@ public:
 	virtual void* addPythonArgument(CyArgsList* argsList);
 	virtual void disposePythonArgument(void* pArgument);
 
-	virtual int adaptValueToGame(uint uiID, int iValue) const;
+	virtual int adaptValueToGame(int iID, int iValue) const;
 
 protected:
 	CvCity* m_pCity;
@@ -193,7 +193,7 @@ public:
 	virtual void* addPythonArgument(CyArgsList* argsList);
 	virtual void disposePythonArgument(void* pArgument);
 
-	virtual int adaptValueToGame(uint uiID, int iValue) const;
+	virtual int adaptValueToGame(int iID, int iValue) const;
 
 protected:
 	CvUnit* m_pUnit;

--- a/Sources/CvGlobals.cpp
+++ b/Sources/CvGlobals.cpp
@@ -443,6 +443,7 @@ m_cszModDir("NONE")
 /* BETTER_BTS_AI_MOD                       END                                                  */
 /************************************************************************************************/
 ,m_bIsInPedia(false)
+,m_iLastTypeID(-1)
 ,m_iActiveLandscapeID(0),
 // uninitialized variables bugfix
 m_iNumPlayableCivilizationInfos(0),
@@ -5475,6 +5476,19 @@ void cvInternalGlobals::setInfoTypeFromString(const char* szType, int idx)
 	char* strCpy = new char[strlen(szType)+1];
 
 	m_infosMap[strcpy(strCpy, szType)] = idx;
+}
+
+// returns the ID if it exists, otherwise assigns a new ID
+int cvInternalGlobals::getOrCreateInfoTypeForString(const char* szType)
+{
+	int iID = getInfoTypeForString(szType, true);
+	if (iID < 0)
+	{
+		m_iLastTypeID++;
+		iID = m_iLastTypeID;
+		setInfoTypeFromString(szType, iID);
+	}
+	return iID;
 }
 
 void cvInternalGlobals::logInfoTypeMap(const char* tagMsg)

--- a/Sources/CvGlobals.h
+++ b/Sources/CvGlobals.h
@@ -362,6 +362,7 @@ public:
 /************************************************************************************************/
 	void addToInfosVectors(void *infoVector);
 	void infosReset();
+	int getOrCreateInfoTypeForString(const char* szType);
 
 	void addDelayedResolution(int* pType, CvString szString);
 	CvString* getDelayedResolution(int* pType);
@@ -1526,6 +1527,8 @@ protected:
 	typedef stdext::hash_map<const char* /* type */, int /* info index */, SZStringHash> InfosMap;
 	InfosMap m_infosMap;
 	std::vector<std::vector<CvInfoBase *> *> m_aInfoVectors;
+
+	int m_iLastTypeID; // last generic type ID assigned (for type strings that do not have an assigned info class) 
 
 	// AIAndy: Delayed resolution of type strings
 	typedef std::map<int*,std::pair<CvString,CvString> > DelayedResolutionMap;

--- a/Sources/CvInfos.cpp
+++ b/Sources/CvInfos.cpp
@@ -15110,9 +15110,9 @@ int CvHandicapInfo::isAIFreeTechs(int i) const
 	return m_pbAIFreeTechs ? m_pbAIFreeTechs[i] : false;
 }
 
-int CvHandicapInfo::getPercent(uint uiID) const
+int CvHandicapInfo::getPercent(int iID) const
 {
-	return m_Percent.getValue(uiID);
+	return m_Percent.getValue(iID);
 }
 
 /************************************************************************************************/
@@ -15760,9 +15760,9 @@ int CvGameSpeedInfo::getTraitGainPercent() const
 }
 //TB GameSpeed end
 
-int CvGameSpeedInfo::getPercent(uint uiID) const
+int CvGameSpeedInfo::getPercent(int iID) const
 {
-	return m_Percent.getValue(uiID);
+	return m_Percent.getValue(iID);
 }
 
 bool CvGameSpeedInfo::read(CvXMLLoadUtility* pXML)
@@ -22853,9 +22853,9 @@ int CvWorldInfo::getCommandersLevelThresholdsPercent() const
 /* Afforess						 END															*/
 /************************************************************************************************/
 
-int CvWorldInfo::getPercent(uint uiID) const
+int CvWorldInfo::getPercent(int iID) const
 {
-	return m_Percent.getValue(uiID);
+	return m_Percent.getValue(iID);
 }
 
 bool CvWorldInfo::read(CvXMLLoadUtility* pXML)

--- a/Sources/CvInfos.h
+++ b/Sources/CvInfos.h
@@ -5109,7 +5109,7 @@ public:
 	int isFreeTechs(int i) const;				// Exposed to Python
 	int isAIFreeTechs(int i) const;				// Exposed to Python
 
-	int getPercent(uint uiID) const;
+	int getPercent(int iID) const;
 
 	void read(FDataStreamBase* stream) {}
 	void write(FDataStreamBase* stream) {}
@@ -5255,7 +5255,7 @@ public:
 
 	void allocateGameTurnInfos(const int iSize);
 
-	int getPercent(uint uiID) const;
+	int getPercent(int iID) const;
 
 	//TB GameSpeed begin
 	int getTraitGainPercent() const;
@@ -6894,7 +6894,7 @@ public:
 
 	bool read(CvXMLLoadUtility* pXML);
 
-	int getPercent(uint uiID) const;
+	int getPercent(int iID) const;
 
 	void copyNonDefaults(CvWorldInfo* pClassInfo = NULL, CvXMLLoadUtility* pXML = NULL);
 

--- a/Sources/IDValueMap.h
+++ b/Sources/IDValueMap.h
@@ -12,7 +12,6 @@
 #define IDVALUEMAP_H
 
 #include "CvXMLLoadUtility.h"
-#include "CvString.h"
 
 // ValueType will usually be int, only value types that are supported by FDataStreamBase as overloaded read and write will work without template specialization
 // The maps are assumed to be small, so a vector of pairs is used
@@ -20,14 +19,12 @@ template <class ValueType, ValueType& defaultValue>
 class IDValueMap
 {
 public:
-	static uint getIDForString(const char* szType);
-
 	void read(FDataStreamBase* pStream)
 	{
 		unsigned int iSize = 0;
 		pStream->Read(&iSize);
 		m_map.resize(iSize);
-		for (unsigned int i=0; i<iSize; i++)
+		for (unsigned int i = 0; i < iSize; i++)
 		{
 			pStream->Read(&(m_map[i].first));
 			pStream->Read(&(m_map[i].second));
@@ -37,7 +34,7 @@ public:
 	void write(FDataStreamBase* pStream)
 	{
 		pStream->Write(m_map.size());
-		for (unsigned int i=0; i<m_map.size(); i++)
+		for (unsigned int i = 0; i < m_map.size(); i++)
 		{
 			pStream->Write(m_map[i].first);
 			pStream->Write(m_map[i].second);
@@ -56,26 +53,25 @@ public:
 				if (pXML->TryMoveToXmlFirstChild())
 				{
 					pXML->GetXmlVal(szTextVal);
-					uint iID = getIDForString(szTextVal);
+					int iID = GC.getOrCreateInfoTypeForString(szTextVal);
 					ValueType val = defaultValue;
 					pXML->GetNextXmlVal(&val);
 					setValue(iID, val);
-					
+
 					pXML->MoveToXmlParent();
 				}
-			}
-			while (pXML->TryMoveToXmlNextSibling());
+			} while (pXML->TryMoveToXmlNextSibling());
 			pXML->MoveToXmlParent();
 		}
 	}
 
 	void copyNonDefaults(IDValueMap<ValueType, defaultValue>* pMap, CvXMLLoadUtility* pXML)
 	{
-		for (unsigned int i=0; i<pMap->m_map.size(); i++)
+		for (unsigned int i = 0; i < pMap->m_map.size(); i++)
 		{
 			bool bNotFound = true;
 			int iID = pMap->m_map[i].first;
-			for (unsigned int j=0; j<m_map.size(); j++)
+			for (unsigned int j = 0; j < m_map.size(); j++)
 			{
 				if (iID == m_map[j].first)
 				{
@@ -92,24 +88,24 @@ public:
 
 	void getCheckSum(unsigned int& iSum)
 	{
-		for (unsigned int i=0; i<m_map.size(); i++)
+		for (unsigned int i = 0; i < m_map.size(); i++)
 		{
 			CheckSum(iSum, m_map[i].first);
 			CheckSum(iSum, m_map[i].second);
 		}
 	}
 
-	ValueType getValue(uint iID) const
+	ValueType getValue(int iID) const
 	{
-		for (uint i = 0; i < m_map.size(); i++)
+		for (unsigned int i = 0; i < m_map.size(); i++)
 			if (m_map[i].first == iID)
 				return m_map[i].second;
 		return defaultValue;
 	}
 
-	void setValue(uint iID, ValueType val)
+	void setValue(int iID, ValueType val)
 	{
-		for (uint i = 0; i < m_map.size(); i++)
+		for (unsigned int i = 0; i < m_map.size(); i++)
 		{
 			if (m_map[i].first == iID)
 			{
@@ -122,8 +118,7 @@ public:
 
 
 protected:
-	std::vector<std::pair<uint,ValueType> > m_map;
-	static std::vector<std::pair<uint,CvString> > s_IDmap;
+	std::vector<std::pair<int, ValueType> > m_map;
 };
 
 extern int g_iPercentDefault;
@@ -131,23 +126,5 @@ extern int g_iModifierDefault;
 
 typedef IDValueMap<int, g_iPercentDefault> IDValueMapPercent;
 typedef IDValueMap<int, g_iModifierDefault> IDValueMapModifier;
-
-template <class ValueType, ValueType& defaultValue>
-std::vector<std::pair<uint,CvString> > IDValueMap<ValueType, defaultValue>::s_IDmap;
-
-template <class ValueType, ValueType& defaultValue>
-uint IDValueMap<ValueType, defaultValue>::getIDForString(const char* szType)
-{
-	for (std::vector<std::pair<uint,CvString> >::iterator it = s_IDmap.begin(); it != s_IDmap.end(); ++it)
-	{
-		if (it->second.CompareNoCase(szType) == 0)
-		{
-			return it->first;
-		}
-	}
-	uint uiID = s_IDmap.size();
-	s_IDmap.push_back(std::make_pair(uiID, szType));
-	return uiID;
-}
 
 #endif

--- a/Sources/IntExpr.cpp
+++ b/Sources/IntExpr.cpp
@@ -86,7 +86,7 @@ IntExpr* IntExpr::read(CvXMLLoadUtility *pXML)
 				IntExpr* pExpr = read(pXML);
 				
 				pXML->MoveToXmlParent();
-				return new IntExprAdapt(pExpr, IDValueMapPercent::getIDForString(szTextVal));
+				return new IntExprAdapt(pExpr, GC.getOrCreateInfoTypeForString(szTextVal));
 			}
 		}
 	}
@@ -781,13 +781,13 @@ IntExprAdapt::~IntExprAdapt()
 
 int IntExprAdapt::evaluate(CvGameObject *pObject)
 {
-	return pObject->adaptValueToGame(m_uiID, m_pExpr->evaluate(pObject));
+	return pObject->adaptValueToGame(m_iID, m_pExpr->evaluate(pObject));
 }
 
 void IntExprAdapt::buildDisplayString(CvWStringBuffer &szBuffer) const
 {
 	CvWString szTextVal;
-	szTextVal.Format(L"%d", GC.getGameINLINE().getGameObject()->adaptValueToGame(m_uiID, m_pExpr->evaluate(GC.getGameINLINE().getGameObject())));
+	szTextVal.Format(L"%d", GC.getGameINLINE().getGameObject()->adaptValueToGame(m_iID, m_pExpr->evaluate(GC.getGameINLINE().getGameObject())));
 	szBuffer.append(szTextVal);
 }
 
@@ -799,7 +799,7 @@ int IntExprAdapt::getBindingStrength() const
 void IntExprAdapt::getCheckSum(unsigned int &iSum)
 {
 	m_pExpr->getCheckSum(iSum);
-	CheckSum(iSum, m_uiID);
+	CheckSum(iSum, m_iID);
 }
 
 

--- a/Sources/IntExpr.h
+++ b/Sources/IntExpr.h
@@ -235,7 +235,7 @@ protected:
 class IntExprAdapt : public IntExpr
 {
 public:
-	IntExprAdapt(IntExpr* pExpr = NULL, uint uiID = 0) : m_pExpr(pExpr), m_uiID(uiID) {}
+	IntExprAdapt(IntExpr* pExpr = NULL, int iID = 0) : m_pExpr(pExpr), m_iID(iID) {}
 	virtual ~IntExprAdapt();
 	virtual int evaluate(CvGameObject* pObject);
 	virtual void getCheckSum(unsigned int& iSum);
@@ -243,7 +243,7 @@ public:
 	virtual int getBindingStrength() const;
 protected:
 	IntExpr* m_pExpr;
-	uint m_uiID;
+	int m_iID;
 };
 
 


### PR DESCRIPTION
I reverted some changes from svn10994 to fix IDValueMap and it's usages.
These changes broke the adaptValueToGame functionality including the city limit scaling by worldsize.

Fixes #63