### PR TITLE
fix(wonder prereqs): mostly animal trainer+heritages and units, plus log roller

### DIFF
--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Bear/Bear_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Bear/Bear_CIV4BuildingInfos.xml
@@ -61,47 +61,47 @@
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_ASIANBEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_ASIANBEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_BLACK_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_BLACK_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_BROWN_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_BROWN_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_CAVE_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_CAVE_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_GRIZZLY_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_GRIZZLY_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_PANDA_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_PANDA_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_POLAR_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_POLAR_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_REDPANDA_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_REDPANDA_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_SLOTH_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_SLOTH_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_SPECTACLED_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_SPECTACLED_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
-					<BuildingClassType>BUILDINGCLASS_SUN_BEAR_MYTH_EFFECT</BuildingClassType>
+					<BuildingClassType>BUILDINGCLASS_SUN_BEAR_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 			</PrereqOrBuildingClasses>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Bear/Bear_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Bear/Bear_CIV4GameText.xml
@@ -90,7 +90,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_BEAR_TRAINER_EFFECT</Tag>
-		<English>Effect - heritage - Bears</English>
+		<English>Effect - Heritage - Bears</English>
 		<French>Effet - Patrimoine (Ours)</French>
 		<Polish>Efekt - Dziedzictwo - Niedźwiedź</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Big_Cats/Big_Cats_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Big_Cats/Big_Cats_CIV4BuildingInfos.xml
@@ -24,6 +24,7 @@
 				<MapCategoryType>MAPCATEGORY_EARTH</MapCategoryType>
 			</MapCategoryTypes>
 			<FreeBuilding>BUILDINGCLASS_BIG_CAT_TRAINER_EFFECT</FreeBuilding>
+            <Bonus>BONUS_CAT</Bonus>
 			<iCost>624</iCost>
 			<iTradeRoutes>1</iTradeRoutes>
 			<iAsset>4</iAsset>
@@ -61,6 +62,14 @@
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_BENGALTIGER_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_SIBERIAN_TIGER_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_TIGER_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
@@ -70,6 +79,10 @@
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_SABRETOOTH_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_CAVE_LION_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Big_Cats/Big_Cats_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Big_Cats/Big_Cats_CIV4GameText.xml
@@ -70,7 +70,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_BIG_CAT_TRAINER_EFFECT</Tag>
-		<English>Effect - Big Cat Trainer</English>
+		<English>Effect - Heritage - Big Cats</English>
 		<French>Effet (Entraineur de Félins)</French>
 		<Polish>Efekt - Treser Wielkich Kotów</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Bison_Rider/BisonRider_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Bison_Rider/BisonRider_CIV4GameText.xml
@@ -72,7 +72,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_BISON_TRAINER_EFFECT</Tag>
-		<English>Effect - heritage - Bison</English>
+		<English>Effect - Heritage - Bison</English>
 		<French>Effet - Patrimoine (Bisons)</French>
 		<Polish>Efekt - Dziedzictwo - Bizon</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Bison_Rider/BisonTrainer_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Bison_Rider/BisonTrainer_CIV4BuildingInfos.xml
@@ -59,7 +59,15 @@
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_BISON_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_BISON_HERD</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_MUSKOX_CAMP</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
 				<PrereqOrBuildingClass>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/DeerRider/DeerRider_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/DeerRider/DeerRider_CIV4BuildingInfos.xml
@@ -20,6 +20,7 @@
 			<MapCategoryTypes>
 				<MapCategoryType>MAPCATEGORY_EARTH</MapCategoryType>
 			</MapCategoryTypes>
+            <Bonus>BONUS_DEER</Bonus>
 			<iCost>624</iCost>
 			<iConquestProb>0</iConquestProb>
 			<iMinLatitude>45</iMinLatitude>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/DeerRider/DeerRider_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/DeerRider/DeerRider_CIV4GameText.xml
@@ -89,8 +89,8 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_DEER_TRAINER_EFFECT</Tag>
-		<English>Effect - Deer Trainer Heritage</English>
-		<French>Effet - Patrimoine (Cervidés).</French>
+		<English>Effect - Heritage - Deer</English>
+		<French>Effet - Patrimoine (Cervidés)</French>
 		<Polish>Efekt - Dziedzictwo Tresera Jeleni</Polish>
 	</TEXT>
 	<TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Giraffe/Giraffe_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Giraffe/Giraffe_CIV4GameText.xml
@@ -97,7 +97,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_GIRAFFE_TRAINER_EFFECT</Tag>
-		<English>Effect - Giraffe Trainer Heritage</English>
+		<English>Effect - Heritage - Giraffes</English>
 		<French>Effet - Patrimoine (Girafes)</French>
 		<Polish>Efekt - Dziedzictwo - Żyrafa</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4BuildingInfos.xml
