### PR TITLE
feat(Language): german translations to some of the new pedia labels

### DIFF
--- a/Assets/Python/Contrib/Pedia/PediaBonus.py
+++ b/Assets/Python/Contrib/Pedia/PediaBonus.py
@@ -144,9 +144,9 @@ class PediaBonus:
 		szTxt = ""
 		if iMinLatitude or iMaxLatitude < 90:
 			if not iMinLatitude:
-				szTxt = szfont4b + "<color=200,240,120,255>Exist in latitude: 0&#176  &#187  &#177 " + str(iMaxLatitude) + "&#176"
+				szTxt = szfont4b + "<color=200,240,120,255>" + TRNSLTR.getText("TXT_KEY_PEDIA_LATITUDE", ()) + " 0&#176  &#187  &#177 " + str(iMaxLatitude) + "&#176"
 			else:
-				szTxt = szfont4b + "<color=200,240,120,255>Exist in latitude: &#177 " + str(iMinLatitude) + "&#176  &#187  &#177 " + str(iMaxLatitude) + "&#176"
+				szTxt = szfont4b + "<color=200,240,120,255>" + TRNSLTR.getText("TXT_KEY_PEDIA_LATITUDE", ()) + " &#177 " + str(iMinLatitude) + "&#176  &#187  &#177 " + str(iMaxLatitude) + "&#176"
 		szChange = ""
 		for k in range(eNumYieldTypes):
 			iYieldChange = CvTheBonusInfo.getYieldChange(k)

--- a/Assets/Python/Contrib/Pedia/PediaBuilding.py
+++ b/Assets/Python/Contrib/Pedia/PediaBuilding.py
@@ -103,7 +103,7 @@ class PediaBuilding:
 				szCost = TRNSLTR.getText("TXT_KEY_PEDIA_COST", ((iProductionCost * GC.getDefineINT("BUILDING_PRODUCTION_PERCENT"))/100,))
 			screen.appendListBoxStringNoUpdate(panelName, szfont3b + szCost + u'%c' %GC.getYieldInfo(YieldTypes.YIELD_PRODUCTION).getChar(), eWidGen, 0, 0, 1<<0)
 		elif CvTheBuildingInfo.isAutoBuild():
-			screen.appendListBoxStringNoUpdate(panelName, szfont3 + "Auto-Build", eWidGen, 0, 0, 1<<0)
+			screen.appendListBoxStringNoUpdate(panelName, szfont3 + TRNSLTR.getText("TXT_KEY_PEDIA_AUTOBUILD",()) , eWidGen, 0, 0, 1<<0)
 		if CvTheBuildingInfo.isGoldenAge():
 			szText1 = unichr(8866) + "<color=255,200,0,255> Golden Age"
 			screen.appendListBoxStringNoUpdate(panelName, szfont3 + szText1, eWidGen, 0, 0, 1<<0)

--- a/Assets/XML/Text/Pedia_CIV4GameText.xml
+++ b/Assets/XML/Text/Pedia_CIV4GameText.xml
@@ -9,12 +9,13 @@
 		<Tag>TXT_KEY_CIVILOPEDIA_BACKGROUND</Tag>
 		<English>Background:[PARAGRAPH:1]</English>
 		<French>Contexte:[PARAGRAPH:1]</French>
-		<German>Hintergrund:[PARAGRAPH:1]</German>
+		<German>Hintergrund:[NEWLINE]</German>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_CIVILOPEDIA_STRATEGY</Tag>
 		<English>Strategy:[PARAGRAPH:1]</English>
 		<French>Stratégie:[PARAGRAPH:1]</French>
+		<German>Strategie:[NEWLINE]</German>
 		<Italian>Strategia:[PARAGRAPH:1]</Italian>
 		<Spanish>Estrategia:[PARAGRAPH:1]</Spanish>
 	</TEXT>
@@ -24,6 +25,11 @@
 		<German>Attitüde: [BOLD]%d1%[\BOLD] (Basis) + [BOLD]%d2%[\BOLD] (gegenüber Kriegstreibern)[NEWLINE]</German>
 		<Spanish>Actitud: [BOLD]%d1%[\BOLD] (base) + [BOLD]%d2%[\BOLD] (estima bélica)[NEWLINE]</Spanish>
 		<Polish>Podstawa: [BOLD]%d1%%[\BOLD] (Baza) + [BOLD]%d2%[\BOLD] (Podżegacz Wojenny)[NEWLINE]</Polish>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_PEDIA_AUTOBUILD</Tag>
+		<English>Auto-Build</English>
+		<German>automatisch</German>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PEDIA_BONUS_APPEARANCE_AND_TRADE</Tag>
@@ -603,7 +609,7 @@
 		<Tag>TXT_KEY_PEDIA_CATEGORY_SUBCOMBAT_TYPE</Tag>
 		<English>Sub Combat Types</English>
 		<French>Type de Spé-Combat</French>
-		<German>(E) Unterkategorien</German>
+		<German>Unterkategorien</German>
 		<Spanish>Subtipos de combate</Spanish>
 		<Polish>Typy Walki</Polish>
 	</TEXT>
@@ -736,12 +742,12 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PEDIA_HISTORY</Tag>
-		<English>History:[PARAGRAPH:1]</English>
-		<French>Historique:[PARAGRAPH:1]</French>
-		<German>Geschichte:[PARAGRAPH:1]</German>
-		<Italian>Storia:[PARAGRAPH:1]</Italian>
-		<Spanish>Historia:[PARAGRAPH:1]</Spanish>
-		<Polish>Historia:[PARAGRAPH:1]</Polish>
+		<English>History</English>
+		<French>Historique</French>
+		<German>Geschichte</German>
+		<Italian>Storia</Italian>
+		<Spanish>Historia</Spanish>
+		<Polish>Historia</Polish>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PEDIA_IMPROVEMENT_AIR_DEFENSE</Tag>
@@ -760,6 +766,11 @@
 		<Italian>Può essere costruito all'esterno dei confini culturali</Italian>
 		<Spanish>Se puede construir fuera de las fronteras de la civilización</Spanish>
 		<Polish>Może zostać zbudowany wewnątrz granic kulturowych</Polish>
+	</TEXT>
+	<TEXT>
+		<Tag>TXT_KEY_PEDIA_LATITUDE</Tag>
+		<English>Exist in latitude:</English>
+		<German>Geografische Breite:</German>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PEDIA_LIMITED_WAR</Tag>
@@ -809,6 +820,7 @@
 		<Tag>TXT_KEY_PEDIA_QUOTE</Tag>
 		<English>Quote</English>
 		<French>Citations</French>
+		<German>Zitat</German>
 		<Spanish>Cita</Spanish>
 		<Polish>Wpis</Polish>
 	</TEXT>

--- a/Assets/XML/Text/Promotions_CIV4GameText.xml
+++ b/Assets/XML/Text/Promotions_CIV4GameText.xml
@@ -8802,6 +8802,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTION_INVISIBILE_PLOT_CHANGE_TEXT</Tag>
 		<English>[ICON_BULLET]%D1_Mod %F2_Icon Veil on %s3_Type.</English>
+		<German>[ICON_BULLET]%D1_Mod %F2_Icon-Unsichtbarkeit %s3_Type.</German>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTION_INVISIBILITY_INTENSITY_CHANGE_TEXT</Tag>


### PR DESCRIPTION
My first pull request. I keep it small, cause it's mainly a test, if I made everything right. 
Content: Some new translations for latitude and auto-build pedia labels and some minor corrections
- the history label should now display correctly
- German newline instead of paragraph to suppress hanging feeder (not used in German)