### PR TITLE
fix(pedia): sun, brown bears entry no longer states they make bird buildings

### DIFF
--- a/Assets/XML/Text/Units_CIV4GameText.xml
+++ b/Assets/XML/Text/Units_CIV4GameText.xml
@@ -23152,8 +23152,7 @@ Lived:[\BOLD] 1805 - 1874[BOLD]
 		<Tag>TXT_KEY_UNIT_SUBDUED_BROWN_BEAR_HELP</Tag>
 		<English>[ICON_BULLET][COLOR_YELLOW]HELP: [COLOR_REVERT][COLOR_HIGHLIGHT_TEXT]Build[COLOR_REVERT] Myth, Story and Stories -  Brown Bear
 [ICON_BULLET]Myth- Bears
-[ICON_BULLET]Bird Cage and Enclosure
-[ICON_BULLET]Feather Worker and Parrots</English>
+[ICON_BULLET]Bear Cage and Enclosure</English>
 
 		<Polish>[COLOR_HIGHLIGHT_TEXT]Buduj[COLOR_REVERT] Mit, Opowieść i Historie - Niedźwiedź Brunatny
 [ICON_BULLET]Mity - Niedźwiedzie
@@ -23581,9 +23580,8 @@ Lived:[\BOLD] 1805 - 1874[BOLD]
 	<TEXT>
 		<Tag>TXT_KEY_UNIT_SUBDUED_SUN_BEAR_HELP</Tag>
 		<English>[ICON_BULLET][COLOR_YELLOW]HELP: [COLOR_REVERT][COLOR_HIGHLIGHT_TEXT]Build[COLOR_REVERT] Myth, Story and Stories -  Sun Bear
-[ICON_BULLET]Myths of Sky and Birds
-[ICON_BULLET]Bird Cage and Enclosure
-[ICON_BULLET]Feather Worker and Parrots</English>
+[ICON_BULLET]Myth- Bears
+[ICON_BULLET]Bear Cage and Enclosure</English>
 
 		<Polish>[COLOR_HIGHLIGHT_TEXT]Buduj[COLOR_REVERT] Mit, Opowieść i Historie - Niedźwiedź Malajski
 [ICON_BULLET]Mity - Niedźwiedzie


### PR DESCRIPTION
Sun and Brown bears had a pedia entry suggesting they construct bird buildings, not bear ones (their actual functionality was fine). Tiny change, mostly to see if I can figure out git kraken / how best to submit text fixes I find