@@ -131,6 +131,10 @@
 					<BuildingClassType>BUILDINGCLASS_MAMMOTH_HERD</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_PALEOLITHIC_MAMMOTH_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
 			</PrereqOrBuildingClasses>
 		</BuildingInfo>
 		<BuildingInfo>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4BuildingInfos.xml
@@ -76,6 +76,7 @@
 					<iNumFreeBonuses>1</iNumFreeBonuses>
 				</ExtraFreeBonus>
 			</ExtraFreeBonuses>
+            <Bonus>BONUS_MAMMOTH</Bonus>
 			<iCost>624</iCost>
 			<iMinLatitude>40</iMinLatitude>
 			<iHealth>-1</iHealth>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Mammoths/Mammoths_CIV4GameText.xml
@@ -40,7 +40,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_MAMMOTH_TRAINER_EFFECT</Tag>
-		<English>Effect - heritage - Mammoth</English>
+		<English>Effect - Heritage - Mammoths</English>
 		<French>Effet - Patrimoine (Mammouth)</French>
 		<Polish>Efekt - Dziedzictwo - Mamut</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/Rhinoceros_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/Rhinoceros_CIV4GameText.xml
@@ -84,7 +84,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_RHINO_TRAINER_EFFECT</Tag>
-		<English>Effect - Rhinoceros Trainer Heritage</English>
+		<English>Effect - Heritage - Rhinos</English>
 		<French>Effet - Patrimoine (Rhinocéros)</French>
 		<Polish>Efekt - Dziedzictwo - Nosorożec</Polish>
 	</TEXT>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/Rhinoceros_CIV4UnitInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/Rhinoceros_CIV4UnitInfos.xml
@@ -72,7 +72,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_RHINO_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+                <BuildingType>BUILDING_RHINO_TRAINER_EFFECT</BuildingType>
+                <BuildingType>BUILDING_RHINO_TRAINER</BuildingType>
+            </PrereqOrBuildings>
 			<PrereqTech>TECH_IRON_WORKING</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
@@ -151,7 +154,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_RHINO_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+                <BuildingType>BUILDING_RHINO_TRAINER</BuildingType>
+                <BuildingType>BUILDING_RHINO_TRAINER_EFFECT</BuildingType>
+            </PrereqOrBuildings>
 			<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
 			<iCost>94</iCost>
 			<iMoves>1</iMoves>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/zDepend_Rhinoceros_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/zDepend_Rhinoceros_CIV4BuildingInfos.xml
@@ -52,4 +52,13 @@
 			</PrereqOrBuildingClasses>
 		</BuildingInfo>
 	</BuildingInfos>
+    <BuildingInfo>
+        <Type>BUILDING_RHINO_TRAINER</Type>
+        <PrereqOrBuildingClasses>
+            <PrereqOrBuildingClass>
+                <BuildingClassType>BUILDINGCLASS_ELASMOTHERIUM_MYTH</BuildingClassType>
+                <bPrereqBuildingClass>1</bPrereqBuildingClass>
+            </PrereqOrBuildingClass>
+        </PrereqOrBuildingClasses>
+    </BuildingInfo>
 </Civ4BuildingInfos>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/zDepend_Rhinoceros_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Rhinoceros/zDepend_Rhinoceros_CIV4BuildingInfos.xml
@@ -13,52 +13,27 @@
 					<BuildingClassType>BUILDINGCLASS_RHINO_TAXONOMY_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
-			</PrereqOrBuildingClasses>
-		</BuildingInfo>
-		<BuildingInfo>
-			<Type>BUILDING_RHINO_TRAINER</Type>
-			<PrereqOrBuildingClasses>
 				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_BLACK_RHINO_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
-			</PrereqOrBuildingClasses>
-		</BuildingInfo>
-		<BuildingInfo>
-			<Type>BUILDING_RHINO_TRAINER</Type>
-			<PrereqOrBuildingClasses>
 				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_INDIAN_RHINO_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
-			</PrereqOrBuildingClasses>
-		</BuildingInfo>
-		<BuildingInfo>
-			<Type>BUILDING_RHINO_TRAINER</Type>
-			<PrereqOrBuildingClasses>
 				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_JAVA_RHINO_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
-			</PrereqOrBuildingClasses>
-		</BuildingInfo>
-		<BuildingInfo>
-			<Type>BUILDING_RHINO_TRAINER</Type>
-			<PrereqOrBuildingClasses>
 				<PrereqOrBuildingClass>
 					<BuildingClassType>BUILDINGCLASS_WHITE_RHINO_MYTH</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
