### PR TITLE
SVN 11042

### DIFF
--- a/Assets/Modules/Pepper2000/Pepper2000Earth_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Pepper2000/Pepper2000Earth_CIV4BuildingInfos.xml
@@ -16167,7 +16167,7 @@
 		<BuildingInfo>
 			<BuildingClass>BUILDINGCLASS_MUNITIONS_FACTORY</BuildingClass>
 			<Type>BUILDING_MUNITIONS_FACTORY</Type>
-			<ObsoleteTech>TECH_COILGUN</ObsoleteTech>
+			<ObsoleteTech>TECH_WARMACHINES</ObsoleteTech>
 			<ReplaceBuildings>
 				<ReplaceBuilding>
 					<BuildingClassType>BUILDINGCLASS_MILITARY_INDUSTRIAL_COMPLEX</BuildingClassType>

--- a/Assets/XML/Buildings/Regular_CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/Regular_CIV4BuildingInfos.xml
@@ -32587,7 +32587,7 @@
 				</BuildingClassNeeded>
 			</BuildingClassNeededs>
 			<!-- Obsolescence -->
-			<ObsoleteTech>TECH_FLASHMEMORY</ObsoleteTech>
+			<ObsoleteTech>TECH_WEARABLE_ELECTRONICS</ObsoleteTech>
 			<!-- Construction cost -->
 			<iCost>1410</iCost>
 			<!-- Main effects -->


### PR DESCRIPTION
Ammunition and diskettes factories were obsoleted bit early catching players off guard (replacements were available in same column).