### PR TITLE
fix(audio): mp tech quotes now either vanilla mp quotes or just 'ding'

### DIFF
--- a/Assets/Modules/Alt_Timelines/Atompunk/Atompunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Atompunk/Atompunk_CIV4TechInfos.xml
@@ -10,7 +10,7 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<Quote>TXT_KEY_CULTURE_ATOMPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATOMPUNK</Sound>
-			<SoundMP>AS2D_TECH_ATOMPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/retrospace.dds</Button>
 			<!-- Main properties -->
 			<iCost>13181</iCost>

--- a/Assets/Modules/Alt_Timelines/Biopunk/Biopunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Biopunk/Biopunk_CIV4TechInfos.xml
@@ -10,7 +10,7 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<Quote>TXT_KEY_CULTURE_BIOPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOPUNK</Sound>
-			<SoundMP>AS2D_TECH_BIOPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/biopunk.dds</Button>
 			<!-- Main properties -->
 			<iCost>40165</iCost>

--- a/Assets/Modules/Alt_Timelines/Clockpunk/Clockpunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Clockpunk/Clockpunk_CIV4TechInfos.xml
@@ -46,7 +46,7 @@
 			</AndPreReqs>
 			<Quote>TXT_KEY_CULTURE_CLOCKPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLOCKPUNK</Sound>
-			<SoundMP>AS2D_TECH_CLOCKPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/clockpunk.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Alt_Timelines/Cyberpunk/Cyberpunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Cyberpunk/Cyberpunk_CIV4TechInfos.xml
@@ -10,7 +10,7 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<Quote>TXT_KEY_CULTURE_CYBERPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_CYBERPUNK2</Sound>
-			<SoundMP>AS2D_TECH_CYBERPUNK2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cyberpunk.dds</Button>
 			<!-- Main properties -->
 			<iCost>67710</iCost>

--- a/Assets/Modules/Alt_Timelines/Dieselpunk/Dieselpunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Dieselpunk/Dieselpunk_CIV4TechInfos.xml
@@ -10,7 +10,7 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<Quote>TXT_KEY_CULTURE_DIESELPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_DIESELPUNK</Sound>
-			<SoundMP>AS2D_TECH_DIESELPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/dieselpunk.dds</Button>
 			<!-- Main properties -->
 			<iCost>10744</iCost>

--- a/Assets/Modules/Alt_Timelines/Nanopunk/Nanopunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Nanopunk/Nanopunk_CIV4TechInfos.xml
@@ -10,7 +10,7 @@
 			<Advisor>ADVISOR_CULTURE</Advisor>
 			<Quote>TXT_KEY_CULTURE_NANOPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOPUNK</Sound>
-			<SoundMP>AS2D_TECH_NANOPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/nanopunk.dds</Button>
 			<!-- Main properties -->
 			<iCost>38858</iCost>

--- a/Assets/Modules/Alt_Timelines/Steampunk/Steampunk_CIV4TechInfos.xml
+++ b/Assets/Modules/Alt_Timelines/Steampunk/Steampunk_CIV4TechInfos.xml
@@ -44,7 +44,7 @@
 			</AndPreReqs>
 			<Quote>TXT_KEY_CULTURE_STEAMPUNK_QUOTE</Quote>
 			<Sound>AS2D_TECH_STEAMPUNK</Sound>
-			<SoundMP>AS2D_TECH_STEAMPUNK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/steampunk.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Andean/Andeanism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Andean/Andeanism_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_ANDEAN_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANDEANISM</Sound>
-			<SoundMP>AS2D_TECH_ANDEANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/andeanism.dds</Button>
 			<!-- Main properties -->
 			<iCost>242</iCost>

--- a/Assets/Modules/Custom_Religions/Asatru/Asatru_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Asatru/Asatru_CIV4TechInfos.xml
@@ -42,7 +42,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_ASATRU_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASATRU</Sound>
-			<SoundMP>AS2D_TECH_ASATRU</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/asatru.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Bahai/Bahai_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Bahai/Bahai_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_BAHAI_QUOTE</Quote>
 			<Sound>AS2D_TECH_BAHAI</Sound>
-			<SoundMP>AS2D_TECH_BAHAI</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Bahai.dds</Button>
 			<!-- Main properties -->
 			<iCost>5187</iCost>

--- a/Assets/Modules/Custom_Religions/Canaanism/Canaanism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Canaanism/Canaanism_CIV4TechInfos.xml
@@ -34,7 +34,7 @@
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_CANAANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CANAANISM</Sound>
-			<SoundMP>AS2D_TECH_CANAANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Canaanism.dds</Button>
 		</TechInfo>

--- a/Assets/Modules/Custom_Religions/Caodai/CaoDai_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Caodai/CaoDai_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_CAODAI_QUOTE</Quote>
 			<Sound>AS2D_TECH_CAODAIISM</Sound>
-			<SoundMP>AS2D_TECH_CAODAIISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Caodai.dds</Button>
 			<!-- Main properties -->
 			<iCost>9484</iCost>

--- a/Assets/Modules/Custom_Religions/Druid/Druidism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Druid/Druidism_CIV4TechInfos.xml
@@ -39,7 +39,7 @@
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_DRUID_QUOTE</Quote>
 			<Sound>AS2D_TECH_DRUIDISM</Sound>
-			<SoundMP>AS2D_TECH_DRUIDISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/interface/buttons/techtree/Druidism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Jainism/Jainism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Jainism/Jainism_CIV4TechInfos.xml
@@ -42,7 +42,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_JAINISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_JAINISM</Sound>
-			<SoundMP>AS2D_TECH_JAINISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Jainism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Mesopotamian/Mesopotamism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Mesopotamian/Mesopotamism_CIV4TechInfos.xml
@@ -42,7 +42,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_MESO_QUOTE</Quote>
 			<Sound>AS2D_TECH_MESOPOTAMISM</Sound>
-			<SoundMP>AS2D_TECH_MESOPOTAMISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mesopotamian.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Mormon/Mormon_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Mormon/Mormon_CIV4TechInfos.xml
@@ -39,7 +39,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_MORMON_QUOTE</Quote>
 			<Sound>AS2D_TECH_MORMON</Sound>
-			<SoundMP>AS2D_TECH_MORMON</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mormonism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Ngai/Ngaiism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Ngai/Ngaiism_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_NGAI_QUOTE</Quote>
 			<Sound>AS2D_TECH_NGAIISM</Sound>
-			<SoundMP>AS2D_TECH_NGAIISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Ngai.dds</Button>
 			<!-- Main properties -->
 			<iCost>242</iCost>

--- a/Assets/Modules/Custom_Religions/Rodnovery/Rodnovery_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Rodnovery/Rodnovery_CIV4TechInfos.xml
@@ -42,7 +42,7 @@
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_RODNOVERY_QUOTE</Quote>
 			<Sound>AS2D_TECH_RODNOVERY</Sound>
-			<SoundMP>AS2D_TECH_RODNOVERY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/techtree/Rodnovery.dds</Button>
 		</TechInfo>

--- a/Assets/Modules/Custom_Religions/Scientology/Scientology_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Scientology/Scientology_CIV4TechInfos.xml
@@ -36,7 +36,7 @@
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_SCIENTOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCIENTOLOGY2</Sound>
-			<SoundMP>AS2D_TECH_SCIENTOLOGY2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Scientology.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Shaman/Shamanism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Shaman/Shamanism_CIV4TechInfos.xml
@@ -39,7 +39,7 @@
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_SHAMAN_QUOTE</Quote>
 			<Sound>AS2D_TECH_SHAMANISM</Sound>
-			<SoundMP>AS2D_TECH_SHAMANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/shamanism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Shinto/Shinto_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Shinto/Shinto_CIV4TechInfos.xml
@@ -39,7 +39,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_SHINTOISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_SHINTOISM</Sound>
-			<SoundMP>AS2D_TECH_SHINTOISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Shintoism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Sikh/Sikhism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Sikh/Sikhism_CIV4TechInfos.xml
@@ -36,7 +36,7 @@
 			</Flavors>
 			<Quote>TXT_KEY_RELIGION_SIKHISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_SIKHISM</Sound>
-			<SoundMP>AS2D_TECH_SIKHISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/sikhism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Tengri/Tengriism_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Tengri/Tengriism_CIV4TechInfos.xml
@@ -39,7 +39,7 @@
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_TENGRIISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_TENGRIISM2</Sound>
-			<SoundMP>AS2D_TECH_TENGRIISM2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/tengriism.dds</Button>
 		</TechInfo>
 	</TechInfos>

--- a/Assets/Modules/Custom_Religions/Voodoo/Voodoo_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Voodoo/Voodoo_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_VOODOO_QUOTE</Quote>
 			<Sound>AS2D_TECH_VOODOO</Sound>
-			<SoundMP>AS2D_TECH_VOODOO</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Voodoo.dds</Button>
 			<!-- Main properties -->
 			<iCost>1334</iCost>

--- a/Assets/Modules/Custom_Religions/Yoruba/Yoruba_CIV4TechInfos.xml
+++ b/Assets/Modules/Custom_Religions/Yoruba/Yoruba_CIV4TechInfos.xml
@@ -11,7 +11,7 @@
 			<Advisor>ADVISOR_RELIGION</Advisor>
 			<Quote>TXT_KEY_RELIGION_YORUBA_QUOTE</Quote>
 			<Sound>AS2D_TECH_YORUBA2</Sound>
-			<SoundMP>AS2D_TECH_YORUBA2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Yoruba.dds</Button>
 			<!-- Main properties -->
 			<iCost>187</iCost>

--- a/Assets/XML/Technologies/CIV4TechInfos.xml
+++ b/Assets/XML/Technologies/CIV4TechInfos.xml
@@ -8900,7 +8900,7 @@ Current techs which are not in this file:-
 			</PrereqBuildingClasses>
 			<Quote>TXT_KEY_TECH_WATERPROOF_CEMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Concrete.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12614,7 +12614,7 @@ Current techs which are not in this file:-
 			</PrereqBuildingClasses>
 			<Quote>TXT_KEY_TECH_LEAD_GLASS_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/GlassBlowing.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14441,7 +14441,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_STATISTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/statistics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15807,7 +15807,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_INCANDESCENT_LIGHTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/incandescent_lighting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16288,7 +16288,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TELEPHONE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/telephone.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -16322,7 +16322,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MANAGEMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/management.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16805,7 +16805,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ABSTRACT_MATHEMATICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/abstract_mathematics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18721,7 +18721,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COMPUTER_SCIENCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/computer_science.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18966,7 +18966,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_POSTMODERNISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/postmodernism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21093,7 +21093,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CHAOS_THEORY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/chaos_theory.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21884,6 +21884,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DERIVATIVES_QUOTE</Quote>
 			<Sound>AS2D_TECH_DERIVATIVES</Sound>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/derivatives.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22918,7 +22919,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INDUSTRIAL_ECOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/industrial_ecology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22996,7 +22997,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AUTONOMOUS_VEHICLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/autonomous_vehicles.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -23034,7 +23035,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMPUTATIONAL_SOCIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/computational_sociology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32588,7 +32589,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_JOVIAN_TERRAFORMING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENERIC</Sound>
-			<SoundMP/>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/jovian_terraforming.dds</Button>
 		</TechInfo>
 		<TechInfo>

--- a/Assets/XML/Technologies/CIV4TechInfos.xml
+++ b/Assets/XML/Technologies/CIV4TechInfos.xml
@@ -41,6 +41,7 @@ Current techs which are not in this file:-
 	( 113, 07 ) TECH_CYBERPUNK
 	( 102, 11 ) TECH_NANOPUNK
 -->
+<!-- <Civ4TechInfos> -->
 <Civ4TechInfos xmlns="x-schema:../Schema/C2C_CIV4TechnologiesSchema.xml">
 	<TechInfos>
 		<TechInfo>
@@ -69,7 +70,7 @@ Current techs which are not in this file:-
 			</Flavors>
 			<Quote>TXT_KEY_TECH_CAVE_DWELLING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CAVE_DWELLING</Sound>
-			<SoundMP>AS2D_TECH_CAVE_DWELLING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cavedwelling.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -97,7 +98,7 @@ Current techs which are not in this file:-
 			</Flavors>
 			<Quote>TXT_KEY_TECH_NOMADIC_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_NOMADIC_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_NOMADIC_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Exploration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -126,7 +127,7 @@ Current techs which are not in this file:-
 			</Flavors>
 			<Quote>TXT_KEY_TECH_LANGUAGE_QUOTE</Quote>
 			<Sound>AS2D_TECH_LANGUAGE</Sound>
-			<SoundMP>AS2D_TECH_LANGUAGE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/language.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -169,7 +170,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SCAVENGING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCAVENGING</Sound>
-			<SoundMP>AS2D_TECH_SCAVENGING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/scavenging.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -202,7 +203,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_GATHERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GATHERING</Sound>
-			<SoundMP>AS2D_TECH_GATHERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_GrainGathering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -253,7 +254,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_TRACKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRACKING</Sound>
-			<SoundMP>AS2D_TECH_TRACKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/tracking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -289,7 +290,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DECEPTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_DECEPTION</Sound>
-			<SoundMP>AS2D_TECH_DECEPTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/buttons/techs/DeceptionTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -345,7 +346,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TOOL_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_TOOL_MAKING</Sound>
-			<SoundMP>AS2D_TECH_TOOL_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Stone_tools.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,4,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -380,7 +381,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HERBALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_HERBALISM</Sound>
-			<SoundMP>AS2D_TECH_HERBALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Herbalism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -407,7 +408,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CONTROLLED_FIRE_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONTROLLED_FIRE</Sound>
-			<SoundMP>AS2D_TECH_CONTROLLED_FIRE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/controlledfire.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -454,7 +455,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WEAVING_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEAVING</Sound>
-			<SoundMP>AS2D_TECH_WEAVING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Weaving.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -487,7 +488,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ORAL_TRADITION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORAL_TRADITION</Sound>
-			<SoundMP>AS2D_TECH_ORAL_TRADITION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_OralTradition.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -533,7 +534,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SHELTER_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SHELTER_BUILDING</Sound>
-			<SoundMP>AS2D_TECH_SHELTER_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/shelterbuilding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -576,7 +577,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COOPERATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_COOPERATION</Sound>
-			<SoundMP>AS2D_TECH_COOPERATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cooperation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -623,7 +624,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HARD_HAMMER_PERCUSSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_HARD_HAMMER_PERCUSSION</Sound>
-			<SoundMP>AS2D_TECH_HARD_HAMMER_PERCUSSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_StoneTools.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -670,7 +671,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSISTENCE_HUNTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PERSISTENCE_HUNTING</Sound>
-			<SoundMP>AS2D_TECH_PERSISTENCE_HUNTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/PersistenceHunting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -718,7 +719,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BASKETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_BASKETRY</Sound>
-			<SoundMP>AS2D_TECH_BASKETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/basketry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -754,7 +755,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PREHISTORIC_MUSIC_QUOTE</Quote>
 			<Sound>AS2D_TECH_PREHISTORIC_MUSIC</Sound>
-			<SoundMP>AS2D_TECH_PREHISTORIC_MUSIC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_PrehistoricMusic.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -793,7 +794,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BINDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BINDING</Sound>
-			<SoundMP>AS2D_TECH_BINDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/binding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -837,7 +838,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COUNTING_QUOTE</Quote>
 			<Sound>AS2D_COUNTING</Sound>
-			<SoundMP>AS2D_COUNTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/counting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -881,7 +882,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SOFT_HAMMER_PERCUSSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOFT_HAMMER_PERCUSSION</Sound>
-			<SoundMP>AS2D_TECH_SOFT_HAMMER_PERCUSSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/softhammerpercussion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -915,7 +916,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GROUND_STONE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GROUND_STONE</Sound>
-			<SoundMP>AS2D_TECH_GROUND_STONE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/groundstones.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -962,7 +963,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RITUALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_RITUALISM</Sound>
-			<SoundMP>AS2D_TECH_RITUALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/ritualism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,15</Button>
 		</TechInfo>
 		<TechInfo>
@@ -993,7 +994,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COOKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_COOKING</Sound>
-			<SoundMP>AS2D_TECH_COOKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_CookedFood.dds</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -1028,7 +1029,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PREHISTORIC_DANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_PREHISTORIC_DANCE</Sound>
-			<SoundMP>AS2D_TECH_PREHISTORIC_DANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/prehistoricdance.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1056,7 +1057,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SCRAPING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCRAPING</Sound>
-			<SoundMP>AS2D_TECH_SCRAPING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/scraping.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1100,7 +1101,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CHOPPING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHOPPING</Sound>
-			<SoundMP>AS2D_TECH_CHOPPING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/chopping.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1136,7 +1137,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PIERCING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PIERCING</Sound>
-			<SoundMP>AS2D_TECH_PIERCING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/piercing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1183,7 +1184,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRAPPING_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRAPPING</Sound>
-			<SoundMP>AS2D_TECH_TRAPPING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/trapping.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1218,7 +1219,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NATURAL_PIGMENTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NATURAL_PIGMENTS</Sound>
-			<SoundMP>AS2D_TECH_NATURAL_PIGMENTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_NaturalPigments.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1254,7 +1255,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CULTURAL_IDENTITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CULTURAL_IDENTITY</Sound>
-			<SoundMP>AS2D_TECH_CULTURAL_IDENTITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_CulturalIdentity.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1292,7 +1293,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SEWING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SEWING</Sound>
-			<SoundMP>AS2D_TECH_SEWING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/sewing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1339,7 +1340,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BARK_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BARK_WORKING</Sound>
-			<SoundMP>AS2D_TECH_BARK_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/barkworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1386,7 +1387,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SKINNING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SKINNING</Sound>
-			<SoundMP>AS2D_TECH_SKINNING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/skinning.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1422,7 +1423,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CARVING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CARVING</Sound>
-			<SoundMP>AS2D_TECH_CARVING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/carving.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1455,7 +1456,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FINE_EDGED_TOOLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_FINE_EDGED_TOOLS</Sound>
-			<SoundMP>AS2D_TECH_FINE_EDGED_TOOLS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_FineEdgedTools.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1490,7 +1491,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_POISON_CRAFTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_POISON_CRAFTING</Sound>
-			<SoundMP>AS2D_TECH_POISON_CRAFTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/poisoncrafting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1525,7 +1526,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DRYING_QUOTE</Quote>
 			<Sound>AS2D_DRYING</Sound>