-			</PrereqOrBuildingClasses>
-		</BuildingInfo>
-	</BuildingInfos>
-    <BuildingInfo>
-        <Type>BUILDING_RHINO_TRAINER</Type>
-        <PrereqOrBuildingClasses>
-            <PrereqOrBuildingClass>
-                <BuildingClassType>BUILDINGCLASS_ELASMOTHERIUM_MYTH</BuildingClassType>
-                <bPrereqBuildingClass>1</bPrereqBuildingClass>
-            </PrereqOrBuildingClass>
-        </PrereqOrBuildingClasses>
-    </BuildingInfo>
+                <PrereqOrBuildingClass>
+                    <BuildingClassType>BUILDINGCLASS_ELASMOTHERIUM_MYTH</BuildingClassType>
+                    <bPrereqBuildingClass>1</bPrereqBuildingClass>
+                </PrereqOrBuildingClass>
+            </PrereqOrBuildingClasses>
+        </BuildingInfo>
+    </BuildingInfos>
 </Civ4BuildingInfos>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4BuildingInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4BuildingInfos.xml
@@ -83,6 +83,10 @@
 					<BuildingClassType>BUILDINGCLASS_ZEBRA_CAMP</BuildingClassType>
 					<bPrereqBuildingClass>1</bPrereqBuildingClass>
 				</PrereqOrBuildingClass>
+				<PrereqOrBuildingClass>
+					<BuildingClassType>BUILDINGCLASS_ZEBRA_MYTH</BuildingClassType>
+					<bPrereqBuildingClass>1</bPrereqBuildingClass>
+				</PrereqOrBuildingClass>
 			</PrereqOrBuildingClasses>
 		</BuildingInfo>
 		<BuildingInfo>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4GameText.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4GameText.xml
@@ -137,13 +137,13 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_ZEBRA_TRAINER_EFFECT</Tag>
-		<English>Effect - heritage - Zebra</English>
+		<English>Effect - Heritage - Zebras</English>
 		<French>Effet - Patrimoine (Zèbres)</French>
 		<Polish>Efekt - Dziedzictwo - Zebra</Polish>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDING_ZEBRA_TRAINER_HELP</Tag>
-		<English>[ICON_BULLET][COLOR_YELLOW]HELP: [COLOR_REVERT]Allows the training of Zebra units,.</English>
+		<English>[ICON_BULLET][COLOR_YELLOW]HELP: [COLOR_REVERT]Allows the training of Zebra units.</English>
 		<French>Permet l'entraînement d'unités avec des zèbres.</French>
 	</TEXT>
 </Civ4GameText>

--- a/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4UnitInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Megafauna_Units/Zebra_Mounts/ZebraMounts_CIV4UnitInfos.xml
@@ -92,7 +92,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_ZEBRA_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+				<BuildingType>BUILDING_ZEBRA_TRAINER_EFFECT</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_TRAINER</BuildingType>
+			</PrereqOrBuildings>
 			<PrereqTech>TECH_MOUNTED_ARCHERY</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
@@ -253,7 +256,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_ZEBRA_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+				<BuildingType>BUILDING_ZEBRA_TRAINER_EFFECT</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_TRAINER</BuildingType>
+			</PrereqOrBuildings>
 			<PrereqTech>TECH_STEAM_POWER</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
@@ -440,7 +446,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_ZEBRA_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+				<BuildingType>BUILDING_ZEBRA_TRAINER_EFFECT</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_TRAINER</BuildingType>
+			</PrereqOrBuildings>
 			<PrereqTech>TECH_CHARIOTRY</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
@@ -569,7 +578,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_ZEBRA_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+				<BuildingType>BUILDING_ZEBRA_TRAINER_EFFECT</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_TRAINER</BuildingType>
+			</PrereqOrBuildings>
 			<PrereqTech>TECH_CAVALRY_TACTICS</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>
@@ -753,7 +765,10 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
-			<PrereqBuilding>BUILDING_ZEBRA_TRAINER</PrereqBuilding>
+			<PrereqOrBuildings>
+				<BuildingType>BUILDING_ZEBRA_TRAINER_EFFECT</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_TRAINER</BuildingType>
+			</PrereqOrBuildings>
 			<PrereqTech>TECH_ARMORED_CAVALRY</PrereqTech>
 			<TechTypes>
 				<PrereqTech>TECH_MEGAFAUNA_DOMESTICATION</PrereqTech>

--- a/Assets/XML/Buildings/NationalWonders_CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/NationalWonders_CIV4BuildingInfos.xml
@@ -3938,6 +3938,10 @@
 					<FeatureType>FEATURE_FOREST</FeatureType>
 					<bPrereqFeature>1</bPrereqFeature>
 				</PrereqFeature>
+				<PrereqFeature>
+					<FeatureType>FEATURE_FOREST_OLD</FeatureType>
+					<bPrereqFeature>1</bPrereqFeature>
+				</PrereqFeature>
 			</PrereqOrFeature>
 			<!-- Obsolescence -->
 			<ObsoleteTech>TECH_ENGINEERING</ObsoleteTech>


### PR DESCRIPTION
This should be it for matching the alternate history animal trainer wonders and units with each other (plus the log roller because it annoyed me once), though the entire animal trainer module really needs a polishing pass or two; it's all over the place, both in coding practices and pedia text