-			<SoundMP>AS2D_DRYING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/drying.dds</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -1570,7 +1571,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GAMES_QUOTE</Quote>
 			<Sound>AS2D_TECH_GAMES</Sound>
-			<SoundMP>AS2D_TECH_GAMES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Games.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1605,7 +1606,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRAP_FISHING_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRAP_FISHING</Sound>
-			<SoundMP>AS2D_TECH_TRAP_FISHING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_EarlyFishing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1647,7 +1648,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADHESIVES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADHESIVES</Sound>
-			<SoundMP>AS2D_TECH_ADHESIVES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/adhesives.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1683,7 +1684,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BONE_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BONE_WORKING</Sound>
-			<SoundMP>AS2D_TECH_BONE_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/boneworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1719,7 +1720,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FLINT_KNAPPING_QUOTE</Quote>
 			<Sound>AS2D_TECH_FLINT_KNAPPING</Sound>
-			<SoundMP>AS2D_TECH_FLINT_KNAPPING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/flintknapping.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1806,7 +1807,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PETROGLYPHS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PETROGLYPHS</Sound>
-			<SoundMP>AS2D_TECH_PETROGLYPHS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_CavePainting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1854,7 +1855,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSONAL_ADORNMENT_QUOTE</Quote>
 			<Sound>AS2D_PERSONAL_ADORNMENT</Sound>
-			<SoundMP>AS2D_PERSONAL_ADORNMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/personaladornment.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1891,7 +1892,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMPOSITE_TOOLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMPOSITE_TOOLS</Sound>
-			<SoundMP>AS2D_TECH_COMPOSITE_TOOLS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/compositetools.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1926,7 +1927,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SIMPLE_WOOD_WORKING_QUOTE</Quote>
 			<Sound>AS2D_SIMPLE_WOOD_WORKING</Sound>
-			<SoundMP>AS2D_SIMPLE_WOOD_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/simplewoodworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -1958,7 +1959,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MICROLITH_QUOTE</Quote>
 			<Sound>AS2D_MICROLITH</Sound>
-			<SoundMP>AS2D_MICROLITH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Microlith.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2000,7 +2001,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NATUROPATHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NATUROPATHY</Sound>
-			<SoundMP>AS2D_TECH_NATUROPATHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/naturopath.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,12</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -2036,7 +2037,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_THEFT_QUOTE</Quote>
 			<Sound>AS2D_TECH_THEFT</Sound>
-			<SoundMP>AS2D_TECH_THEFT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/buttons/techs/TheftTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2070,7 +2071,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CONDUCT_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONDUCT</Sound>
-			<SoundMP>AS2D_TECH_CONDUCT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/conduct.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2106,7 +2107,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPEAR_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPEAR_MAKING</Sound>
-			<SoundMP>AS2D_TECH_SPEAR_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/spearmaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2154,7 +2155,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BEAD_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BEAD_MAKING</Sound>
-			<SoundMP>AS2D_TECH_BEAD_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/beadmaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2209,7 +2210,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RAFT_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_RAFT_BUILDING</Sound>
-			<SoundMP>AS2D_RAFT_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/raftbuilding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2248,7 +2249,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FIRE_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_FIRE_MAKING</Sound>
-			<SoundMP>AS2D_TECH_FIRE_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_TheFire.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2284,7 +2285,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AXE_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_AXE_MAKING</Sound>
-			<SoundMP>AS2D_TECH_AXE_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/axemaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2329,7 +2330,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PORTABLE_SHELTERS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PORTABLE_SHELTERS</Sound>
-			<SoundMP>AS2D_TECH_PORTABLE_SHELTERS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/portableshelter.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2363,7 +2364,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TATTOOS_QUOTE</Quote>
 			<Sound>AS2D_TECH_TATTOOS</Sound>
-			<SoundMP>AS2D_TECH_TATTOOS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/tattoos.dds</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -2409,7 +2410,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CEREMONIAL_BURIAL_QUOTE</Quote>
 			<Sound>AS2D_TECH_CEREMONIAL_BURIAL</Sound>
-			<SoundMP>AS2D_TECH_CEREMONIAL_BURIAL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_CeremonialBurial.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2452,7 +2453,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPEARFISHING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPEARFISHING</Sound>
-			<SoundMP>AS2D_TECH_SPEARFISHING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Spearfishing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2499,7 +2500,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HEAT_TREATMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_HEAT_TREATMENT</Sound>
-			<SoundMP>AS2D_TECH_HEAT_TREATMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/heattreatment.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2542,7 +2543,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TANNING_QUOTE</Quote>
 			<Sound>AS2D_TECH_TANNING</Sound>
-			<SoundMP>AS2D_TECH_TANNING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/tanning2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2586,7 +2587,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WOOD_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_Woodworking</Sound>
-			<SoundMP>AS2D_TECH_Woodworking</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_WoodWorking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2625,7 +2626,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STONE_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_STONE_BUILDING</Sound>
-			<SoundMP>AS2D_TECH_STONE_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_HutBuilding.dds</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -2660,7 +2661,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BARTER_QUOTE</Quote>
 			<Sound>AS2D_TECH_BARTER</Sound>
-			<SoundMP>AS2D_TECH_BARTER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Barter.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2700,7 +2701,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SLASH_AND_BURN_QUOTE</Quote>
 			<Sound>AS2D_TECH_SLASH_AND_BURN</Sound>
-			<SoundMP>AS2D_TECH_SLASH_AND_BURN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/SlashBurn.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2731,7 +2732,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CARPENTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CARPENTRY</Sound>
-			<SoundMP>AS2D_TECH_CARPENTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/carpentry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2774,7 +2775,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ATLATL_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATLATL_MAKING</Sound>
-			<SoundMP>AS2D_TECH_ATLATL_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/atlatlmaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2813,7 +2814,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PICTOGRAPHS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PICTOGRAPHS</Sound>
-			<SoundMP>AS2D_TECH_PICTOGRAPHS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/pictographs.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2847,7 +2848,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BOAT_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BOAT_BUILDING</Sound>
-			<SoundMP>AS2D_TECH_BOAT_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/boatbuilding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2884,7 +2885,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_OBSIDIAN_WEAPONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_OBSIDIAN_WEAPONS</Sound>
-			<SoundMP>AS2D_TECH_OBSIDIAN_WEAPONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/obsidianweapons.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2919,7 +2920,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARITHMETIC_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARITHMETIC</Sound>
-			<SoundMP>AS2D_TECH_ARITHMETIC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/arithmetic.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2959,7 +2960,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRIBALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRIBALISM</Sound>
-			<SoundMP>AS2D_TECH_TRIBALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Tribalism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -2990,7 +2991,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HUNTING_TACTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HUNTING_TACTICS</Sound>
-			<SoundMP>AS2D_TECH_HUNTING_TACTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/huntingtactics.dds</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -3029,7 +3030,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANIMISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANIMISM</Sound>
-			<SoundMP>AS2D_TECH_ANIMISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Animism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3102,7 +3103,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_EARTH_OVEN_QUOTE</Quote>
 			<Sound>AS2D_TECH_EARTH_OVEN</Sound>
-			<SoundMP>AS2D_TECH_EARTH_OVEN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/earthoven.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3136,7 +3137,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CHIEFDOM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHIEFDOM</Sound>
-			<SoundMP>AS2D_TECH_CHIEFDOM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Chiefdom.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3164,7 +3165,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NOCTURNALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_NOCTURNALISM</Sound>
-			<SoundMP>AS2D_TECH_NOCTURNALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Nocturnalism.dds</Button>
 		</TechInfo>		
 <!--	(014, 17) TECH_ANIMISM		-->
@@ -3206,7 +3207,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HARPOON_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_HARPOON_MAKING</Sound>
-			<SoundMP>AS2D_TECH_HARPOON_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/harpoonmaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3237,7 +3238,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_Warfare.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3331,7 +3332,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SLAVERY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SLAVERY</Sound>
-			<SoundMP>AS2D_TECH_SLAVERY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/slave.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,16</Button>
 		</TechInfo>		
 		<TechInfo>
@@ -3365,7 +3366,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CELEBRATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CELEBRATION</Sound>
-			<SoundMP>AS2D_TECH_CELEBRATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/celebration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3393,7 +3394,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CANINE_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CANINE_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_CANINE_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_DogBreeding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3421,7 +3422,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FELINE_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_FELINE_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_FELINE_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/felinedomestication.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3468,7 +3469,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_POULTRY_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_POULTRY_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_POULTRY_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Poultry_Domestication.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3512,7 +3513,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PACHYDERM_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_PACHYDERM_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_PACHYDERM_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/ElephantRiding.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,6</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3556,7 +3557,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CAMELID_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CAMELID_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_CAMELID_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Camel_Riding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3603,7 +3604,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_EQUINE_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_EQUINE_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_EQUINE_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/equinedomestication.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3721,7 +3722,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MEGAFAUNA_DOMESTICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEGAFAUNA_DOMESTICATION</Sound>
-			<SoundMP>AS2D_TECH_MEGAFAUNA_DOMESTICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/megafaunadomestication.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3762,7 +3763,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEGALITH_CONSTRUCTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEGALITH_CONSTRUCTION</Sound>
-			<SoundMP>AS2D_TECH_MEGALITH_CONSTRUCTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/megalithconstruction.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3808,7 +3809,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SEDENTARY_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SEDENTARY_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_SEDENTARY_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Button_SedentaryLifeStyle.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3847,7 +3848,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_IDEOGRAMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_IDEOGRAMS</Sound>
-			<SoundMP>AS2D_TECH_IDEOGRAMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ideograms.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3957,7 +3958,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COMMUNITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMMUNITY</Sound>
-			<SoundMP>AS2D_TECH_COMMUNITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/community.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -3992,7 +3993,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TAXONOMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_TAXONOMY</Sound>
-			<SoundMP>AS2D_TECH_TAXONOMY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/taxonomy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4065,7 +4066,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BREAD_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BREAD_MAKING</Sound>
-			<SoundMP>AS2D_TECH_BREAD_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/breadmaking2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4096,7 +4097,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CONSCIOUSNESS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONSCIOUSNESS</Sound>
-			<SoundMP>AS2D_TECH_CONSCIOUSNESS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/consciousness.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4135,7 +4136,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FOLK_MUSIC_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOLK_MUSIC</Sound>
-			<SoundMP>AS2D_TECH_FOLK_MUSIC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/folkmusic.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4174,7 +4175,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FOLK_DANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOLK_DANCE</Sound>
-			<SoundMP>AS2D_TECH_FOLK_DANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/folkdance.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4219,7 +4220,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CASTE_SYSTEM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CASTE_SYSTEM</Sound>
-			<SoundMP>AS2D_TECH_CASTE_SYSTEM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/CasteSystem.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4261,7 +4262,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FUNGICULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_FUNGICULTURE</Sound>
-			<SoundMP>AS2D_TECH_FUNGICULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/fungiculture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4302,7 +4303,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_APICULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_APICULTURE</Sound>
-			<SoundMP>AS2D_TECH_APICULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/apiculture2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4407,7 +4408,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MINING2</Sound>
-			<SoundMP>AS2D_TECH_MINING2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Mining.dds,Art/Interface/Buttons/TechTree_Atlas.dds,8,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4481,7 +4482,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ANCESTOR_WORSHIP_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANCESTOR_WORSHIP</Sound>
-			<SoundMP>AS2D_TECH_ANCESTOR_WORSHIP</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ancestorworship.dds</Button>
 		</TechInfo>
 <!--	(022, 19) TECH_MESOPOTAMISM	-->
@@ -4516,7 +4517,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ORCHARDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORCHADS</Sound>
-			<SoundMP>AS2D_TECH_ORCHADS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/orchards2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4550,7 +4551,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXPLORATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXPLORATION</Sound>
-			<SoundMP>AS2D_TECH_EXPLORATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/exploration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4599,7 +4600,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NAVAL_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAVAL_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_NAVAL_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/NavalWarfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4650,7 +4651,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CHARIOTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHARIOTRY</Sound>
-			<SoundMP>AS2D_TECH_CHARIOTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Chariotry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4684,7 +4685,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STANDARDIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_STANDARDIZATION</Sound>
-			<SoundMP>AS2D_TECH_STANDARDIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/standardization2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4715,7 +4716,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HERITAGE_QUOTE</Quote>
 			<Sound>AS2D_TECH_HERITAGE</Sound>
-			<SoundMP>AS2D_TECH_HERITAGE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/heritage.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4762,7 +4763,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BLOOD_CULT_QUOTE</Quote>
 			<Sound>AS2D_TECH_BLOOD_CULT</Sound>
-			<SoundMP>AS2D_TECH_BLOOD_CULT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/BloodCult.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4797,7 +4798,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MUMMIFICATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MUMMIFICATION</Sound>
-			<SoundMP>AS2D_TECH_MUMMIFICATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mummification.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4836,7 +4837,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FERMENTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_FERMENTATION</Sound>
-			<SoundMP>AS2D_TECH_FERMENTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/fermentation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4882,7 +4883,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STARGAZING_QUOTE</Quote>
 			<Sound>AS2D_TECH_STARGAZING</Sound>
-			<SoundMP>AS2D_TECH_STARGAZING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/stargazing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4912,7 +4913,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NEGOTIATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_NEGOTIATION_LORE</Sound>
-			<SoundMP>AS2D_TECH_NEGOTIATION_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Negotiation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4952,7 +4953,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COPPER_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_COPPER_WORKING</Sound>
-			<SoundMP>AS2D_TECH_COPPER_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/copperworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -4987,7 +4988,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PULLEY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PULLEY</Sound>
-			<SoundMP>AS2D_TECH_PULLEY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/pulley2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5072,7 +5073,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LEAD_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LEAD_WORKING</Sound>
-			<SoundMP>AS2D_TECH_LEAD_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/leadworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5114,7 +5115,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BOARDGAMES_QUOTE</Quote>
 			<Sound>AS2D_TECH_BOARDGAMES</Sound>
-			<SoundMP>AS2D_TECH_BOARDGAMES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Boardgames.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5149,7 +5150,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FOLK_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOLK_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_FOLK_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/folkmedicine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5187,7 +5188,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_OIL_LAMPS_QUOTE</Quote>
 			<Sound>AS2D_TECH_OIL_LAMPS</Sound>
-			<SoundMP>AS2D_TECH_OIL_LAMPS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/oillamps.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5223,7 +5224,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_Trade</Sound>
-			<SoundMP>AS2D_TECH_Trade</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Currency.dds,Art/Interface/Buttons/Warlords_Atlas_1.dds,5,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5264,7 +5265,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLOUGH_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLOUGH</Sound>
-			<SoundMP>AS2D_TECH_PLOUGH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/plough2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5339,7 +5340,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_TEXTILE_LOOM_QUOTE</Quote>
 			<Sound>AS2D_TECH_TEXTILE_LOOM</Sound>
-			<SoundMP>AS2D_TECH_TEXTILE_LOOM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/loom2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5381,7 +5382,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SALT_PROCESSING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SALT_PROCESSING</Sound>
-			<SoundMP>AS2D_TECH_SALT_PROCESSING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/saltprocessing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5415,7 +5416,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CEREMONY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CEREMONY</Sound>
-			<SoundMP>AS2D_TECH_CEREMONY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ceremony.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5449,7 +5450,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SOAP_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOAP_MAKING</Sound>
-			<SoundMP>AS2D_TECH_SOAP_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/soapmaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5498,7 +5499,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PIRACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PIRACY</Sound>
-			<SoundMP>AS2D_TECH_PIRACY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/piracy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5537,7 +5538,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_IRRIGATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_Irrigation</Sound>
-			<SoundMP>AS2D_TECH_Irrigation</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Irrigation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5578,7 +5579,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SERICULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SERICULTURE</Sound>
-			<SoundMP>AS2D_TECH_SERICULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/sericulture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5620,7 +5621,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SCULPTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCULPTURE</Sound>
-			<SoundMP>AS2D_TECH_SCULPTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Stone_working.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,5,1</Button>
 		</TechInfo>
 <!--	(026, 15) TECH_YORUBA	-->
@@ -5704,7 +5705,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FALCONRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_FALCONRY</Sound>
-			<SoundMP>AS2D_TECH_FALCONRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Falconry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5745,7 +5746,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GARDENING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GARDENING</Sound>
-			<SoundMP>AS2D_TECH_GARDENING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/gardening.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5780,7 +5781,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LEISURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_LEISURE</Sound>
-			<SoundMP>AS2D_TECH_LEISURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/leisure.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5815,7 +5816,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ORNAMENTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORNAMENTATION</Sound>
-			<SoundMP>AS2D_TECH_ORNAMENTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ornamentation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5852,7 +5853,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DUALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_DUALISM</Sound>
-			<SoundMP>AS2D_TECH_DUALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Dualism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5928,7 +5929,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DIVINATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_DIVINATION</Sound>
-			<SoundMP>AS2D_TECH_DIVINATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/divination.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -5970,7 +5971,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CANDLE_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CANDLE_MAKING</Sound>
-			<SoundMP>AS2D_TECH_CANDLE_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/candlemaking.dds</Button>
 		</TechInfo>
 <!--	(028, 03) TECH_SHINTOISM	-->
@@ -6006,7 +6007,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPECIALIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPECIALIZATION</Sound>
-			<SoundMP>AS2D_TECH_SPECIALIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/specialization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6054,7 +6055,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SUNDIAL_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUNDIAL</Sound>
-			<SoundMP>AS2D_TECH_SUNDIAL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/sundialtech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6088,7 +6089,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FURNITURE_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_FURNITURE_MAKING</Sound>
-			<SoundMP>AS2D_TECH_FURNITURE_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/furnituremaking2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6170,7 +6171,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MATRIARCHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MATRIARCHY</Sound>
-			<SoundMP>AS2D_TECH_MATRIARCHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/matriarchy.dds</Button>
 		</TechInfo>
 <!--	(028, 17) TECH_ANDEANISM	-->
@@ -6217,7 +6218,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RESURRECTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_RESURRECTION</Sound>
-			<SoundMP>AS2D_TECH_RESURRECTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/resurrection.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6252,7 +6253,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LOCKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_LOCKS</Sound>
-			<SoundMP>AS2D_TECH_LOCKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/locks.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6332,7 +6333,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLUMBING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLUMBING</Sound>
-			<SoundMP>AS2D_TECH_PLUMBING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/plumbing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6367,7 +6368,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GEAR_QUOTE</Quote>
 			<Sound>AS2D_TECH_GEAR</Sound>
-			<SoundMP>AS2D_TECH_GEAR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/gear.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6401,7 +6402,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CUISINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_CUISINE</Sound>
-			<SoundMP>AS2D_TECH_CUISINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cuisine2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6473,7 +6474,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_VETERIANARY_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_VETERIANARY_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_VETERIANARY_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/vmedicine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6507,7 +6508,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PATRIARCHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PATRIARCHY</Sound>
-			<SoundMP>AS2D_TECH_PATRIARCHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/patriarchy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6543,7 +6544,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MAGIC_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAGIC</Sound>
-			<SoundMP>AS2D_TECH_MAGIC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/magic.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6659,7 +6660,7 @@ Current techs which are not in this file:-
 			</TerrainTrades>
 			<Quote>TXT_KEY_TECH_SEAFARING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SEAFARING</Sound>
-			<SoundMP>AS2D_TECH_SEAFARING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Seafaring.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6693,7 +6694,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BRASS_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BRASS_WORKING</Sound>
-			<SoundMP>AS2D_TECH_BRASS_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/brassworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6727,7 +6728,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CENTRAL_HEATING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CENTRAL_HEATING</Sound>
-			<SoundMP>AS2D_TECH_CENTRAL_HEATING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/centralheating.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6761,7 +6762,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HYDRAULIC_MINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_HYDRAULIC_MINING</Sound>
-			<SoundMP>AS2D_TECH_HYDRAULIC_MINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/hmining.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6802,7 +6803,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SCRIPTURES_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCRIPTURES</Sound>
-			<SoundMP>AS2D_TECH_SCRIPTURES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/scriptures.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6840,7 +6841,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_ZOROASTRIANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_ZOROASTRIANISM</Sound>
-			<SoundMP>AS2D_TECH_ZOROASTRIANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Zoroastrianism.dds</Button>
 		</TechInfo>
@@ -6888,7 +6889,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_KARMA_QUOTE</Quote>
 			<Sound>AS2D_TECH_KARMA</Sound>
-			<SoundMP>AS2D_TECH_KARMA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/karma.dds</Button>
 		</TechInfo>
 <!--	(030, 17) TECH_CANAANITE	-->
@@ -6929,7 +6930,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_EGYPT_MYTHOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_KEMETISM</Sound>
-			<SoundMP>AS2D_TECH_KEMETISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Kemetism.dds</Button>
 		</TechInfo>
@@ -6957,7 +6958,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CLOUD_PATTERNS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLOUD_PATTERNS</Sound>
-			<SoundMP>AS2D_TECH_CLOUD_PATTERNS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/CloudPatterns.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -6991,7 +6992,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LINGUISTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_LINGUISTICS</Sound>
-			<SoundMP>AS2D_TECH_LINGUISTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/llinguistics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7029,7 +7030,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GLASS_BLOWING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GLASS_BLOWING</Sound>
-			<SoundMP>AS2D_TECH_GLASS_BLOWING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/GlassBlowing.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7067,7 +7068,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_HINDUISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_REINCARNATION</Sound>
-			<SoundMP>AS2D_TECH_REINCARNATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Hinduism.dds</Button>
 		</TechInfo>
@@ -7106,7 +7107,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_JUDAISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_JUDAISM</Sound>
-			<SoundMP>AS2D_TECH_JUDAISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/judaism.dds</Button>
 		</TechInfo>
@@ -7188,7 +7189,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_REINCARNATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_REINCARNATION2</Sound>
-			<SoundMP>AS2D_TECH_REINCARNATION2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/reincarnation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7233,7 +7234,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CLASSICAL_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLASSICAL_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_CLASSICAL_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/classicallifestyle.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7281,7 +7282,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SHIP_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SHIP_BUILDING</Sound>
-			<SoundMP>AS2D_TECH_SHIP_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Shipbuilding.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7326,7 +7327,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARISTOCRACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARISTOCRACY</Sound>
-			<SoundMP>AS2D_TECH_ARISTOCRACY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/Civics/Hereditary_Rule.dds,Art/Interface/Buttons/Civics_Civilizations_Religions_Atlas.dds,3,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7363,7 +7364,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MILITARY_TRAINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MILITARY_TRAINING</Sound>
-			<SoundMP>AS2D_TECH_MILITARY_TRAINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/MedievalCombat.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7515,7 +7516,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MAIL_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAIL</Sound>
-			<SoundMP>AS2D_TECH_MAIL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mail.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7641,7 +7642,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HORSE_BREEDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_HORSE_BREEDING2</Sound>
-			<SoundMP>AS2D_TECH_HORSE_BREEDING2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Horsebreeding.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7673,7 +7674,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ANCIENT_MACHINERY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANCIENT_MACHINERY</Sound>
-			<SoundMP>AS2D_TECH_ANCIENT_MACHINERY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/amachinery.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7705,7 +7706,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ATHLETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATHLETICS</Sound>
-			<SoundMP>AS2D_TECH_ATHLETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Athletics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7746,7 +7747,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_GEOMETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GEOMETRY</Sound>
-			<SoundMP>AS2D_TECH_GEOMETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/geometry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7788,7 +7789,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ROAD_BUILDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ROAD_BUILDING</Sound>
-			<SoundMP>AS2D_TECH_ROAD_BUILDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Roadbuilding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7836,7 +7837,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CRYPTOGRAPHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CRYPTOGRAPHY_LORE</Sound>
-			<SoundMP>AS2D_TECH_CRYPTOGRAPHY_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Cryptography.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -7961,7 +7962,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_BUDDHISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_BUDDHISM</Sound>
-			<SoundMP>AS2D_TECH_BUDDHISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Buddhism.dds</Button>
 		</TechInfo>
@@ -7999,7 +8000,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MOUNTED_ARCHERY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOUNTED_ARCHERY</Sound>
-			<SoundMP>AS2D_TECH_MOUNTED_ARCHERY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mounted_archery.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8035,7 +8036,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STIRRUP_QUOTE</Quote>
 			<Sound>AS2D_TECH_STIRRUP</Sound>
-			<SoundMP>AS2D_TECH_STIRRUP</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Stirrup.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,3,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8073,7 +8074,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COMBAT_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_COMBAT_SPORTS</Sound>
-			<SoundMP>AS2D_COMBAT_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Combat_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8111,7 +8112,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_HELLENISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_HELLENISM</Sound>
-			<SoundMP>AS2D_TECH_HELLENISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Hellenism.dds</Button>
 		</TechInfo>
@@ -8205,7 +8206,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CITY_PLANNING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CITY_PLANNING</Sound>
-			<SoundMP>AS2D_TECH_CITY_PLANNING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/CityPlanning.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8301,7 +8302,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LAW_ENFORCEMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_LAW_ENFORCEMENT</Sound>
-			<SoundMP>AS2D_TECH_LAW_ENFORCEMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/buttons/techs/LawEnforcementTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8337,7 +8338,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DIPLOMACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_DIPLOMACY_LORE</Sound>
-			<SoundMP>AS2D_TECH_DIPLOMACY_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Diplomacy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8413,7 +8414,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_NAGHUALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAGHUALISM</Sound>
-			<SoundMP>AS2D_TECH_NAGHUALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/naghualism.dds</Button>
 		</TechInfo>
@@ -8453,7 +8454,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPICE_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPICE_TRADE</Sound>
-			<SoundMP>AS2D_TECH_SPICE_TRADE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/spice_trade.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8499,7 +8500,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROLOGY</Sound>
-			<SoundMP>AS2D_TECH_ASTROLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astrology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8546,7 +8547,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CALLIGRAPHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CALLIGRAPHY</Sound>
-			<SoundMP>AS2D_TECH_CALLIGRAPHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/calligraphy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8589,7 +8590,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANCIENT_BALLISTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANCIENT_BALLISTICS</Sound>
-			<SoundMP>AS2D_TECH_ANCIENT_BALLISTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ancientballistics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8640,7 +8641,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CONCRETE_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONCRETE</Sound>
-			<SoundMP>AS2D_TECH_CONCRETE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Concrete.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8679,7 +8680,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANCIENT_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANCIENT_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_ANCIENT_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ancientmedicine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8723,7 +8724,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MERITOCRACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MERITOCRACY</Sound>
-			<SoundMP>AS2D_TECH_MERITOCRACY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/meritocracy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8761,7 +8762,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DRUG_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_DRUG_TRADE2</Sound>
-			<SoundMP>AS2D_TECH_DRUG_TRADE2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/drug_trade.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8803,7 +8804,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WATERWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CANAL_SYSTEMS</Sound>
-			<SoundMP>AS2D_TECH_CANAL_SYSTEMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Canals.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8848,7 +8849,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SIEGE_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SIEGE_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_SIEGE_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Siege_Warfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,2,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -8972,7 +8973,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_RELIGION_CONFUCIANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONFUCIANISM</Sound>
-			<SoundMP>AS2D_TECH_CONFUCIANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Confucianism.dds</Button>
 		</TechInfo>
@@ -9012,7 +9013,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AESTHETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AESTHETICS</Sound>
-			<SoundMP>AS2D_TECH_AESTHETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/StoneCarving.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,6,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9049,7 +9050,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INSURANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_INSURANCE</Sound>
-			<SoundMP>AS2D_TECH_INSURANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/insurance.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9084,7 +9085,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_TAOISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_TAOISM</Sound>
-			<SoundMP>AS2D_TECH_TAOISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Taoism.dds</Button>
 		</TechInfo>
@@ -9169,7 +9170,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FLORISTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_FLORISTRY</Sound>
-			<SoundMP>AS2D_TECH_FLORISTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/floristry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9207,7 +9208,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MOSAIC_WORKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOSAIC_WORKING</Sound>
-			<SoundMP>AS2D_TECH_MOSAIC_WORKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mosaicworking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9249,7 +9250,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SANITATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SANITATION</Sound>
-			<SoundMP>AS2D_TECH_SANITATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Sanitation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,15</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9328,7 +9329,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEATHER_LORE_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEATHER_LORE</Sound>
-			<SoundMP>AS2D_TECH_WEATHER_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/weather_lore.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9409,7 +9410,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_POETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_POETRY</Sound>
-			<SoundMP>AS2D_TECH_POETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/poetry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9454,7 +9455,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PAVED_ROADS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PAVED_ROADS</Sound>
-			<SoundMP>AS2D_TECH_PAVED_ROADS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Pavedroads.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9498,7 +9499,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WATERWHEELS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WATERWHEELS</Sound>
-			<SoundMP>AS2D_TECH_WATERWHEELS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/waterwheels.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9549,7 +9550,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GEOCENTRISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_GEOCENTRISM_LORE</Sound>
-			<SoundMP>AS2D_TECH_GEOCENTRISM_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Geocentrism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9604,7 +9605,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEDIEVAL_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEDIEVAL_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_MEDIEVAL_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/medievallifestyle.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9773,7 +9774,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FIRE_BRIGADES_QUOTE</Quote>
 			<Sound>AS2D_TECH_FIRE_BRIGADES</Sound>
-			<SoundMP>AS2D_TECH_FIRE_BRIGADES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Fire_Brigades.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9813,7 +9814,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SMITHING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SMITHING</Sound>
-			<SoundMP>AS2D_TECH_SMITHING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Smithing2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9856,7 +9857,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_VASSALAGE_QUOTE</Quote>
 			<Sound>AS2D_TECH_VASSALAGE</Sound>
-			<SoundMP>AS2D_TECH_VASSALAGE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/Civics/Vassalage.dds,Art/Interface/Buttons/Civics_Civilizations_Religions_Atlas.dds,1,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9903,7 +9904,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FUNDAMENTALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_FUNDAMENTALISM</Sound>
-			<SoundMP>AS2D_TECH_FUNDAMENTALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Fundamentalism.dds,Art/RoM_Atlas.dds,3,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9940,7 +9941,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PAPACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PAPACY</Sound>
-			<SoundMP>AS2D_TECH_PAPACY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Papacy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -9975,7 +9976,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_CHRISTIANITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHRISTIANITY</Sound>
-			<SoundMP>AS2D_TECH_CHRISTIANITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/christianity.dds</Button>
 		</TechInfo>
@@ -10015,7 +10016,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SURVEYING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SURVEYING</Sound>
-			<SoundMP>AS2D_TECH_SURVEYING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/surveying.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10065,7 +10066,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_EXECUTIONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXECUTIONS</Sound>
-			<SoundMP>AS2D_TECH_EXECUTIONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/executions.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10113,7 +10114,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_RUDDER_QUOTE</Quote>
 			<Sound>AS2D_TECH_RUDDER</Sound>
-			<SoundMP>AS2D_TECH_RUDDER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/rudder.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10183,7 +10184,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_RELIGION_ISLAM_QUOTE</Quote>
 			<Sound>AS2D_TECH_ISLAM</Sound>
-			<SoundMP>AS2D_TECH_ISLAM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<FirstFreeProphet>UNITCLASS_PROPHET</FirstFreeProphet>
 			<Button>Art/Interface/Buttons/TechTree/Islam.dds</Button>
 		</TechInfo>
@@ -10220,7 +10221,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ALCHEMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_AlchemyAstrology</Sound>
-			<SoundMP>AS2D_TECH_AlchemyAstrology</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/alchemy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10266,7 +10267,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ARCHITECTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_Architecture</Sound>
-			<SoundMP>AS2D_TECH_Architecture</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Architecture.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10305,7 +10306,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WINDMILLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WINDMILLS</Sound>
-			<SoundMP>AS2D_TECH_WINDMILLS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/windmills.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10342,7 +10343,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CROP_ROTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CROP_ROTATION</Sound>
-			<SoundMP>AS2D_TECH_CROP_ROTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/croprotation2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10387,7 +10388,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_YEOMANRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_YEOMANRY</Sound>
-			<SoundMP>AS2D_TECH_YEOMANRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/yeomany.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10421,7 +10422,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RAT_CATCHING_QUOTE</Quote>
 			<Sound>AS2D_TECH_RAT_CATCHING</Sound>
-			<SoundMP>AS2D_TECH_RAT_CATCHING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ratcatching.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10458,7 +10459,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STAINED_GLASS_QUOTE</Quote>
 			<Sound>AS2D_TECH_StainedGlass</Sound>
-			<SoundMP>AS2D_TECH_StainedGlass</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/stainedglass.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10596,7 +10597,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AGRICULTURAL_TOOLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AGRICULTURAL_TOOLS</Sound>
-			<SoundMP>AS2D_TECH_AGRICULTURAL_TOOLS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/agriculturaltools2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10633,7 +10634,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_USURY_QUOTE</Quote>
 			<Sound>AS2D_TECH_USURY</Sound>
-			<SoundMP>AS2D_TECH_USURY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Usury.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,4,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10669,7 +10670,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HERALDRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_HERALDRY</Sound>
-			<SoundMP>AS2D_TECH_HERALDRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/heraldry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10707,7 +10708,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLAGUE_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLAGUE_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_PLAGUE_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/plaguemedicine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10742,7 +10743,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INVENTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_INVENTION</Sound>
-			<SoundMP>AS2D_TECH_INVENTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/alchemy.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10792,7 +10793,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMMERCIAL_WHALING_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMMERCIAL_WHALING</Sound>
-			<SoundMP>AS2D_TECH_COMMERCIAL_WHALING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/whaling.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10872,7 +10873,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MARTIAL_ARTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MARTIAL_ARTS</Sound>
-			<SoundMP>AS2D_TECH_MARTIAL_ARTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Martial_Arts.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10919,7 +10920,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARMOR_CRAFTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ArmorCrafting</Sound>
-			<SoundMP>AS2D_TECH_ArmorCrafting</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Armorcrafting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10962,7 +10963,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CLOCKWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLOCKWORKS</Sound>
-			<SoundMP>AS2D_TECH_CLOCKWORKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Clockworks.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -10999,7 +11000,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARMORED_CAVALRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARMORED_CAVALRY</Sound>
-			<SoundMP>AS2D_TECH_ARMORED_CAVALRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/armoredcavalry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11053,7 +11054,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TORTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_TORTURE</Sound>
-			<SoundMP>AS2D_TECH_TORTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/torture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11102,7 +11103,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSPECTIVE_QUOTE</Quote>
 			<Sound>AS2D_TECH_PERSPECTIVE</Sound>
-			<SoundMP>AS2D_TECH_PERSPECTIVE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Perspective.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11142,7 +11143,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MAP_MAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAP_MAKING</Sound>
-			<SoundMP>AS2D_TECH_MAP_MAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mapmaking.dds</Button>
 			<bMoveFastPeaks>1</bMoveFastPeaks>
 		</TechInfo>
@@ -11189,7 +11190,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CHARTERS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHARTERS</Sound>
-			<SoundMP>AS2D_TECH_CHARTERS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/charters.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11238,7 +11239,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CRUCIBLE_STEEL_QUOTE</Quote>
 			<Sound>AS2D_TECH_CrucibleSteel</Sound>
-			<SoundMP>AS2D_TECH_CrucibleSteel</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cruciblesteel.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11274,7 +11275,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CHIVALRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CHIVALRY</Sound>
-			<SoundMP>AS2D_TECH_CHIVALRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/chivalry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11310,7 +11311,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MOUNTAINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOUNTAINEERING</Sound>
-			<SoundMP>AS2D_TECH_MOUNTAINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Mountianeering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11360,7 +11361,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DECREES_QUOTE</Quote>
 			<Sound>AS2D_TECH_DECREES</Sound>
-			<SoundMP>AS2D_TECH_DECREES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/decrees.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11434,7 +11435,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PARLIAMENTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PARLIAMENTS</Sound>
-			<SoundMP>AS2D_TECH_PARLIAMENTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/parliaments.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11511,7 +11512,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COAL_MINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_COAL_MINING</Sound>
-			<SoundMP>AS2D_TECH_COAL_MINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/coalmining.dds</Button>
 		</TechInfo>
 <!--	(049, 01) TECH_CLOCKPUNK	-->
@@ -11551,7 +11552,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TOURNAMENTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_TOURNAMENTS</Sound>
-			<SoundMP>AS2D_TECH_TOURNAMENTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Tournaments.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11638,7 +11639,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ACOUSTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ACOUSTICS</Sound>
-			<SoundMP>AS2D_TECH_ACOUSTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/acoustics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11675,7 +11676,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANATOMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANATOMY</Sound>
-			<SoundMP>AS2D_TECH_ANATOMY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Anatomy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11708,7 +11709,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ALGEBRA_QUOTE</Quote>
 			<Sound>AS2D_TECH_ALGEBRA</Sound>
-			<SoundMP>AS2D_TECH_ALGEBRA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Algebra.dds</Button>
 			<bCanFoundOnPeaks>1</bCanFoundOnPeaks>
 		</TechInfo>
@@ -11753,7 +11754,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RENAISSANCE_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_RENAISSANCE_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_RENAISSANCE_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/renaissancelifestyle.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11868,7 +11869,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HUMANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_HUMANISM</Sound>
-			<SoundMP>AS2D_TECH_HUMANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Protestantism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11912,7 +11913,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROLABE_QUOTE</Quote>
 			<Sound>AS2D_TECH_Astrolabe</Sound>
-			<SoundMP>AS2D_TECH_Astrolabe</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astrolabe.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11954,7 +11955,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_OIL_PAINTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_OIL_PAINTING</Sound>
-			<SoundMP>AS2D_TECH_OIL_PAINTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Corporation.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,2,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -11990,7 +11991,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LEADERSHIP_QUOTE</Quote>
 			<Sound>AS2D_TECH_LEADERSHIP</Sound>
-			<SoundMP>AS2D_TECH_LEADERSHIP</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/MilitaryLeadership.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12026,7 +12027,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MATCHLOCK_QUOTE</Quote>
 			<Sound>AS2D_TECH_MATCHLOCK</Sound>
-			<SoundMP>AS2D_TECH_MATCHLOCK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/matchlock.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,10</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12074,7 +12075,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_METALLURGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_METALLURGY</Sound>
-			<SoundMP>AS2D_TECH_METALLURGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/metallurgy.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12117,7 +12118,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_POLITICAL_PHILOSOPHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_POLITICAL_PHILOSOPHY</Sound>
-			<SoundMP>AS2D_TECH_POLITICAL_PHILOSOPHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Diplomacy.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,5</Button>
 		</TechInfo>
 <!--	(052, 11) TECH_SIKHISM	-->
@@ -12195,7 +12196,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FREE_ARTISTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_FREE_ARTISTRY</Sound>
-			<SoundMP>AS2D_TECH_FREE_ARTISTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/FreeArtistry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,6</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12241,7 +12242,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BATTLEFIELD_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_BATTLEFIELD_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_BATTLEFIELD_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/fieldSurgery.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,1,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12284,7 +12285,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DUELING_QUOTE</Quote>
 			<Sound>AS2D_TECH_DUELING</Sound>
-			<SoundMP>AS2D_TECH_DUELING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Dueling.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12324,7 +12325,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NAVAL_CANNON_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAVAL_CANNON</Sound>
-			<SoundMP>AS2D_TECH_NAVAL_CANNON</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/NavalOrdnance.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12408,7 +12409,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_JURIS_PRUDENCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_JURIS_PRUDENCE</Sound>
-			<SoundMP>AS2D_TECH_JURIS_PRUDENCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/justice.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12491,7 +12492,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NAVIGATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAVIGATION</Sound>
-			<SoundMP>AS2D_TECH_NAVIGATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/navigation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12524,7 +12525,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COLONIALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_COLONIALISM</Sound>
-			<SoundMP>AS2D_TECH_COLONIALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/colonialism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12562,7 +12563,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEATHER_FORECASTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEATHER_FORECASTING</Sound>
-			<SoundMP>AS2D_TECH_WEATHER_FORECASTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Weather_Forecasting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12657,7 +12658,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TEAM_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_TEAM_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_TEAM_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Team_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12706,7 +12707,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FLINTLOCK_QUOTE</Quote>
 			<Sound>AS2D_TECH_FLINTLOCK</Sound>
-			<SoundMP>AS2D_TECH_FLINTLOCK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Flintlock.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,6</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12748,7 +12749,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CRITICAL_THOUGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_CriticalThought</Sound>
-			<SoundMP>AS2D_TECH_CriticalThought</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/criticalthought.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12796,7 +12797,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HELIOCENTRISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_HELIOCENTRISM_LORE</Sound>
-			<SoundMP>AS2D_TECH_HELIOCENTRISM_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Heliocentrism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12840,7 +12841,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MERCANTILISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_MERCANTILISM</Sound>
-			<SoundMP>AS2D_TECH_MERCANTILISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Mercantilism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12921,7 +12922,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CAVALRY_TACTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CavalryTactics</Sound>
-			<SoundMP>AS2D_TECH_CavalryTactics</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/MilitaryTactics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -12962,7 +12963,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NAVAL_TACTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAVAL_TACTICS</Sound>
-			<SoundMP>AS2D_TECH_NAVAL_TACTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/NavalTactics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13003,7 +13004,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SOCIAL_CONTRACT_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOCIAL_CONTRACT</Sound>
-			<SoundMP>AS2D_TECH_SOCIAL_CONTRACT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Human_rights.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13079,7 +13080,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PATENT_RIGHTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PatentRight</Sound>
-			<SoundMP>AS2D_TECH_PatentRight</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/patentrights.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13123,7 +13124,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_STOCK_BROKERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_STOCK_EXCHANGING</Sound>
-			<SoundMP>AS2D_TECH_STOCK_EXCHANGING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/stockbrokering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13162,7 +13163,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXPLOSIVES_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXPLOSIVES</Sound>
-			<SoundMP>AS2D_TECH_EXPLOSIVES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Explosives.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13203,7 +13204,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ENLIGHTENMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_ENLIGHTENMENT</Sound>
-			<SoundMP>AS2D_TECH_ENLIGHTENMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/enlightenment.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13275,7 +13276,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CALCULUS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CALCULUS</Sound>
-			<SoundMP>AS2D_TECH_CALCULUS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/calculus.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13312,7 +13313,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MICROBIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROBIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_MICROBIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/microbiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13348,7 +13349,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MINE_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MINE_WARFARE2</Sound>
-			<SoundMP>AS2D_TECH_MINE_WARFARE2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/minewarfare.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13464,7 +13465,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_GEOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GEOLOGY</Sound>
-			<SoundMP>AS2D_TECH_GEOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/geology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13540,7 +13541,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ELIXIRS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ELIXIRS</Sound>
-			<SoundMP>AS2D_TECH_ELIXIRS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/buttons/techs/ElixirsandTonicsTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13582,7 +13583,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ZOOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ZOOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ZOOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Zoology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13627,7 +13628,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BOTANY_QUOTE</Quote>
 			<Sound>AS2D_TECH_BOTANY</Sound>
-			<SoundMP>AS2D_TECH_BOTANY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Botany.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13716,7 +13717,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CONSTITUTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONSTITUTION</Sound>
-			<SoundMP>AS2D_TECH_CONSTITUTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Constitution.dds,Art/Interface/Buttons/TechTree_Atlas.dds,8,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13754,7 +13755,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARCHEOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARCHEOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ARCHEOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/archeology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13840,7 +13841,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SEXTANT_QUOTE</Quote>
 			<Sound>AS2D_TECH_Sextant</Sound>
-			<SoundMP>AS2D_TECH_Sextant</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/sextant.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -13878,7 +13879,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PALEONTOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PALEONTOLOGY</Sound>
-			<SoundMP>AS2D_TECH_PALEONTOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/palentology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14009,7 +14010,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HOT_AIR_BALLOON_QUOTE</Quote>
 			<Sound>AS2D_TECH_HOT_AIR_BALLOON</Sound>
-			<SoundMP>AS2D_TECH_HOT_AIR_BALLOON</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/hotairballoon.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14055,7 +14056,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_REPRESENTATIVE_DEMOCRACY_QUOTE</Quote>
 			<Sound>AS2D_TECH_REPRESENTATIVE_DEMOCRACY</Sound>
-			<SoundMP>AS2D_TECH_REPRESENTATIVE_DEMOCRACY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Democracy.dds,Art/Interface/Buttons/TechTree_Atlas.dds,8,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14127,7 +14128,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GRAND_WAR_QUOTE</Quote>
 			<Sound>AS2D_TECH_GRAND_WAR</Sound>
-			<SoundMP>AS2D_TECH_GRAND_WAR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Grand_war.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14175,7 +14176,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INDUSTRIAL_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_INDUSTRIAL_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_INDUSTRIAL_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/industriallifestyle.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14221,7 +14222,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PHOTOGRAPHY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PHOTOGRAPHY</Sound>
-			<SoundMP>AS2D_TECH_PHOTOGRAPHY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Photography.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14260,7 +14261,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MARINE_BIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MARINE_BIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_MARINE_BIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/marinebiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14294,7 +14295,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DEPUTIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_DEPUTIZATION</Sound>
-			<SoundMP>AS2D_TECH_DEPUTIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>art/buttons/techs/DeputizationTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14410,7 +14411,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ROMANTICISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_ROMANTICISM</Sound>
-			<SoundMP>AS2D_TECH_ROMANTICISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/romanticism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14475,7 +14476,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_JOURNALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_JOURNALISM</Sound>
-			<SoundMP>AS2D_TECH_JOURNALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/journalism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14521,7 +14522,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_EMANCIPATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_EMANCIPATION</Sound>
-			<SoundMP>AS2D_TECH_EMANCIPATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/emancipation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14567,7 +14568,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FOODP_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOODP</Sound>
-			<SoundMP>AS2D_TECH_FOODP</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Foodp.dds</Button>
 		</TechInfo>
 <!--	(063, 13) TECH_STEAMPUNK	-->
@@ -14613,7 +14614,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SCREW_PROPELLER_QUOTE</Quote>
 			<Sound>AS2D_TECH_SCREW_PROPELLER</Sound>
-			<SoundMP>AS2D_TECH_SCREW_PROPELLER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Screw_propeller.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,15</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14651,7 +14652,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_THERMODYNAMICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_THERMODYNAMICS</Sound>
-			<SoundMP>AS2D_TECH_THERMODYNAMICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Thermodynamics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,7,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14739,7 +14740,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WILDERNESSC_QUOTE</Quote>
 			<Sound>AS2D_TECH_WILDERNESSC</Sound>
-			<SoundMP>AS2D_TECH_WILDERNESSC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Wildernessc.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14783,7 +14784,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GAS_LIGHTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_GAS_LIGHTING</Sound>
-			<SoundMP>AS2D_TECH_GAS_LIGHTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/gaslighting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14827,7 +14828,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MACHINE_TOOLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MachineTools</Sound>
-			<SoundMP>AS2D_TECH_MachineTools</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/MachineTools.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,10</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14864,7 +14865,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BALLOON_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_BALLOON_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_BALLOON_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/warballooning.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14901,7 +14902,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ORGANIC_CHEMISTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORGANIC_CHEMISTRY</Sound>
-			<SoundMP>AS2D_TECH_ORGANIC_CHEMISTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/organicChemistry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -14940,7 +14941,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FIREFIGHTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_FIREFIGHTING</Sound>
-			<SoundMP>AS2D_TECH_FIREFIGHTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Firefighting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15018,7 +15019,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_REFINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_REFINING</Sound>
-			<SoundMP>AS2D_TECH_REFINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Refining.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,15</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15064,7 +15065,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_SANITATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERN_SANITATION</Sound>
-			<SoundMP>AS2D_TECH_MODERN_SANITATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Modern_Sanitation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15105,7 +15106,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PESTICIDES_QUOTE</Quote>
 			<Sound>AS2D_TECH_PESTICIDES</Sound>
-			<SoundMP>AS2D_TECH_PESTICIDES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Agronomy.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15144,7 +15145,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NITROGLYCERIN_QUOTE</Quote>
 			<Sound>AS2D_TECH_NITROGLYCERIN</Sound>
-			<SoundMP>AS2D_TECH_NITROGLYCERIN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/nitroglycerin.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15229,7 +15230,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MARXISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_MARXISM</Sound>
-			<SoundMP>AS2D_TECH_MARXISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Marxism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,10</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15266,7 +15267,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_POLYMERIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_POLYMERIZATION</Sound>
-			<SoundMP>AS2D_TECH_POLYMERIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/polymerization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15400,7 +15401,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BARBED_WIRE_QUOTE</Quote>
 			<Sound>AS2D_TECH_BARBED_WIRE</Sound>
-			<SoundMP>AS2D_TECH_BARBED_WIRE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/barbedwire.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15441,7 +15442,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LAWN_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_LAWN_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_LAWN_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Lawn_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15529,7 +15530,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BICYCLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_BICYCLES</Sound>
-			<SoundMP>AS2D_TECH_BICYCLES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/bicycles.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15564,7 +15565,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SEMI_AUTOMATIC_WEAPONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SEMI_AUTOMATIC_WEAPONS</Sound>
-			<SoundMP>AS2D_TECH_SEMI_AUTOMATIC_WEAPONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Semi_automatic.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,15</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15603,7 +15604,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LABOR_UNION_QUOTE</Quote>
 			<Sound>AS2D_TECH_LABOR_UNION</Sound>
-			<SoundMP>AS2D_TECH_LABOR_UNION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/LaborUnion.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15645,7 +15646,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_REALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_REALISM</Sound>
-			<SoundMP>AS2D_TECH_REALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Realism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15684,7 +15685,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WATER_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WATER_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_WATER_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Water_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15730,7 +15731,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CRIMINOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CRIMINOLOGY</Sound>
-			<SoundMP>AS2D_TECH_CRIMINOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/criminology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15776,7 +15777,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANTIBIOTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_Antibiotics</Sound>
-			<SoundMP>AS2D_TECH_Antibiotics</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/antibiotics.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -15895,7 +15896,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_TELEGRAPH_QUOTE</Quote>
 			<Sound>AS2D_TECH_TELEGRAPH</Sound>
-			<SoundMP>AS2D_TECH_TELEGRAPH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/telegraph.dds</Button>
 			<bDCMAirBombTech1>0</bDCMAirBombTech1>
 		</TechInfo>
@@ -15941,7 +15942,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CIVIL_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CivilEngineering</Sound>
-			<SoundMP>AS2D_TECH_CivilEngineering</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/concrete.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -15979,7 +15980,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_HYDROELECTRICITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_Hydroelectricity</Sound>
-			<SoundMP>AS2D_TECH_Hydroelectricity</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/hydroelectricity.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16014,7 +16015,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_IMPERIALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_IMPERIALISM</Sound>
-			<SoundMP>AS2D_TECH_IMPERIALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/imperialism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16053,7 +16054,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WOMENS_SUFFRAGE_QUOTE</Quote>
 			<Sound>AS2D_TECH_WOMENS_SUFFRAGE</Sound>
-			<SoundMP>AS2D_TECH_WOMENS_SUFFRAGE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/womenssuffrage.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16092,7 +16093,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_IMPRESSIONISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_IMPRESSIONISM</Sound>
-			<SoundMP>AS2D_TECH_IMPRESSIONISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/impressionism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16131,7 +16132,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PSYCHOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_PSYCHOLOGY</Sound>
-			<SoundMP>AS2D_TECH_PSYCHOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Psychology.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16170,7 +16171,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MOTION_PICTURES_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOTION_PICTURES</Sound>
-			<SoundMP>AS2D_TECH_MOTION_PICTURES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/motionpictures.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16221,7 +16222,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MOTORIZED_TRANSPORTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOTORIZED_TRANSPORTATION</Sound>
-			<SoundMP>AS2D_TECH_MOTORIZED_TRANSPORTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Motorized_transportation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16254,7 +16255,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_METEOROLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_METEOROLOGY</Sound>
-			<SoundMP>AS2D_TECH_METEOROLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/Meteorology.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -16440,7 +16441,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FOREIGN_POLICY_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOREIGN_POLICY_LORE</Sound>
-			<SoundMP>AS2D_TECH_FOREIGN_POLICY_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/ForeignPolicy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16478,7 +16479,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CUBISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CUBISM</Sound>
-			<SoundMP>AS2D_TECH_CUBISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cubism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16517,7 +16518,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ANIMATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANIMATION</Sound>
-			<SoundMP>AS2D_TECH_ANIMATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/animation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16553,7 +16554,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MOTER_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOTER_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_MOTER_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Motor_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16595,7 +16596,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MASS_TRANSIT_QUOTE</Quote>
 			<Sound>AS2D_TECH_MASS_TRANSIT</Sound>
-			<SoundMP>AS2D_TECH_MASS_TRANSIT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/UrbanTransportation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,3,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16687,7 +16688,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMPULSORY_EDUCATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMPULSORY_EDUCATION</Sound>
-			<SoundMP>AS2D_TECH_COMPULSORY_EDUCATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Education.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,6</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16725,7 +16726,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXPRESSIONISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXPRESSIONISM</Sound>
-			<SoundMP>AS2D_TECH_EXPRESSIONISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/expressionism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16777,7 +16778,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERN_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_MODERN_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/modernlifestyle.dds</Button>
 		</TechInfo>
 <!--	(072, 01) TECH_CAODAIISM	-->
@@ -16842,7 +16843,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PROPAGANDA_QUOTE</Quote>
 			<Sound>AS2D_TECH_PROPAGANDA</Sound>
-			<SoundMP>AS2D_TECH_PROPAGANDA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/propaganda.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16919,7 +16920,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRENCH_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRENCH_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_TRENCH_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/TrenchWarfare_Button.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -16999,7 +17000,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ENCRYPTION_MACHINES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ENCRYPTION_MACHINES</Sound>
-			<SoundMP>AS2D_TECH_ENCRYPTION_MACHINES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/encryptionmachines.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17033,7 +17034,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_THEORY_OF_RELATIVITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_THEORY_OF_RELATIVITY</Sound>
-			<SoundMP>AS2D_TECH_THEORY_OF_RELATIVITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/TheoryofRelativity.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,6,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17179,7 +17180,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_METALLURGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_METALLURGY2</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_METALLURGY2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/advancedmetallurgy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17218,7 +17219,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_AUTOMATIC_WEAPONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AUTOMATIC_WEAPONS</Sound>
-			<SoundMP>AS2D_TECH_AUTOMATIC_WEAPONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/AutomaticWeapons.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17250,7 +17251,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NAVAL_AVIATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_NAVAL_AVIATION</Sound>
-			<SoundMP>AS2D_TECH_NAVAL_AVIATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/NavalAviation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17294,7 +17295,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ZEPPELINS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ZEPPELINS</Sound>
-			<SoundMP>AS2D_TECH_ZEPPELINS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/zeppelins.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17324,7 +17325,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DECRYPTION_MACHINES_QUOTE</Quote>
 			<Sound>AS2D_TECH_DECRYPTION_MACHINES</Sound>
-			<SoundMP>AS2D_TECH_DECRYPTION_MACHINES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/decryptionmachines.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17363,7 +17364,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_QUANTUM_PHYSICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_QUANTUM_PHYSICS</Sound>
-			<SoundMP>AS2D_TECH_QUANTUM_PHYSICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/QuantumPhysics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,14</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17397,7 +17398,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COSMOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_COSMOLOGY</Sound>
-			<SoundMP>AS2D_TECH_COSMOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cosmology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17431,7 +17432,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CONSUMERISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONSUMERISM</Sound>
-			<SoundMP>AS2D_TECH_CONSUMERISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/consumerism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17474,7 +17475,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AVIATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_AVIATION</Sound>
-			<SoundMP>AS2D_TECH_AVIATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/aviation.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17525,7 +17526,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARMORED_VEHICLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARMORED_VEHICLES</Sound>
-			<SoundMP>AS2D_TECH_ARMORED_VEHICLES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/blitzkrieg.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17606,7 +17607,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GUERRILLA_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_GUERRILLA_WARFARE</Sound>
-			<SoundMP>AS2D_GUERRILLA_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/guerrillawarfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17638,7 +17639,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SUBMARINE_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUBMARINE_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_SUBMARINE_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/nukesub.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17682,7 +17683,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COAST_GUARD_QUOTE</Quote>
 			<Sound>AS2D_TECH_COAST_GUARD</Sound>
-			<SoundMP>AS2D_TECH_COAST_GUARD</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/coastguard.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17769,7 +17770,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_ART_QUOTE</Quote>
 			<Sound>AS2D_TECH_FineArts</Sound>
-			<SoundMP>AS2D_TECH_FineArts</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/modernart.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17811,7 +17812,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_APPLIED_ECONOMICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MerchantAdventures</Sound>
-			<SoundMP>AS2D_TECH_MerchantAdventures</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Economics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17889,7 +17890,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MECHANIZED_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MECHANIZED_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_MECHANIZED_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/GlobalWarfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17930,7 +17931,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AGRICEMICALS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AGRICHEMICALS</Sound>
-			<SoundMP>AS2D_TECH_AGRICHEMICALS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/agrichemicals.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -17976,7 +17977,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ELECTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ELECTRONICS</Sound>
-			<SoundMP>AS2D_TECH_ELECTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/electronics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,6</Button>
 		</TechInfo>
 <!--	(075, 17) TECH_DIESELPUNK	-->
@@ -18015,7 +18016,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AMPHIBIOUS_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_AMPHIBIOUS_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_AMPHIBIOUS_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/amphibious_war.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18054,7 +18055,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERNPHYSICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERNPHYSICS</Sound>
-			<SoundMP>AS2D_TECH_MODERNPHYSICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/AdvancedCalculus.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18100,7 +18101,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_DADA_QUOTE</Quote>
 			<Sound>AS2D_TECH_DADA</Sound>
-			<SoundMP>AS2D_TECH_DADA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/dada.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18152,7 +18153,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LOGISTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_LOGISTICS</Sound>
-			<SoundMP>AS2D_TECH_LOGISTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Logistic.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,10</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18198,7 +18199,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HIGHWAY_SYSTEMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HIGHWAY_SYSTEMS</Sound>
-			<SoundMP>AS2D_TECH_HIGHWAY_SYSTEMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/highwaysystem.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18241,7 +18242,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FRANCHISES_QUOTE</Quote>
 			<Sound>AS2D_TECH_FRANCHISES</Sound>
-			<SoundMP>AS2D_TECH_FRANCHISES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/franchises.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18279,7 +18280,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CATALYTIC_POLYMERIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_CATALYTIC_POLYMERIZATION</Sound>
-			<SoundMP>AS2D_TECH_CATALYTIC_POLYMERIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/catalyticpolymerization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18328,7 +18329,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TELEVISION_QUOTE</Quote>
 			<Sound>AS2D_TECH_TELEVISION</Sound>
-			<SoundMP>AS2D_TECH_TELEVISION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/television.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18381,7 +18382,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SONAR_QUOTE</Quote>
 			<Sound>AS2D_TECH_SONAR</Sound>
-			<SoundMP>AS2D_TECH_SONAR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Sonar.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18422,7 +18423,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EARLY_COMPUTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_EARLY_COMPUTING</Sound>
-			<SoundMP>AS2D_TECH_EARLY_COMPUTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechEarlyComputing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18464,7 +18465,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SURREALISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_SURREALISM</Sound>
-			<SoundMP>AS2D_TECH_SURREALISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/surrealism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18515,7 +18516,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GLOBALIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_Globalization</Sound>
-			<SoundMP>AS2D_TECH_Globalization</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Globalization.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18559,7 +18560,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MINIATURIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_MINIATURIZATION</Sound>
-			<SoundMP>AS2D_TECH_MINIATURIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Automatization.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,2</Button>
 		</TechInfo>
 <!--	(077, 07) TECH_SCIENTOLOGY	-->
@@ -18602,7 +18603,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BIOLOGICAL_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOLOGICAL_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_BIOLOGICAL_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/BioTech.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18694,7 +18695,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RADAR_QUOTE</Quote>
 			<Sound>AS2D_TECH_RADAR</Sound>
-			<SoundMP>AS2D_TECH_RADAR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Radar.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,15</Button>
 		</TechInfo>
         <TechInfo>
@@ -18765,7 +18766,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CONGLOMERATES_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONGLOMERATES</Sound>
-			<SoundMP>AS2D_TECH_CONGLOMERATES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Conglomerates2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18805,7 +18806,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Corporation.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,3,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18847,7 +18848,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_POP_ART_QUOTE</Quote>
 			<Sound>AS2D_TECH_POP_ART</Sound>
-			<SoundMP>AS2D_TECH_POP_ART</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/popart.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18893,7 +18894,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MICROWAVES_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROWAVES</Sound>
-			<SoundMP>AS2D_TECH_MICROWAVES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/microwaves.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -18931,7 +18932,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERN_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_MODERN_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Modern_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19005,7 +19006,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TOURISM_QUOTE</Quote>
 			<Sound>AS2D_TOURISM</Sound>
-			<SoundMP>AS2D_TOURISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/tourism.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,8,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19039,7 +19040,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_HEALTH_CARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERN_HEALTH_CARE</Sound>
-			<SoundMP>AS2D_TECH_MODERN_HEALTH_CARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Biotechnics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19074,7 +19075,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_VERTICAL_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_VERTICAL_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_VERTICAL_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/VerticalFlight.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,7,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19110,7 +19111,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_JET_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_JET_PROPULSION</Sound>
-			<SoundMP>AS2D_TECH_JET_PROPULSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/JetEngines.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19149,7 +19150,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_RADIO_ASTRONOMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_RADIO_ASTRONOMY</Sound>
-			<SoundMP>AS2D_TECH_RADIO_ASTRONOMY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/radioastronomy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19192,7 +19193,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NUCLEAR_POWER_QUOTE</Quote>
 			<Sound>AS2D_TECH_NUCLEAR_POWER</Sound>
-			<SoundMP>AS2D_TECH_NUCLEAR_POWER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/NuclearPower.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19239,7 +19240,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MICROCHIP_QUOTE</Quote>
 			<Sound>AS2D_TECH_Transistors</Sound>
-			<SoundMP>AS2D_TECH_Transistors</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/transistors.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,1,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19282,7 +19283,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_GASTRONOMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GASTRONOMY</Sound>
-			<SoundMP>AS2D_TECH_GASTRONOMY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/gastronomy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19320,7 +19321,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LEGALIZED_GAMBLING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LEGALIZED_GAMBLING</Sound>
-			<SoundMP>AS2D_TECH_LEGALIZED_GAMBLING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Gambling.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,3,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19395,7 +19396,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SUPERSONIC_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUPERSONIC_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_SUPERSONIC_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/SupersonicFlight.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,8,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19430,7 +19431,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_ROCKETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_ROCKETRY</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_ROCKETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Advanced_Rocketry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,8,3</Button>
 		</TechInfo>
 <!--	(080, 13) TECH_ATOMPUNK	-->
@@ -19478,7 +19479,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DEEP_SEA_EXPLORATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_DEEP_SEA_EXPLORATION</Sound>
-			<SoundMP>AS2D_TECH_DEEP_SEA_EXPLORATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/deepseaexploration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19521,7 +19522,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SOLAR_POWER_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOLAR_POWER</Sound>
-			<SoundMP>AS2D_TECH_SOLAR_POWER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/solarpower.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19558,7 +19559,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HYDROPONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HYDROPONICS</Sound>
-			<SoundMP>AS2D_TECH_HYDROPONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Ecology.dds,Art/Interface/Buttons/NextWar_Atlas.dds,8,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19592,7 +19593,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COUNTERCULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_COUNTERCULTURE2</Sound>
-			<SoundMP>AS2D_TECH_COUNTERCULTURE2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/counterculture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19634,7 +19635,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MOLECULAR_BIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MolecularBiology</Sound>
-			<SoundMP>AS2D_TECH_MolecularBiology</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/molecularbiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19717,7 +19718,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SEISMOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SEISMOLOGY</Sound>
-			<SoundMP>AS2D_TECH_SEISMOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Modern_seismology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19759,7 +19760,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LASER_QUOTE</Quote>
 			<Sound>AS2D_TECH_LASER</Sound>
-			<SoundMP>AS2D_TECH_LASER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/laser.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,4,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19800,7 +19801,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSONAL_COMPUTERS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PERSONAL_COMPUTERS</Sound>
-			<SoundMP>AS2D_TECH_PERSONAL_COMPUTERS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Computers.dds,Art/Interface/Buttons/TechTree_Atlas.dds,7,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19846,7 +19847,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MINORITY_RIGHTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MINORITY_RIGHTS</Sound>
-			<SoundMP>AS2D_TECH_MINORITY_RIGHTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/minorityrights.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19885,7 +19886,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_RECYCLING_QUOTE</Quote>
 			<Sound>AS2D_TECH_RECYCLING</Sound>
-			<SoundMP>AS2D_TECH_RECYCLING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Ecology.dds,Art/Interface/Buttons/TechTree_Atlas.dds,3,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19922,7 +19923,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MODERN_WARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MODERN_WARFARE</Sound>
-			<SoundMP>AS2D_TECH_MODERN_WARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/ModernWarfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -19965,7 +19966,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPACE_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_SpaceFlight</Sound>
-			<SoundMP>AS2D_TECH_SpaceFlight</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Space_Flight.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20008,7 +20009,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_VOLCANOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_VOLCANOLOGY</Sound>
-			<SoundMP>AS2D_TECH_VOLCANOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/volcanology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20046,7 +20047,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COMPUTER_NETWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMPUTER_NETWORKS</Sound>
-			<SoundMP>AS2D_TECH_COMPUTER_NETWORKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Networks.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,13</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20076,7 +20077,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LONG_RANGE_FORECASTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LONG_RANGE_FORECASTING</Sound>
-			<SoundMP>AS2D_TECH_LONG_RANGE_FORECASTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Long-RangeForecasting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20123,7 +20124,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NEW_URBANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_NEW_URBANISM_LORE</Sound>
-			<SoundMP>AS2D_TECH_NEW_URBANISM_LORE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/New_Urbanism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20166,7 +20167,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTRO_ENVIRONMENTAL_SYSTEMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTRO_ENVIRONMENTAL_SYSTEMS</Sound>
-			<SoundMP>AS2D_TECH_ASTRO_ENVIRONMENTAL_SYSTEMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astroenvironmentalsystems.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20203,7 +20204,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FIRE_SUPPRESSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_FIRE_SUPPRESSION</Sound>
-			<SoundMP>AS2D_TECH_FIRE_SUPPRESSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Fire_Suppression.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20246,7 +20247,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MICROPROCESSOR_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROPROCESSOR</Sound>
-			<SoundMP>AS2D_TECH_MICROPROCESSOR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Microprocessor.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20287,7 +20288,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CLIMATE_MODELLING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLIMATE_MODELLING</Sound>
-			<SoundMP>AS2D_TECH_CLIMATE_MODELLING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/techtree/climate_modeling.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20331,7 +20332,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXTREME_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXTREME_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_EXTREME_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Extreme_Sports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20405,7 +20406,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GUIDED_WEAPONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_GUIDED_WEAPONS</Sound>
-			<SoundMP>AS2D_TECH_GUIDED_WEAPONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/smart_weapons.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,16</Button>
 			<bDCMAirBombTech2>1</bDCMAirBombTech2>
 		</TechInfo>
@@ -20446,7 +20447,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_EXPLORATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_EXPLORATION</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_EXPLORATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunarexploration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20480,7 +20481,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_3D_MODELLING_QUOTE</Quote>
 			<Sound>AS2D_TECH_3D_MODELLING</Sound>
-			<SoundMP>AS2D_TECH_3D_MODELLING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/3d_modeling.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20520,7 +20521,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_URBAN_CULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_URBAN_CULTURE</Sound>
-			<SoundMP>AS2D_TECH_URBAN_CULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechUrbanCulture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20555,7 +20556,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMPOSITES_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMPOSITES</Sound>
-			<SoundMP>AS2D_TECH_COMPOSITES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Composites.dds,Art/Interface/Buttons/TechTree_Atlas.dds,6,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20598,7 +20599,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPACE_STATIONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPACE_STATIONS</Sound>
-			<SoundMP>AS2D_TECH_SPACE_STATIONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Space_stations.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20642,7 +20643,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROBIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROBIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ASTROBIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astrobiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20686,7 +20687,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROGEOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROGEOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ASTROGEOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astrogeology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20779,7 +20780,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INFORMATION_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_INFORMATION_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_INFORMATION_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/InformationLifestyleTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20853,7 +20854,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FORENSICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_FORENSICS</Sound>
-			<SoundMP>AS2D_TECH_FORENSICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Forensics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -20900,7 +20901,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GENEMANIPULATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENEMANIPULATION</Sound>
-			<SoundMP>AS2D_TECH_GENEMANIPULATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/dna_button_04.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21029,7 +21030,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FUEL_CELLS_QUOTE</Quote>
 			<Sound>AS2D_TECH_FUEL_CELLS</Sound>
-			<SoundMP>AS2D_TECH_FUEL_CELLS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Fuel_cells.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21134,7 +21135,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AQUACULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_AQUACULTURE</Sound>
-			<SoundMP>AS2D_TECH_AQUACULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Ecology.dds,Art/Interface/Buttons/NextWar_Atlas.dds,2,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21166,7 +21167,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_UNMANNED_AIR_VEHICLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_UNMANNED_AIR_VEHICLES</Sound>
-			<SoundMP>AS2D_TECH_UNMANNED_AIR_VEHICLES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/uav.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,2,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21201,7 +21202,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NANOTECHNOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOTECHNOLOGY</Sound>
-			<SoundMP>AS2D_TECH_NANOTECHNOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Nanotech.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21233,7 +21234,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CLONING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLONING</Sound>
-			<SoundMP>AS2D_TECH_CLONING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Robotics.dds,Art/Interface/Buttons/NextWar_Atlas.dds,5,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21272,7 +21273,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INTERSTELLAR_TRAVEL_QUOTE</Quote>
 			<Sound>AS2D_TECH_INTERSTELLAR_TRAVEL</Sound>
-			<SoundMP>AS2D_TECH_INTERSTELLAR_TRAVEL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/interstellartravel.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21314,7 +21315,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_EXOPLANETDISCOVERY_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXOPLANETDISCOVERY</Sound>
-			<SoundMP>AS2D_TECH_EXOPLANETDISCOVERY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Exoplanetdiscovery.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21356,7 +21357,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMMUNICATION_NETWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMMUNICATION_NETWORKS</Sound>
-			<SoundMP>AS2D_TECH_COMMUNICATION_NETWORKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/GlobalNetwork.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21433,7 +21434,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MAGLEV_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAGLEV</Sound>
-			<SoundMP>AS2D_TECH_MAGLEV</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechLevitation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21475,7 +21476,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_UNMANNED_NAVAL_VEHICLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_UNMANNED_NAVAL_VEHICLES</Sound>
-			<SoundMP>AS2D_TECH_UNMANNED_NAVAL_VEHICLES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/UNMANNEDSEA.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21515,7 +21516,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BIOFUELS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOFUELS</Sound>
-			<SoundMP>AS2D_TECH_BIOFUELS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Biofuels.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21558,7 +21559,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SOLAR_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOLAR_PROPULSION</Sound>
-			<SoundMP>AS2D_TECH_SOLAR_PROPULSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/solarpropulsion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21593,7 +21594,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_KNOWLEDGE_MANAGEMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_KNOWLEDGE_MANAGEMENT</Sound>
-			<SoundMP>AS2D_TECH_KNOWLEDGE_MANAGEMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Knowledge_management.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21635,7 +21636,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CLOUDCOMPUTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLOUDCOMPUTING</Sound>
-			<SoundMP>AS2D_TECH_CLOUDCOMPUTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Cloudcomputing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21680,7 +21681,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CYBERWARFARE_QUOTE</Quote>
 			<Sound>AS2D_TECH_CYBERWARFARE</Sound>
-			<SoundMP>AS2D_TECH_CYBERWARFARE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cyberwarfare.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21723,7 +21724,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SUPERSTRINGTHEORY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUPERSTRINGTHEORY</Sound>
-			<SoundMP>AS2D_TECH_SUPERSTRINGTHEORY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Superstring.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,1,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21764,7 +21765,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ECOLOGICAL_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ECOLOGICAL_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_ECOLOGICAL_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/forestry.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,6</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21809,7 +21810,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NEUROTECHNOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NEUROTECHNOLOGY</Sound>
-			<SoundMP>AS2D_TECH_NEUROTECHNOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/geneticb.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21851,7 +21852,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WARSIMULATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_WARSIMULATION</Sound>
-			<SoundMP>AS2D_TECH_WARSIMULATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Warsimulation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21922,7 +21923,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_VIRTUAL_REALITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_VIRTUAL_REALITY</Sound>
-			<SoundMP>AS2D_TECH_VIRTUAL_REALITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/CyberWarfare.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -21967,7 +21968,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MMO_QUOTE</Quote>
 			<Sound>AS2D_TECH_MMO</Sound>
-			<SoundMP>AS2D_TECH_MMO</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mmo2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22009,7 +22010,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FLASHMEMORY_QUOTE</Quote>
 			<Sound>AS2D_TECH_FLASHMEMORY</Sound>
-			<SoundMP>AS2D_TECH_FLASHMEMORY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Flashmemory.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22054,7 +22055,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BIOINFORMATICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOINFORMATICS</Sound>
-			<SoundMP>AS2D_TECH_BIOINFORMATICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Bioinformatics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22096,7 +22097,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MOLECULAR_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_TISSUE</Sound>
-			<SoundMP>AS2D_TECH_TISSUE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Tissueengineering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22138,7 +22139,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPACE_TOURISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPACE_TOURISM</Sound>
-			<SoundMP>AS2D_TECH_SPACE_TOURISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Space_Tourism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22175,7 +22176,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_3D_PRINTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_3D_PRINTING</Sound>
-			<SoundMP>AS2D_TECH_3D_PRINTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/3dprinting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22217,7 +22218,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NEURAL_NETWORK_QUOTE</Quote>
 			<Sound>AS2D_TECH_NEURAL_NETWORK</Sound>
-			<SoundMP>AS2D_TECH_NEURAL_NETWORK</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Neural_Network.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22259,7 +22260,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FSYSTEMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_FSYSTEMS</Sound>
-			<SoundMP>AS2D_TECH_FSYSTEMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/digitization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22304,7 +22305,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_IMAGINARY_PHYSICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_THEORICALPHYSICS</Sound>
-			<SoundMP>AS2D_TECH_THEORICALPHYSICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/TheoreticalPhysics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22350,7 +22351,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GENCYCLOPEDIA_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENCYCLOPEDIA</Sound>
-			<SoundMP>AS2D_TECH_GENCYCLOPEDIA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Gencyclopedia.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22392,7 +22393,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BIOMATHMATICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOMATHMATICS</Sound>
-			<SoundMP>AS2D_TECH_BIOMATHMATICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Biomathmatics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22423,7 +22424,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COGNITIVE_ROBOTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_COGNITIVE_ROBOTICS</Sound>
-			<SoundMP>AS2D_TECH_COGNITIVE_ROBOTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Sentient_robots.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22469,7 +22470,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEDIAPSYCOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEDIAPSYCOLOGY</Sound>
-			<SoundMP>AS2D_TECH_MEDIAPSYCOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/MediaPsychology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22512,7 +22513,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEARABLE_ELECTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEARABLE_ELECTRONICS</Sound>
-			<SoundMP>AS2D_TECH_WEARABLE_ELECTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wearable_electronics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22547,7 +22548,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_QUANTUM_TELEPORTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_QUANTUM_TELEPORTATION</Sound>
-			<SoundMP>AS2D_TECH_QUANTUM_TELEPORTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Quantum_teleportation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22586,7 +22587,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CONTROLLED_PLASMA_QUOTE</Quote>
 			<Sound>AS2D_TECH_CONTROLLED_PLASMA</Sound>
-			<SoundMP>AS2D_TECH_CONTROLLED_PLASMA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Plasma_Physics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22632,7 +22633,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CSPACECRAFT_QUOTE</Quote>
 			<Sound>AS2D_TECH_CSPACECRAFT</Sound>
-			<SoundMP>AS2D_TECH_CSPACECRAFT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Cspacecraft.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22675,7 +22676,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RAPID_PROTOTYPING_QUOTE</Quote>
 			<Sound>AS2D_TECH_RAPID_PROTOTYPING</Sound>
-			<SoundMP>AS2D_TECH_RAPID_PROTOTYPING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/3D_Printing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22721,7 +22722,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DMERCH_QUOTE</Quote>
 			<Sound>AS2D_TECH_DMERCH</Sound>
-			<SoundMP>AS2D_TECH_DMERCH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Dmerch.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22766,7 +22767,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LEDLIGHTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LEDLIGHTING</Sound>
-			<SoundMP>AS2D_TECH_LEDLIGHTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/photonics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22811,7 +22812,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_VIRTUALSOCIETY_QUOTE</Quote>
 			<Sound>AS2D_TECH_VIRTUALSOCIETY</Sound>
-			<SoundMP>AS2D_TECH_VIRTUALSOCIETY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Virtualsociety.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22841,7 +22842,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MICROWAVE_WEAPONRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROWAVE_WEAPONRY</Sound>
-			<SoundMP>AS2D_TECH_MICROWAVE_WEAPONRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechMicrowaveWeaponry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22885,7 +22886,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_BASES_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_BASES</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_BASES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/moonbases.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -22954,7 +22955,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_METAMATERIALS_QUOTE</Quote>
 			<Sound>AS2D_TECH_METAMATERIALS</Sound>
-			<SoundMP>AS2D_TECH_METAMATERIALS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/Techtree/Metamaterials.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -23081,7 +23082,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BIOMECHANICALHARVESTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOMECHANICALHARVESTING</Sound>
-			<SoundMP>AS2D_TECH_BIOMECHANICALHARVESTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Biomechanicalharvesting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23128,7 +23129,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AUGUMENTEDREALITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_AUGUMENTEDREALITY</Sound>
-			<SoundMP>AS2D_TECH_AUGUMENTEDREALITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Augmentedreality.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23175,7 +23176,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSONALIZEDHEALTH_QUOTE</Quote>
 			<Sound>AS2D_TECH_PERSONALIZEDHEALTH</Sound>
-			<SoundMP>AS2D_TECH_PERSONALIZEDHEALTH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/PersonalizedHealth2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23220,7 +23221,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTEROIDPROBE_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTEROIDPROBE</Sound>
-			<SoundMP>AS2D_TECH_ASTEROIDPROBE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Asteroidprobe.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23303,7 +23304,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AFFECTIVEALGORITHMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AFFECTIVEALGORITHMS</Sound>
-			<SoundMP>AS2D_TECH_AFFECTIVEALGORITHMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Affectivealgorithms.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23348,7 +23349,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MICROTURBINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROTURBINE</Sound>
-			<SoundMP>AS2D_TECH_MICROTURBINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Microturbine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23387,7 +23388,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RAILGUN_QUOTE</Quote>
 			<Sound>AS2D_TECH_RAILGUN</Sound>
-			<SoundMP>AS2D_TECH_RAILGUN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/railgun.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23427,7 +23428,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ASTEROID_MINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTEROID_MINING</Sound>
-			<SoundMP>AS2D_TECH_ASTEROID_MINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/asteroidmining.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23462,7 +23463,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MICROMECHANICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MICROMECHANICS</Sound>
-			<SoundMP>AS2D_TECH_MICROMECHANICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Micromechanics.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -23500,7 +23501,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXOSKELETON_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXOSKELETON</Sound>
-			<SoundMP>AS2D_TECH_EXOSKELETON</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/exoskeleton.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23543,7 +23544,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BACTERIUM_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_BACTERIUM_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_BACTERIUM_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/bacteriumcomputing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23578,7 +23579,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_REPLACEMENT_ORGANS_QUOTE</Quote>
 			<Sound>AS2D_TECH_REPLACEMENT_ORGANS</Sound>
-			<SoundMP>AS2D_TECH_REPLACEMENT_ORGANS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Replacement_Organs.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23623,7 +23624,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MARINEARCHITECTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MARINEARCHITECTURE</Sound>
-			<SoundMP>AS2D_TECH_MARINEARCHITECTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Marinearchitecture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23658,7 +23659,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEAPONIZED_LASERS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEAPONIZED_LASERS</Sound>
-			<SoundMP>AS2D_TECH_WEAPONIZED_LASERS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechWeaponizedLasers.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23698,7 +23699,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MILITARY_ROBOTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MILITARY_ROBOTS</Sound>
-			<SoundMP>AS2D_TECH_MILITARY_ROBOTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/military_robotics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,11</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23728,7 +23729,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COILGUN_QUOTE</Quote>
 			<Sound>AS2D_TECH_COILGUN</Sound>
-			<SoundMP>AS2D_TECH_COILGUN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechCoilgun.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23773,7 +23774,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GENESIS_BIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GBIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_GBIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Gbiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23818,7 +23819,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_JUPITERE_QUOTE</Quote>
 			<Sound>AS2D_TECH_JUPITERE</Sound>
-			<SoundMP>AS2D_TECH_JUPITERE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/jovian.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23863,7 +23864,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GRAPHENE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GRAPHENE</Sound>
-			<SoundMP>AS2D_TECH_GRAPHENE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Graphene.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23909,7 +23910,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FRESPONSE_QUOTE</Quote>
 			<Sound>AS2D_TECH_FRESPONSE</Sound>
-			<SoundMP>AS2D_TECH_FRESPONSE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/firstresponse.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -23951,7 +23952,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HUMAN_MACHINE_INTERFACE_QUOTE</Quote>
 			<Sound>AS2D_TECH_HUMAN_MACHINE_INTERFACE</Sound>
-			<SoundMP>AS2D_TECH_HUMAN_MACHINE_INTERFACE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/human_machine.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,8,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24006,7 +24007,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NANOTECH_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOTECH_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_NANOTECH_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/NanotechTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24054,7 +24055,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_ENVIRONMENTAL_SYSTEMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_ENVIRONMENTAL_SYSTEMS2</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_ENVIRONMENTAL_SYSTEMS2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/advancedenvironmentalsystems.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24140,7 +24141,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INSECTROBOTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_INSECTROBOTICS</Sound>
-			<SoundMP>AS2D_TECH_INSECTROBOTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/biometricw.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24179,7 +24180,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BRAIN_SCAN_QUOTE</Quote>
 			<Sound>AS2D_TECH_BRAIN_SCAN</Sound>
-			<SoundMP>AS2D_TECH_BRAIN_SCAN</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/brain_scan.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24225,7 +24226,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LIQUIDMETAL_QUOTE</Quote>
 			<Sound>AS2D_TECH_LIQUIDMETAL</Sound>
-			<SoundMP>AS2D_TECH_LIQUIDMETAL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/liquidmaterials.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24301,7 +24302,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INVISIBILITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_INVISIBILITY</Sound>
-			<SoundMP>AS2D_TECH_INVISIBILITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/Techtree/invisibility2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24347,7 +24348,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PROTOTYPED_PATHOGENS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PROTOTYPED_PATHOGENS</Sound>
-			<SoundMP>AS2D_TECH_PROTOTYPED_PATHOGENS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/prototypedpathogens.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24392,7 +24393,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MELECTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MELECTRONICS</Sound>
-			<SoundMP>AS2D_TECH_MELECTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/melectronics2.dds</Button>
 		</TechInfo>
         <TechInfo>
@@ -24434,7 +24435,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AUTOMATED_TRAFFIC_QUOTE</Quote>
 			<Sound>AS2D_TECH_AUTOMATED_TRAFFIC</Sound>
-			<SoundMP>AS2D_TECH_AUTOMATED_TRAFFIC</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/AutomatedTraffic.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24477,7 +24478,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_COLONIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPACE_COLONIES</Sound>
-			<SoundMP>AS2D_TECH_SPACE_COLONIES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunarcolonization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24524,7 +24525,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MASS_SURVEILLANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_MASS_SURVEILLANCE</Sound>
-			<SoundMP>AS2D_TECH_MASS_SURVEILLANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/massurveillance.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24566,7 +24567,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NANOGENERATOR_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOGENERATOR</Sound>
-			<SoundMP>AS2D_TECH_NANOGENERATOR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Nanogenerators2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24600,7 +24601,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ELECTRIC_ARC_WEAPONRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ELECTRIC_ARC_WEAPONRY</Sound>
-			<SoundMP>AS2D_TECH_ELECTRIC_ARC_WEAPONRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechElectricArcWeaponry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24643,7 +24644,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MASS_DRIVER_QUOTE</Quote>
 			<Sound>AS2D_TECH_MASS_DRIVER</Sound>
-			<SoundMP>AS2D_TECH_MASS_DRIVER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/massdriver.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24682,7 +24683,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HYPERSONIC_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_HYPERSONIC_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_HYPERSONIC_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/hypersonic_flight.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24722,7 +24723,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MESH_NETWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MESH_NETWORKS</Sound>
-			<SoundMP>AS2D_TECH_MESH_NETWORKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/mesh_network.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,3,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24767,7 +24768,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GENEENHANCEMENT_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENEENHANCEMENT</Sound>
-			<SoundMP>AS2D_TECH_GENEENHANCEMENT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Geneenhancement.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24810,7 +24811,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_MANUFACTURING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_MANUFACTURING</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_MANUFACTURING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunarmanufacturing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24853,7 +24854,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEGACORPORATIONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEGACORPORATIONS</Sound>
-			<SoundMP>AS2D_TECH_MEGACORPORATIONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/megacorporations.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24893,7 +24894,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_COLONIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_COLONIZATION</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_COLONIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarycolonization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24939,7 +24940,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HOLOGRAPHICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HOLOGRAPHICS</Sound>
-			<SoundMP>AS2D_TECH_HOLOGRAPHICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Holographics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -24985,7 +24986,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AUGMENT_CONSUMABLES_QUOTE</Quote>
 			<Sound>AS2D_TECH_AUGMENT_CONSUMABLES</Sound>
-			<SoundMP>AS2D_TECH_AUGMENT_CONSUMABLES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/augmentconsumables.dds</Button>
 		</TechInfo>
 <!--	(102, 11) TECH_NANOPUNK	-->
@@ -25020,7 +25021,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ACOUSTIC_WEAPONRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ACOUSTIC_WEAPONRY</Sound>
-			<SoundMP>AS2D_TECH_ACOUSTIC_WEAPONRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechAcousticWeaponry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25067,7 +25068,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AUTOMATEDSERVICES_QUOTE</Quote>
 			<Sound>AS2D_TECH_AUTOMATEDSERVICES</Sound>
-			<SoundMP>AS2D_TECH_AUTOMATEDSERVICES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Automatedsevices.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25110,7 +25111,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_MAINSTREAM_CLONING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAINSTREAM_CLONING</Sound>
-			<SoundMP>AS2D_TECH_MAINSTREAM_CLONING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mainstreamcloning.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25152,7 +25153,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_GENEJURISPRUDENCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GENEJURISPRUDENCE</Sound>
-			<SoundMP>AS2D_TECH_GENEJURISPRUDENCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Genejurisprudence.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25192,7 +25193,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_TOURISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_TOURISM2</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_TOURISM2</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunartourism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25235,7 +25236,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_EXTRACTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_EXTRACTION</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_EXTRACTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarymining.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25282,7 +25283,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEDIA_HIVEMIND_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEDIA_HIVEMIND</Sound>
-			<SoundMP>AS2D_TECH_MEDIA_HIVEMIND</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mediahivemind.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25325,7 +25326,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ACOUSTOPHORESIS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ACOUSTOPHORESIS</Sound>
-			<SoundMP>AS2D_TECH_ACOUSTOPHORESIS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechAcoustophoresis.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25364,7 +25365,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PLASTIC_ELECTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLASTIC_ELECTRONICS</Sound>
-			<SoundMP>AS2D_TECH_PLASTIC_ELECTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wearable_computer.dds</Button>
 		</TechInfo>
 <!--	(103, 11) TECH_BIOPUNK	-->
@@ -25410,7 +25411,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LENGINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_LENGINE</Sound>
-			<SoundMP>AS2D_TECH_LENGINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lengine.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25455,7 +25456,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ONTOLOGICALENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ONTOLOGICALENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_ONTOLOGICALENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Ontologicalengineering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25503,7 +25504,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SYNTHETIC_SENTIENCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SYNTHETIC_SENTIENCE</Sound>
-			<SoundMP>AS2D_TECH_SYNTHETIC_SENTIENCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/syntheticsentience.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25546,7 +25547,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MAGNETIC_SAILS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MAGNETIC_SAILS</Sound>
-			<SoundMP>AS2D_TECH_MAGNETIC_SAILS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/magneticsails.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25589,7 +25590,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_MANUFACTORING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_MANUFACTORING</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_MANUFACTORING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarymanufacturing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25623,7 +25624,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ELECTROMAGNETIC_FIELD_SHIELDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ELECTROMAGNETIC_FIELD_SHIELDING</Sound>
-			<SoundMP>AS2D_TECH_ELECTROMAGNETIC_FIELD_SHIELDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechElectromagneticShielding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25662,7 +25663,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NANOELECTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOELECTRONICS</Sound>
-			<SoundMP>AS2D_TECH_NANOELECTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Nano_electronics.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25707,7 +25708,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AICITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_AICITY</Sound>
-			<SoundMP>AS2D_TECH_AICITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Aicity.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25739,7 +25740,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BIOMIMETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIOMIMETICS</Sound>
-			<SoundMP>AS2D_TECH_BIOMIMETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/Techtree/biomimetics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25781,7 +25782,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NOVUSCHEMISTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NOVUSCHEMISTRY</Sound>
-			<SoundMP>AS2D_TECH_NOVUSCHEMISTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Novuschemistry2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25826,7 +25827,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_RAPID_RECUPERATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_RAPID_RECUPERATION</Sound>
-			<SoundMP>AS2D_TECH_RAPID_RECUPERATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Rapidrecuperation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25869,7 +25870,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WIRELESS_ELECTRICITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_WIRELESS_ELECTRICITY</Sound>
-			<SoundMP>AS2D_TECH_WIRELESS_ELECTRICITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wireless_electricity.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25904,7 +25905,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_NANOBOTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOBOTICS</Sound>
-			<SoundMP>AS2D_TECH_NANOBOTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/nanobotics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25945,7 +25946,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WARMACHINES_QUOTE</Quote>
 			<Sound>AS2D_TECH_WARMACHINES</Sound>
-			<SoundMP>AS2D_TECH_WARMACHINES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mech_Warfare1.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -25980,7 +25981,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_COMPUTERS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_COMPUTERS</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_COMPUTERS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/ai2.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26018,7 +26019,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_VERTICAL_FARMING_QUOTE</Quote>
 			<Sound>AS2D_TECH_VERTICAL_FARMING</Sound>
-			<SoundMP>AS2D_TECH_VERTICAL_FARMING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Vertical_Farming.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26057,7 +26058,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANTI_AGING_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANTI_AGING_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_ANTI_AGING_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/dna_button_05.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,7,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26104,7 +26105,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_BIONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BIONICS</Sound>
-			<SoundMP>AS2D_TECH_BIONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Robotics.dds,Art/Interface/Buttons/NextWar_Atlas.dds,4,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26153,7 +26154,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PHOTON_THERMODYNAMICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PHOTON_THERMODYNAMICS</Sound>
-			<SoundMP>AS2D_TECH_PHOTON_THERMODYNAMICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/photonthermodynamics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26195,7 +26196,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SUPERSONIC_RAILS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SRAILS</Sound>
-			<SoundMP>AS2D_TECH_SRAILS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Straffic2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26241,7 +26242,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AGERMINATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_AGERMINATION</Sound>
-			<SoundMP>AS2D_TECH_AGERMINATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/germination.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26283,7 +26284,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PHOTOVALTICGLASS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PHOTOVALTICGLASS</Sound>
-			<SoundMP>AS2D_TECH_PHOTOVALTICGLASS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Photovalticglass.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26331,7 +26332,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_AMPLIFIED_WAVELENGTHS_QUOTE</Quote>
 			<Sound>AS2D_TECH_AMPLIFIED_WAVELENGTHS</Sound>
-			<SoundMP>AS2D_TECH_AMPLIFIED_WAVELENGTHS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/amplifiedwavelengths.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26370,7 +26371,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DROIDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_DROIDS</Sound>
-			<SoundMP>AS2D_TECH_DROIDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/hal9000.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,8</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26408,7 +26409,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SUPERSTRONG_ALLOYS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUPERSTRONG_ALLOYS</Sound>
-			<SoundMP>AS2D_TECH_SUPERSTRONG_ALLOYS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Superstrong_alloys.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,2,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26447,7 +26448,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SMART_DRUGS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SMART_DRUGS</Sound>
-			<SoundMP>AS2D_TECH_SMART_DRUGS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/smart_drugs.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26494,7 +26495,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXOCORTEXNETWORKS_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXOCORTEXNETWORKS</Sound>
-			<SoundMP>AS2D_TECH_EXOCORTEXNETWORKS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Exocortexnetworks.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26533,7 +26534,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SKYROADS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SKYROADS</Sound>
-			<SoundMP>AS2D_TECH_SKYROADS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/skyroads.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26574,7 +26575,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ENVIRONMENTAL_ECONOMICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_Environmentalism</Sound>
-			<SoundMP>AS2D_TECH_Environmentalism</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/enviromentaleconomics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26612,7 +26613,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_QUANTUM_COMPUTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_QUANTUM_COMPUTING</Sound>
-			<SoundMP>AS2D_TECH_QUANTUM_COMPUTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/quantum_computing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26647,7 +26648,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANDROIDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANDROIDS</Sound>
-			<SoundMP>AS2D_TECH_ANDROIDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/android.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,2</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26687,7 +26688,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ION_BEAMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ION_BEAMS</Sound>
-			<SoundMP>AS2D_TECH_ION_BEAMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechIonBeams.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26727,7 +26728,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_REGENERATIVE_MEDICINE_QUOTE</Quote>
 			<Sound>AS2D_TECH_REGENERATIVE_MEDICINE</Sound>
-			<SoundMP>AS2D_TECH_REGENERATIVE_MEDICINE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Immunology.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,2,9</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26767,7 +26768,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ORBITAL_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORBITAL_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_ORBITAL_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/SpaceColonies.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,1,1</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26812,7 +26813,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANTIGRAV_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANTIGRAV</Sound>
-			<SoundMP>AS2D_TECH_ANTIGRAV</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Antigrav.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26859,7 +26860,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BATTLEFIELD_SPORTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BATTLEFIELD_SPORTS</Sound>
-			<SoundMP>AS2D_TECH_BATTLEFIELD_SPORTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/battlefieldsports.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26897,7 +26898,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_UNIVERSAL_TRANSLATOR_QUOTE</Quote>
 			<Sound>AS2D_TECH_UNIVERSAL_TRANSLATOR</Sound>
-			<SoundMP>AS2D_TECH_UNIVERSAL_TRANSLATOR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/universaltranslator.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26936,7 +26937,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_ECONOMICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_ECONOMICS</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_ECONOMICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetaryeconomics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -26983,7 +26984,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ELECTROMAGNETIC_VOLTAGE_QUOTE</Quote>
 			<Sound>AS2D_TECH_ELECTROMAGNETIC_VOLTAGE</Sound>
-			<SoundMP>AS2D_TECH_ELECTROMAGNETIC_VOLTAGE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/electromagneticvoltage.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27027,7 +27028,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DNA_COMPUTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_DNA_COMPUTING</Sound>
-			<SoundMP>AS2D_TECH_DNA_COMPUTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/DNA_computing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27073,7 +27074,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CYBERIMM_QUOTE</Quote>
 			<Sound>AS2D_TECH_CYBERIMM</Sound>
-			<SoundMP>AS2D_TECH_CYBERIMM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Cyberimmunology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27106,7 +27107,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_CLOAKING_QUOTE</Quote>
 			<Sound>AS2D_TECH_CLOAKING</Sound>
-			<SoundMP>AS2D_TECH_CLOAKING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechCloaking.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27152,7 +27153,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CYBERSOCIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_CYBERSOCIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_CYBERSOCIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/cybersociology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27187,7 +27188,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PERSONAL_ROBOTS_QUOTE</Quote>
 			<Sound>AS2D_TECH_PERSONAL_ROBOTS</Sound>
-			<SoundMP>AS2D_TECH_PERSONAL_ROBOTS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/personal_robots.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27230,7 +27231,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_TRADE</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_TRADE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunartrade.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27276,7 +27277,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SUPERCHARGED_CRYSTALS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUPERCHARGED_CRYSTALS</Sound>
-			<SoundMP>AS2D_TECH_SUPERCHARGED_CRYSTALS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/superchargedcrystallines.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27323,7 +27324,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DESIGNER_MICROBIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_DESIGNER_MICROBIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_DESIGNER_MICROBIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/designermicrobiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27369,7 +27370,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HYPOTHETICAL_BIOCHEMISTRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_HYPOTHETICAL_BIOCHEMISTRY</Sound>
-			<SoundMP>AS2D_TECH_HYPOTHETICAL_BIOCHEMISTRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/hypotheticalbiochemistry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27417,7 +27418,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DYSTOPIA_PATHOGENS_QUOTE</Quote>
 			<Sound>AS2D_TECH_DYSTOPIA_PATHOGENS</Sound>
-			<SoundMP>AS2D_TECH_DYSTOPIA_PATHOGENS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/dystopianpathogens.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27452,7 +27453,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CYBERNETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CYBERNETICS</Sound>
-			<SoundMP>AS2D_TECH_CYBERNETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/cybernetics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27509,7 +27510,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRANSHUMAN_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRANSHUMAN_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_TRANSHUMAN_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TranshumanLifestyleTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27596,7 +27597,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_APHOTOSYNTHESIS_QUOTE</Quote>
 			<Sound>AS2D_TECH_APHOTOSYNTHESIS</Sound>
-			<SoundMP>AS2D_TECH_APHOTOSYNTHESIS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/leafpower222.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27643,7 +27644,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_UNIFICATION_PHYSICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_UNIFICATION_PHYSICS</Sound>
-			<SoundMP>AS2D_TECH_UNIFICATION_PHYSICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/unificationphysics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27690,7 +27691,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BINARYLEGISLATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_BINARYLEGISLATION</Sound>
-			<SoundMP>AS2D_TECH_BINARYLEGISLATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/binarylegislation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27737,7 +27738,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SYNTHETIC_SYNESTHESIA_QUOTE</Quote>
 			<Sound>AS2D_TECH_SYNTHETIC_SYNESTHESIA</Sound>
-			<SoundMP>AS2D_TECH_SYNTHETIC_SYNESTHESIA</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/syntheticsynesthesia.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27785,7 +27786,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NEURON_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_NEURON_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_NEURON_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/neuronengineering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27829,7 +27830,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_TRADE</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_TRADE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarytrade.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27870,7 +27871,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SPECIES_UPLIFTING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPECIES_UPLIFTING</Sound>
-			<SoundMP>AS2D_TECH_SPECIES_UPLIFTING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/speciesuplifting.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27917,7 +27918,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_KUIPER_BELT_QUOTE</Quote>
 			<Sound>AS2D_TECH_KUIPER_BELT</Sound>
-			<SoundMP>AS2D_TECH_KUIPER_BELT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/oortcloudprobes.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -27963,7 +27964,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HYPERMAGNETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HYPERMAGNETICS</Sound>
-			<SoundMP>AS2D_TECH_HYPERMAGNETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/hypermagnetics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28012,7 +28013,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SIMULATED_REALITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SIMULATED_REALITY</Sound>
-			<SoundMP>AS2D_TECH_SIMULATED_REALITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/simulatedreality.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28043,7 +28044,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FROST_BEAMS_QUOTE</Quote>
 			<Sound>AS2D_TECH_FROST_BEAMS</Sound>
-			<SoundMP>AS2D_TECH_FROST_BEAMS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechFrostBeams.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28091,7 +28092,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BINARY_SUBCONSCIOUSNESS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BINARY_SUBCONSCIOUSNESS</Sound>
-			<SoundMP>AS2D_TECH_BINARY_SUBCONSCIOUSNESS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/binarysubconsciousness.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28140,7 +28141,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_UTOPIA_DESTINY_QUOTE</Quote>
 			<Sound>AS2D_TECH_UTOPIA_DESTINY</Sound>
-			<SoundMP>AS2D_TECH_UTOPIA_DESTINY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/utopiadestiny.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28187,7 +28188,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NOVOPALEONTOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NOVOPALEONTOLOGY</Sound>
-			<SoundMP>AS2D_TECH_NOVOPALEONTOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/novopaleontology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28238,7 +28239,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HOMO_SUPERIOR_QUOTE</Quote>
 			<Sound>AS2D_TECH_HOMO_SUPERIOR</Sound>
-			<SoundMP>AS2D_TECH_HOMO_SUPERIOR</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/dna_button_01.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28285,7 +28286,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_QUADRUPLE_HELIX_QUOTE</Quote>
 			<Sound>AS2D_TECH_QUADRUPLEHELIX</Sound>
-			<SoundMP>AS2D_TECH_QUADRUPLEHELIX</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/quadruplehelix.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28323,7 +28324,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEIGHTLESS_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEIGHTLESS_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_WEIGHTLESS_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechWeightlessFlight.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28373,7 +28374,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEGASTRUCTURE_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEGASTRUCTURE_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_MEGASTRUCTURE_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/cybercity.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,5</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28419,7 +28420,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SYNERGETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SYNERGETICS</Sound>
-			<SoundMP>AS2D_TECH_SYNERGETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/synergetics.dds</Button>
 		</TechInfo>
 <!--	(113, 07) TECH_CYBERPUNK	-->
@@ -28452,7 +28453,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SMART_DUST_QUOTE</Quote>
 			<Sound>AS2D_TECH_SMART_DUST</Sound>
-			<SoundMP>AS2D_TECH_SMART_DUST</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/smart_dust.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,4,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28499,7 +28500,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SOCIAL_CALCULUS_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOCIAL_CALCULUS</Sound>
-			<SoundMP>AS2D_TECH_SOCIAL_CALCULUS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/socialcalculus.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28572,7 +28573,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARTIFICIAL_EVOLUTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARTIFICIAL_EVOLUTION</Sound>
-			<SoundMP>AS2D_TECH_ARTIFICIAL_EVOLUTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificialevolution3.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28612,7 +28613,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_CRYOGENICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_CRYOGENICS</Sound>
-			<SoundMP>AS2D_TECH_CRYOGENICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/genetic_engineering.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,5,7</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28658,7 +28659,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BINARY_SEMIOTICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BINARY_SEMIOTICS</Sound>
-			<SoundMP>AS2D_TECH_BINARY_SEMIOTICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/binarysemiotics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28707,7 +28708,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROGATION_CONSTELLATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROGATION_CONSTELLATION</Sound>
-			<SoundMP>AS2D_TECH_ASTROGATION_CONSTELLATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astrogationconstellation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28745,7 +28746,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANTI_GRAVITY_FIELDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANTI_GRAVITY_FIELDS</Sound>
-			<SoundMP>AS2D_TECH_ANTI_GRAVITY_FIELDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechAntiGravityFields.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28788,7 +28789,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MIND_UPLOADING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MIND_UPLOADING</Sound>
-			<SoundMP>AS2D_TECH_MIND_UPLOADING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificial_cognitive_system.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28826,7 +28827,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_OPTRONICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_OPTRONICS</Sound>
-			<SoundMP>AS2D_TECH_OPTRONICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/optronics2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28873,7 +28874,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EVOLVED_CONSTRUCTION_QUOTE</Quote>
 			<Sound>AS2D_TECH_EVOLVED_CONSTRUCTION</Sound>
-			<SoundMP>AS2D_TECH_EVOLVED_CONSTRUCTION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/evolvedconstruction.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28919,7 +28920,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BOTANICAL_ALCHEMY_QUOTE</Quote>
 			<Sound>AS2D_TECH_BOTANICAL_ALCHEMY</Sound>
-			<SoundMP>AS2D_TECH_BOTANICAL_ALCHEMY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/botanicalalchemy.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -28965,7 +28966,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NUTRACEUTICALS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NUTRACEUTICALS</Sound>
-			<SoundMP>AS2D_TECH_NUTRACEUTICALS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/nutraceuticals.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29012,7 +29013,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WHOLE_BRAIN_EMULATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_WHOLE_BRAIN_EMULATION</Sound>
-			<SoundMP>AS2D_TECH_WHOLE_BRAIN_EMULATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wholebrainemulation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29056,7 +29057,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ORBITAL_MEGASTRUCTURES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORBITAL_MEGASTRUCTURES</Sound>
-			<SoundMP>AS2D_TECH_ORBITAL_MEGASTRUCTURES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/orbitalmegastructures.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29107,7 +29108,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SHIELDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SHIELDING</Sound>
-			<SoundMP>AS2D_TECH_SHIELDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Robotics.dds,Art/Interface/Buttons/NextWar_Atlas.dds,1,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29155,7 +29156,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SINGULARITY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SINGULARITY</Sound>
-			<SoundMP>AS2D_TECH_SINGULARITY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/singularity.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29207,7 +29208,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ORGANIC_CITIES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ORGANIC_CITIES</Sound>
-			<SoundMP>AS2D_TECH_ORGANIC_CITIES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/organic_city.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29254,7 +29255,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ABYSS_COLONIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ABYSS_COLONIZATION</Sound>
-			<SoundMP>AS2D_TECH_ABYSS_COLONIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/abysscolonization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29292,7 +29293,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NANOMINING_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOMINING</Sound>
-			<SoundMP>AS2D_TECH_NANOMINING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Nanotechnology.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,6,12</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29337,7 +29338,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARTIFICIAL_LIFE_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARTIFICIAL_LIFE</Sound>
-			<SoundMP>AS2D_TECH_ARTIFICIAL_LIFE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificial_life.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29384,7 +29385,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COMPREHENSIVE_CYBERNETICS_QUOTE</Quote>
 			<Sound>AS2D_TECH_COMPREHENSIVE_CYBERNETICS</Sound>
-			<SoundMP>AS2D_TECH_COMPREHENSIVE_CYBERNETICS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/comprehensivecybernetics.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29422,7 +29423,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_FRICTIONLESS_FLIGHT_QUOTE</Quote>
 			<Sound>AS2D_TECH_FRICTIONLESS_FLIGHT</Sound>
-			<SoundMP>AS2D_TECH_FRICTIONLESS_FLIGHT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechFrictionlessFlight.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29469,7 +29470,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANIMA_MATERIALS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANIMA_MATERIALS</Sound>
-			<SoundMP>AS2D_TECH_ANIMA_MATERIALS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/animamaterials.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29516,7 +29517,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRANSHUMANISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRANSHUMANISM</Sound>
-			<SoundMP>AS2D_TECH_TRANSHUMANISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/transhumanism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29562,7 +29563,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_KNOWLEDGE_MERCANTILISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_KNOWLEDGE_MERCANTILISM</Sound>
-			<SoundMP>AS2D_TECH_KNOWLEDGE_MERCANTILISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/knowledgemercantilism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29610,7 +29611,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_APOCALYPTIC_PATHOGENS_QUOTE</Quote>
 			<Sound>AS2D_TECH_APOCALYPTIC_PATHOGENS</Sound>
-			<SoundMP>AS2D_TECH_APOCALYPTIC_PATHOGENS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/apocolypticpathogens.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29658,7 +29659,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GAIA_ECOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_GAIA_ECOLOGY</Sound>
-			<SoundMP>AS2D_TECH_GAIA_ECOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/gaiaecology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29705,7 +29706,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARTIFICIAL_NUCLEOSYNTHESIS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARTIFICIAL_NUCLEOSYNTHESIS</Sound>
-			<SoundMP>AS2D_TECH_ARTIFICIAL_NUCLEOSYNTHESIS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificialnucleosynthesis.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29752,7 +29753,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPECULATIVE_PHYSIOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPECULATIVE_PHYSIOLOGY</Sound>
-			<SoundMP>AS2D_TECH_SPECULATIVE_PHYSIOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/speculativephysiology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29800,7 +29801,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MYTHOLOCIAL_BEASTIARY_QUOTE</Quote>
 			<Sound>AS2D_TECH_MYTHOLOCIAL_BEASTIARY</Sound>
-			<SoundMP>AS2D_TECH_MYTHOLOCIAL_BEASTIARY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/mythologicalbeastiary.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29847,7 +29848,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HUMANOIDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_HUMANOIDS</Sound>
-			<SoundMP>AS2D_TECH_HUMANOIDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/humanoids.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29895,7 +29896,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_SHIELDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_SHIELDING</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_SHIELDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Robotics.dds,Art/Interface/Buttons/NextWar_Atlas.dds,2,4</Button>
 		</TechInfo>
 		<TechInfo>
@@ -29933,7 +29934,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_WARMACHINES_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_WARMACHINES</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_WARMACHINES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mech_Warfare2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30028,7 +30029,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TERRA_COMPUTER_QUOTE</Quote>
 			<Sound>AS2D_TECH_TERRA_COMPUTER</Sound>
-			<SoundMP>AS2D_TECH_TERRA_COMPUTER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/terra_computer2.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30076,7 +30077,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_BINARY_PYSCHOKINESIS_QUOTE</Quote>
 			<Sound>AS2D_TECH_BINARY_PYSCHOKINESIS</Sound>
-			<SoundMP>AS2D_TECH_BINARY_PYSCHOKINESIS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/binarypsychokinesis.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30123,7 +30124,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_HUMAN_TRANSMUTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_HUMAN_TRANSMUTATION</Sound>
-			<SoundMP>AS2D_TECH_HUMAN_TRANSMUTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/humantransmutation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30195,7 +30196,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_THERMAL_NEGATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_THERMAL_NEGATION</Sound>
-			<SoundMP>AS2D_TECH_THERMAL_NEGATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechThermalNegation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30283,7 +30284,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_DEFENSES_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_DEFENSES</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_DEFENSES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarydefenses.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30317,7 +30318,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NANOSHIELDING_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOSHIELDING</Sound>
-			<SoundMP>AS2D_TECH_NANOSHIELDING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechNanoshielding.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30364,7 +30365,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SENTIENT_EARTH_QUOTE</Quote>
 			<Sound>AS2D_TECH_SENTIENT_EARTH</Sound>
-			<SoundMP>AS2D_TECH_SENTIENT_EARTH</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/sentient_earth.dds,Art/Interface/Buttons/RoM_Techtree_Atlas.dds,1,16</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30423,7 +30424,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WEATHER_CONTROL_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEATHER_CONTROL</Sound>
-			<SoundMP>AS2D_TECH_WEATHER_CONTROL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/weather_control.dds,Art/Interface/Buttons/RoM_Techtree_Atlas2.dds,5,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30458,7 +30459,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_SUBTERRANEAN_EXPLORATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SUBTERRANEAN_EXPLORATION</Sound>
-			<SoundMP>AS2D_TECH_SUBTERRANEAN_EXPLORATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/subterraineanexploration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30492,7 +30493,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NANODISASSEMBLY_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANODISASSEMBLY</Sound>
-			<SoundMP>AS2D_TECH_NANDISASSEMBLY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechNanodisassembly.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30531,7 +30532,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MOLECULAR_SCANNING_QUOTE</Quote>
 			<Sound>AS2D_TECH_MOLECULAR_SCANNING</Sound>
-			<SoundMP>AS2D_TECH_MOLECULAR_SCANNING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechMolecularScanning.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30574,7 +30575,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SOLAR_ORDNANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_SOLAR_ORDNANCE</Sound>
-			<SoundMP>AS2D_TECH_SOLAR_ORDNANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/solarordnance.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30614,7 +30615,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_MEGASTRUCTURES_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_MEGASTRUCTURES</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_MEGASTRUCTURES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunarmegastructures.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30661,7 +30662,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NUCLEAR_PULSE_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_NuclearPhysics</Sound>
-			<SoundMP>AS2D_TECH_NuclearPhysics</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/nuclearpulsepropulsion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30701,7 +30702,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_MEGASTRUCTURES_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_MEGASTRUCTURES</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_MEGASTRUCTURES</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetarymegastructures.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30739,7 +30740,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_NANOTROIDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_NANOTROIDS</Sound>
-			<SoundMP>AS2D_TECH_NANOTROIDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechNanotroids.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30783,7 +30784,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EXTRATERRESTRIAL_AGRICULTURE_QUOTE</Quote>
 			<Sound>AS2D_TECH_EXTRATERRESTRIAL_AGRICULTURE</Sound>
-			<SoundMP>AS2D_TECH_EXTRATERRESTRIAL_AGRICULTURE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/extraterrestrialagriculture.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30836,7 +30837,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GALACTIC_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GALACTIC_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_GALACTIC_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/GalacticLifestyleTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -30905,7 +30906,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_COLONY_ARCOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_COLONY_ARCOLOGY</Sound>
-			<SoundMP>AS2D_TECH_COLONY_ARCOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/colonyarcology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31022,7 +31023,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROECOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROECOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ASTROECOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astroecology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31099,7 +31100,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_LAUNCH_ARCOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_LAUNCH_ARCOLOGY</Sound>
-			<SoundMP>AS2D_TECH_LAUNCH_ARCOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/interface/buttons/TechTree/launch_arcology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31176,7 +31177,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANETARY_TERRAFORMING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANETARY_TERRAFORMING</Sound>
-			<SoundMP>AS2D_TECH_PLANETARY_TERRAFORMING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/planetaryterraforming.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31220,7 +31221,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ATTOMETER_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATTOMETER_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_ATTOMETER_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/attometerengineering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31261,7 +31262,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_VASIMR_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_VASIMR_PROPULSION</Sound>
-			<SoundMP>AS2D_TECH_VASIMR_PROPULSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/vasimrpropulsion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31404,7 +31405,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_LUNAR_TERRAFORMING_QUOTE</Quote>
 			<Sound>AS2D_TECH_LUNAR_TERRAFORMING</Sound>
-			<SoundMP>AS2D_TECH_LUNAR_TERRAFORMING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/lunar_terraforming.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31476,7 +31477,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ATTOMETER_NANOMORPHISM_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATTOMETER_NANOMORPHISM</Sound>
-			<SoundMP>AS2D_TECH_ATTOMETER_NANOMORPHISM</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechAttometerNanomophism.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31516,7 +31517,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_ATOMIZATION_FIELD_QUOTE</Quote>
 			<Sound>AS2D_TECH_ATOMIZATION_FIELD</Sound>
-			<SoundMP>AS2D_TECH_ATOMIZATION_FIELD</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/interface/buttons/TechTree/atomization_field.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31658,7 +31659,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_TELEPORTATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_TELEPORTATION</Sound>
-			<SoundMP>AS2D_TECH_TELEPORTATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/teleportation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31698,7 +31699,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WEAPONIZED_DISINTEGRATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEAPONIZED_DISINTEGRATION</Sound>
-			<SoundMP>AS2D_TECH_WEAPONIZED_DISINTEGRATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/weaponizeddisintegration.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31741,7 +31742,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_INTERSTELLAR_COLONIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_INTERSTELLAR_COLONIZATION</Sound>
-			<SoundMP>AS2D_TECH_INTERSTELLAR_COLONIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/interstellarcolonization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -31840,7 +31841,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_INTERSTELLAR_TRADE_QUOTE</Quote>
 			<Sound>AS2D_TECH_INTERSTELLAR_TRADE</Sound>
-			<SoundMP>AS2D_TECH_INTERSTELLAR_TRADE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/interstellartrade.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32091,7 +32092,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ACNP_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ACNP_PROPULSION</Sound>
-			<SoundMP>AS2D_TECH_ACNP_PROPULSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/acnppropulsion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32129,7 +32130,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GRAVITY_CONTROL_QUOTE</Quote>
 			<Sound>AS2D_TECH_GRAVITY_CONTROL</Sound>
-			<SoundMP>AS2D_TECH_GRAVITY_CONTROL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechGravityControl.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32236,7 +32237,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ANTIMATTER_ROCKET_QUOTE</Quote>
 			<Sound>AS2D_TECH_ANTIMATTER_ROCKET</Sound>
-			<SoundMP>AS2D_TECH_ANTIMATTER_ROCKET</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/antimatterrocket.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32356,7 +32357,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PLANET_ENGINEERING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PLANET_ENGINEERING</Sound>
-			<SoundMP>AS2D_TECH_PLANET_ENGINEERING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/interface/buttons/TechTree/planet_engineering.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32399,7 +32400,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ADVANCED_SEEDSHIPS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ADVANCED_SEEDSHIPS</Sound>
-			<SoundMP>AS2D_TECH_ADVANCED_SEEDSHIPS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/advancedseedships.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32430,7 +32431,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WEAPONIZED_GRAVITY_FIELDS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEAPONIZED_GRAVITY_FIELDS</Sound>
-			<SoundMP>AS2D_TECH_WEAPONIZED_GRAVITY_FIELDS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechWeaponizedGravityFields.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32473,7 +32474,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASTROANTHROPOLOGY_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASTROANTHROPOLOGY</Sound>
-			<SoundMP>AS2D_TECH_ASTROANTHROPOLOGY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/astroanthropology.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32513,7 +32514,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_WEAPONIZED_ANTIMATTER_QUOTE</Quote>
 			<Sound>AS2D_TECH_WEAPONIZED_ANTIMATTER</Sound>
-			<SoundMP>AS2D_TECH_WEAPONIZED_ANTIMATTER</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/weaponizedantimatter.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32633,7 +32634,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARTIFICIAL_PLANETS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARTIFICIAL_PLANETS</Sound>
-			<SoundMP>AS2D_TECH_ARTIFICIAL_PLANETS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificialplanets.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32711,7 +32712,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SINGULARITY_STABILIZATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_SINGULARITY_STABILIZATION</Sound>
-			<SoundMP>AS2D_TECH_SINGULARITY_STABILIZATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/SingularityStanilization.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32820,7 +32821,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ARTIFICIAL_STARS_QUOTE</Quote>
 			<Sound>AS2D_TECH_ARTIFICIAL_STARS</Sound>
-			<SoundMP>AS2D_TECH_ARTIFICIAL_STARS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/artificialstars.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32858,7 +32859,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_MEGASTRONG_ALLOYS_QUOTE</Quote>
 			<Sound>AS2D_TECH_MEGASTRONG_ALLOYS</Sound>
-			<SoundMP>AS2D_TECH_MEGASTRONG_ALLOYS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/megastrongalloys.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32901,7 +32902,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRANSTANGIBLE_NEUTRINO_ACCELERATORS_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRANSTANGIBLE_NEUTRINO_ACCELERATORS</Sound>
-			<SoundMP>AS2D_TECH_TRANSTANGIBLE_NEUTRINO_ACCELERATORS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/interface/buttons/TechTree/transtangible_neutrino_accelerators.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -32944,7 +32945,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WORMHOLE_COMMUNICATIONS_QUOTE</Quote>
 			<Sound>AS2D_TECH_WORMHOLE_COMMUNICATIONS</Sound>
-			<SoundMP>AS2D_TECH_WORMHOLE_COMMUNICATIONS</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wormholecommunications.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33059,7 +33060,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_WORMHOLE_TRAVERSAL_QUOTE</Quote>
 			<Sound>AS2D_TECH_WORMHOLE_TRAVERSAL</Sound>
-			<SoundMP>AS2D_TECH_WORMHOLE_TRAVERSAL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/wormholetraversal.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33093,7 +33094,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_PHASING_QUOTE</Quote>
 			<Sound>AS2D_TECH_PHASING</Sound>
-			<SoundMP>AS2D_TECH_PHASING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TechPhasing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33136,7 +33137,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GALACTIC_FEDERATION_QUOTE</Quote>
 			<Sound>AS2D_TECH_GALACTIC_FEDERATION</Sound>
-			<SoundMP>AS2D_TECH_GALACTIC_FEDERATION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/galacticfederation.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33210,7 +33211,7 @@ Current techs which are not in this file:-
 			</OrPreReqs>
 			<Quote>TXT_KEY_TECH_FOLDING_SPACE_QUOTE</Quote>
 			<Sound>AS2D_TECH_FOLDING_SPACE</Sound>
-			<SoundMP>AS2D_TECH_FOLDING_SPACE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/foldingspace.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33300,7 +33301,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_COSMIC_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_COSMIC_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_COSMIC_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/CosmicLifestyleTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33379,7 +33380,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TIME_TRAVEL_QUOTE</Quote>
 			<Sound>AS2D_TECH_TIME_TRAVEL</Sound>
-			<SoundMP>AS2D_TECH_TIME_TRAVEL</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/timetravel.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -33486,7 +33487,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_SPACE_CREASING_QUOTE</Quote>
 			<Sound>AS2D_TECH_SPACE_CREASING</Sound>
-			<SoundMP>AS2D_TECH_SPACE_CREASING</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/spacecreasing.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -35079,7 +35080,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRANSCENDENT_LIFESTYLE_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRANSCENDENT_LIFESTYLE</Sound>
-			<SoundMP>AS2D_TECH_TRANSCENDENT_LIFESTYLE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Buttons/Techs/TranscendentalLifestyleTech.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -35149,7 +35150,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_DUALFLUX_QUANTUM_TEMPORAL_RIFT_QUOTE</Quote>
 			<Sound>AS2D_TECH_DUALFLUX_QUANTUM_TEMPORAL_RIFT</Sound>
-			<SoundMP>AS2D_TECH_DUALFLUX_QUANTUM_TEMPORAL_RIFT</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/dualflux.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -35266,7 +35267,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_TRANVERSE_EUCLIDEAN_GEOMETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_TRANVERSE_EUCLIDEAN_GEOMETRY</Sound>
-			<SoundMP>AS2D_TECH_TRANVERSE_EUCLIDEAN_GEOMETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/transverseduclideangeometry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -35437,7 +35438,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ENDOGENOUS_EUCLIDEAN_PROPULSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ENDOGENOUS_EUCLIDEAN_PROPULSION</Sound>
-			<SoundMP>AS2D_TECH_ENDOGENOUS_EUCLIDEAN_PROPULSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/interface/buttons/TechTree/endogenous_euclidean_propulsion.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -35480,7 +35481,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_EUCLIDEAN_FIVESPACE_GEOMETRY_QUOTE</Quote>
 			<Sound>AS2D_TECH_EUCLIDEAN_FIVESPACE_GEOMETRY</Sound>
-			<SoundMP>AS2D_TECH_EUCLIDEAN_FIVESPACE_GEOMETRY</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/euclidean5spacegeometry.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -36447,7 +36448,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_ASCENSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_ASCENSION</Sound>
-			<SoundMP>AS2D_TECH_ASCENSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/ascension.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -36951,7 +36952,7 @@ Current techs which are not in this file:-
 			<Flavors/>
 			<Quote>TXT_KEY_TECH_COLD_FUSION_QUOTE</Quote>
 			<Sound>AS2D_TECH_COLD_FUSION</Sound>
-			<SoundMP>AS2D_TECH_COLD_FUSION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Robotics.dds,Art/Interface/Buttons/NextWar_Atlas.dds,6,3</Button>
 		</TechInfo>
 		<TechInfo>
@@ -36988,7 +36989,7 @@ Current techs which are not in this file:-
 			</AndPreReqs>
 			<Quote>TXT_KEY_TECH_GLOBAL_GOVERNANCE_QUOTE</Quote>
 			<Sound>AS2D_TECH_GLOBAL_GOVERNANCE</Sound>
-			<SoundMP>AS2D_TECH_GLOBAL_GOVERNANCE</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/GlobalNetwork.dds</Button>
 		</TechInfo>
 		<TechInfo>
@@ -37005,7 +37006,7 @@ Current techs which are not in this file:-
 			<iGridY>-1</iGridY>
 			<Quote>TXT_KEY_TECH_RELIGION_QUOTE</Quote>
 			<Sound>AS2D_TECH_RELIGION</Sound>
-			<SoundMP>AS2D_TECH_RELIGION</SoundMP>
+			<SoundMP>AS2D_TECH_GENERIC</SoundMP>
 			<Button>,Art/Interface/Buttons/TechTree/Mysticism.dds,Art/Interface/Buttons/TechTree_Atlas.dds,4,11</Button>
 		</TechInfo>
 		<TechInfo>

--- a/Assets/XML/Technologies/TechInfos_MP_Rename.py
+++ b/Assets/XML/Technologies/TechInfos_MP_Rename.py
@@ -1,0 +1,36 @@
+######################
+# IMPORTANT NOTE:
+# To run this, since idk how xml schemas interact with xml.etree lol, you
+# need to TEMPORARILY # remove the xlmns bit from the CIV4TechInfos.xml
+# Remember to replace when done!
+#######################
+
+import lxml.etree as ET
+
+path_tech_infos = 'CIV4TechInfos.xml'
+
+b_tech_infos_reformatted = 0
+
+tree_tech_infos = ET.parse(path_tech_infos)
+root_tech_infos = tree_tech_infos.getroot()[0]
+
+for tech_info in root_tech_infos.iter('TechInfo'):
+    tech_mp_sound = tech_info.find('SoundMP').text
+
+    # mp quote needs replacing if it isn't already generic and not already _MP_
+    if ((tech_mp_sound != 'AS2D_TECH_GENERIC') and ('_MP_' not in tech_mp_sound)):
+        print(f"Switching {tech_mp_sound} to AS2D_TECH_GENERIC")
+        tech_info.find('SoundMP').text = 'AS2D_TECH_GENERIC'
+        b_tech_infos_reformatted = 1
+
+if b_tech_infos_reformatted:
+    tree_tech_infos.write(path_tech_infos)
+    print('''
+        CIV4TechInfos.xml reformatted.
+        Remember to replace the xmlns when done!
+        Additionally, the reformatting occasionally drops the first line of:
+        <?xml version="1.0" encoding="utf-8"?>
+        so be sure to include that if it's missing!
+        ''')
+else:
+    print('No MP techs discovered with duplicate SP counterparts')

--- a/Tools/XMLTools/TechInfos_MP_Rename.py
+++ b/Tools/XMLTools/TechInfos_MP_Rename.py
@@ -7,7 +7,7 @@
 
 import lxml.etree as ET
 
-path_tech_infos = 'CIV4TechInfos.xml'
+path_tech_infos = '../../Assets/XML/Technologies/CIV4TechInfos.xml'
 
 b_tech_infos_reformatted = 0
 


### PR DESCRIPTION
As Thunderbird suggested, multiplayer quote sfx are now either the "You have discovered X" from vanilla quotes where appropriate, or just the 'ding' sfx in place of potentially long, drawn out spoken quotes.

I initially wanted to rename all the tech .mp3 files to have a prefix matching the era the tech is in, for ease of editing them later (and also just for consistency's sake since they're all over the place...) but that didn't quite work out. So, guess I'm doing that manually now in a separate project as I'm passing through recording quotes (will make a different PR as I finish prehistoric era).