### PR TITLE
code cleanup

### DIFF
--- a/Assets/XML/BasicInfos/CIV4ANDConceptInfos.xml
+++ b/Assets/XML/BasicInfos/CIV4ANDConceptInfos.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0"?>
-<Civ4ANDConceptInfos/>

--- a/Assets/XML/BasicInfos/CIV4DCMConceptInfos.xml
+++ b/Assets/XML/BasicInfos/CIV4DCMConceptInfos.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0"?>
-<Civ4DCMConceptInfos/>

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -2987,9 +2987,7 @@ void CvGame::updatePlotGroups(bool reInitialize)
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3003,9 +3001,7 @@ void CvGame::updateBuildingCommerce()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3019,9 +3015,7 @@ void CvGame::updateCitySight(bool bIncrement)
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3037,9 +3031,7 @@ void CvGame::updateTradeRoutes()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3053,14 +3045,12 @@ void CvGame::testExtendedGame()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
 	if (getGameState() != GAMESTATE_OVER)
 	{
 		return;
 	}
 
-	for (iI = 0; iI < MAX_PC_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3221,14 +3211,11 @@ void CvGame::selectGroup(CvUnit* pUnit, bool bShift, bool bCtrl, bool bAlt) cons
 
 void CvGame::selectAll(CvPlot* pPlot) const
 {
-	CvUnit* pSelectUnit;
-	CvUnit* pCenterUnit;
-
-	pSelectUnit = NULL;
+	CvUnit* pSelectUnit = NULL;
 
 	if (pPlot != NULL)
 	{
-		pCenterUnit = pPlot->getDebugCenterUnit();
+		CvUnit* pCenterUnit = pPlot->getDebugCenterUnit();
 
 		if ((pCenterUnit != NULL) && (pCenterUnit->getOwnerINLINE() == getActivePlayer()))
 		{
@@ -3247,19 +3234,14 @@ bool CvGame::selectionListIgnoreBuildingDefense() const
 {
 	PROFILE_FUNC();
 
-	CLLNode<IDInfo>* pSelectedUnitNode;
-	CvUnit* pSelectedUnit;
-	bool bIgnoreBuilding;
-	bool bAttackLandUnit;
+	bool bIgnoreBuilding = false;
+	bool bAttackLandUnit = false;
 
-	bIgnoreBuilding = false;
-	bAttackLandUnit = false;
-
-	pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
+	CLLNode<IDInfo>* pSelectedUnitNode = gDLL->getInterfaceIFace()->headSelectionListNode();
 
 	while (pSelectedUnitNode != NULL)
 	{
-		pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
+		CvUnit* pSelectedUnit = ::getUnit(pSelectedUnitNode->m_data);
 		pSelectedUnitNode = gDLL->getInterfaceIFace()->nextSelectionListNode(pSelectedUnitNode);
 
 		if (pSelectedUnit != NULL)
@@ -3290,13 +3272,11 @@ bool CvGame::selectionListIgnoreBuildingDefense() const
 
 void CvGame::implementDeal(PlayerTypes eWho, PlayerTypes eOtherWho, CLinkList<TradeData>* pOurList, CLinkList<TradeData>* pTheirList, bool bForce)
 {
-	CvDeal* pDeal;
-
 	FAssertMsg(eWho != NO_PLAYER, "Who is not assigned a valid value");
 	FAssertMsg(eOtherWho != NO_PLAYER, "OtherWho is not assigned a valid value");
 	FAssertMsg(eWho != eOtherWho, "eWho is not expected to be equal with eOtherWho");
 
-	pDeal = addDeal();
+	CvDeal* pDeal = addDeal();
 	pDeal->init(pDeal->getID(), eWho, eOtherWho);
 	pDeal->addTrades(pOurList, pTheirList, !bForce);
 	if ((pDeal->getLengthFirstTrades() == 0) && (pDeal->getLengthSecondTrades() == 0))
@@ -3308,10 +3288,9 @@ void CvGame::implementDeal(PlayerTypes eWho, PlayerTypes eOtherWho, CLinkList<Tr
 
 void CvGame::verifyDeals()
 {
-	CvDeal* pLoopDeal;
 	int iLoop;
 
-	for(pLoopDeal = firstDeal(&iLoop); pLoopDeal != NULL; pLoopDeal = nextDeal(&iLoop))
+	for(CvDeal* pLoopDeal = firstDeal(&iLoop); pLoopDeal != NULL; pLoopDeal = nextDeal(&iLoop))
 	{
 		pLoopDeal->verify();
 	}
@@ -4309,7 +4288,7 @@ int CvGame::getTurnSlice() const
 
 int CvGame::getMinutesPlayed() const
 {
-	return (m_iTurnSlice / gDLL->getTurnsPerMinute());
+	return (getTurnSlice() / gDLL->getTurnsPerMinute());
 }
 
 
@@ -4323,7 +4302,7 @@ void CvGame::changeTurnSlice(int iChange)
 {
 	PROFILE_FUNC();
 
-	m_iTurnSlice += iChange;
+	setTurnSlice(getTurnSlice() + iChange);
 }
 
 
@@ -4341,13 +4320,13 @@ void CvGame::setCutoffSlice(int iNewValue)
 
 void CvGame::changeCutoffSlice(int iChange)
 {
-	m_iCutoffSlice += iChange;
+	setCutoffSlice(getCutoffSlice() + iChange);
 }
 
 
 int CvGame::getTurnSlicesRemaining()
 {
-	return (m_iCutoffSlice - m_iTurnSlice);
+	return (getCutoffSlice() - getTurnSlice());
 }
 
 
@@ -6146,9 +6125,7 @@ bool CvGame::isForceCivic(CivicTypes eIndex) const
 
 bool CvGame::isForceCivicOption(CivicOptionTypes eCivicOption) const
 {
-	int iI;
-
-	for (iI = 0; iI < GC.getNumCivicInfos(); iI++)
+	for (int iI = 0; iI < GC.getNumCivicInfos(); iI++)
 	{
 		if (GC.getCivicInfo((CivicTypes)iI).getCivicOptionType() == eCivicOption)
 		{
@@ -6247,7 +6224,7 @@ int CvGame::getReligionGameTurnFounded(ReligionTypes eIndex) const
 
 bool CvGame::isReligionFounded(ReligionTypes eIndex) const
 {
-	return (m_paiReligionGameTurnFounded[eIndex] != -1);
+	return (getReligionGameTurnFounded(eIndex) != -1);
 }
 
 
@@ -6407,7 +6384,7 @@ int CvGame::getCorporationGameTurnFounded(CorporationTypes eIndex) const
 
 bool CvGame::isCorporationFounded(CorporationTypes eIndex) const
 {
-	return (m_paiCorporationGameTurnFounded[eIndex] != -1);
+	return (getCorporationGameTurnFounded(eIndex) != -1);
 }
 
 
@@ -6473,7 +6450,6 @@ void CvGame::makeSpecialBuildingValid(SpecialBuildingTypes eIndex, bool bAnnounc
 	if (!m_pabSpecialBuildingValid[eIndex])
 	{
 		m_pabSpecialBuildingValid[eIndex] = true;
-
 
 		if (bAnnounce)
 		{
@@ -6720,7 +6696,6 @@ void CvGame::setHeadquarters(CorporationTypes eIndex, CvCity* pNewValue, bool bA
 
 		if (NULL != pHeadquarters)
 		{
-
 			pHeadquarters->setHasCorporation(eIndex, true, bAnnounce);
 			pHeadquarters->updateCorporation();
 			pHeadquarters->setInfoDirty(true);
@@ -9636,7 +9611,6 @@ void CvGame::testVictory()
 				}
 			}
 		}
-
 	}
 
 /************************************************************************************************/
@@ -11124,21 +11098,19 @@ void CvGame::saveReplay(PlayerTypes ePlayer)
 
 void CvGame::showEndGameSequence()
 {
-	CvPopupInfo* pInfo;
 	CvWString szBuffer;
-	int iI;
 
 	long iHours = getMinutesPlayed() / 60;
 	long iMinutes = getMinutesPlayed() % 60;
 
-	for (iI = 0; iI < MAX_PC_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 	{
 		CvPlayer& player = GET_PLAYER((PlayerTypes)iI);
 		if (player.isHuman())
 		{
 			addReplayMessage(REPLAY_MESSAGE_MAJOR_EVENT, (PlayerTypes)iI, gDLL->getText("TXT_KEY_MISC_TIME_SPENT", iHours, iMinutes));
 
-			pInfo = new CvPopupInfo(BUTTONPOPUP_TEXT);
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_TEXT);
 			if (NULL != pInfo)
 			{
 				if ((getWinner() != NO_TEAM) && (getVictory() != NO_VICTORY))
@@ -11352,8 +11324,6 @@ void CvGame::addPlayer(PlayerTypes eNewPlayer, LeaderHeadTypes eLeader, Civiliza
 
 void CvGame::changeHumanPlayer( PlayerTypes eOldHuman, PlayerTypes eNewHuman )
 {
-	int iI;
-
 	// It's a multiplayer game, eep!
 	if(GC.getInitCore().getMultiplayer())
 	{
@@ -11366,7 +11336,7 @@ void CvGame::changeHumanPlayer( PlayerTypes eOldHuman, PlayerTypes eNewHuman )
 	if(getActivePlayer()==eOldHuman)
 	setActivePlayer(eNewHuman, false);
 	
-	for (iI = 0; iI < NUM_PLAYEROPTION_TYPES; iI++)
+	for (int iI = 0; iI < NUM_PLAYEROPTION_TYPES; iI++)
 	{
 		GET_PLAYER(eNewHuman).setOption( (PlayerOptionTypes)iI, GET_PLAYER(eOldHuman).isOption((PlayerOptionTypes)iI) );
 	}
@@ -11648,7 +11618,6 @@ void CvGame::changeShrineBuilding(BuildingTypes eBuilding, ReligionTypes eReligi
 
 				m_iShrineBuildingCount--;
 			}
-
 		}
 	}
 	else if (m_iShrineBuildingCount < GC.getNumBuildingInfos())
@@ -11672,12 +11641,7 @@ int CvGame::culturalVictoryNumCultureCities() const
 
 CultureLevelTypes CvGame::culturalVictoryCultureLevel() const
 {
-	if (m_iNumCultureVictoryCities > 0)
-	{
-		return (CultureLevelTypes) m_eCultureVictoryCultureLevel;
-	}
-
-	return NO_CULTURELEVEL;
+	return (m_iNumCultureVictoryCities > 0) ? (CultureLevelTypes) m_eCultureVictoryCultureLevel : NO_CULTURELEVEL;
 }
 
 int CvGame::getCultureThreshold(CultureLevelTypes eLevel) const
@@ -11697,12 +11661,11 @@ int CvGame::getCultureThreshold(CultureLevelTypes eLevel) const
 void CvGame::doUpdateCacheOnTurn()
 {
 	MEMORY_TRACE_FUNCTION();
-	int	iI;
 	
 	// reset shrine count
 	m_iShrineBuildingCount = 0;
 
-	for (iI = 0; iI < GC.getNumBuildingInfos(); iI++)
+	for (int iI = 0; iI < GC.getNumBuildingInfos(); iI++)
 	{
 		CvBuildingInfo&	kBuildingInfo = GC.getBuildingInfo((BuildingTypes) iI);
 		
@@ -12599,7 +12562,7 @@ void CvGame::setWaterAnimalSpawnChance(int iNewValue)
 
 void CvGame::changeWaterAnimalSpawnChance(int iChange)
 {
-	m_iWaterAnimalSpawnChance += iChange;
+	setWaterAnimalSpawnChance(getWaterAnimalSpawnChance() + iChange);
 }
 
 #if defined QC_MASTERY_VICTORY
@@ -12644,7 +12607,7 @@ void CvGame::setXResolution(int iNewValue)
 
 void CvGame::changeXResolution(int iChange)
 {
-	m_iXResolution += iChange;
+	setXResolution(getXResolution() + iChange);
 }
 
 int CvGame::getYResolution() const
@@ -12659,7 +12622,7 @@ void CvGame::setYResolution(int iNewValue)
 
 void CvGame::changeYResolution(int iChange)
 {
-	m_iYResolution += iChange;
+	setYResolution(getYResolution() + iChange);
 }
 
 int CvGame::getCutLosersCounter() const
@@ -12965,10 +12928,9 @@ void CvGame::doFlexibleDifficulty()
 
 void CvGame::averageHandicaps()
 {
-	int iI;
 	int iAverageHandicap = 0;
 	int iHumanCount = 0;
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive() && GET_PLAYER((PlayerTypes)iI).isHuman())
 		{
@@ -13190,25 +13152,21 @@ void CvGame::findBays()
 void CvGame::findForests()
 {
 	CvPlot* pLoopPlot;
-	int iForestCount;
+	FeatureTypes eForest = (FeatureTypes)GC.getInfoTypeForString("FEATURE_FOREST");
 	int iMinimumForestSize = GC.getDefineINT("MINIMUM_FOREST_SIZE");
 	iMinimumForestSize += (int)GC.getMapINLINE().getWorldSize() * 2;
 	for (int iPlot = 0; iPlot < GC.getMapINLINE().numPlotsINLINE(); iPlot++)
 	{
 		pLoopPlot = GC.getMapINLINE().plotByIndexINLINE(iPlot);
-		iForestCount = 0;
-		if (!pLoopPlot->isCountedPlot())
+		int iForestCount = 0;
+		if (!pLoopPlot->isCountedPlot() && pLoopPlot->getFeatureType() == eForest)
 		{
-			//Forest
-			if (pLoopPlot->getFeatureType() == (FeatureTypes)GC.getInfoTypeForString("FEATURE_FOREST"))
+			iForestCount++;
+			pLoopPlot->setCountedPlot(true);
+			iForestCount += countForest(pLoopPlot, iForestCount);
+			if (iForestCount > iMinimumForestSize)
 			{
-				iForestCount++;
-				pLoopPlot->setCountedPlot(true);
-				iForestCount += countForest(pLoopPlot, iForestCount);
-				if (iForestCount > iMinimumForestSize)
-				{
-					pLoopPlot->setLandmarkType(LANDMARK_FOREST);
-				}
+				pLoopPlot->setLandmarkType(LANDMARK_FOREST);
 			}
 		}
 	}
@@ -13309,8 +13267,7 @@ void CvGame::findLakes()
 //Used to ensure no more than 1 sign gets placed on each lake.
 void CvGame::markLakePlots(CvPlot* pPlot)
 {
-	int iI;
-	for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 	{
 		CvPlot* pAdjacentPlot = plotDirection(pPlot->getX_INLINE(), pPlot->getY_INLINE(), ((DirectionTypes)iI));
 		if (pAdjacentPlot != NULL)
@@ -13687,9 +13644,8 @@ void CvGame::markBayPlots(CvPlot* pPlot)
 
 int CvGame::countPeaks(CvPlot* pPlot, bool bCountHill)
 {
-	int iI;
 	int iPeak = 0;
-	for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 	{
 		CvPlot* pAdjacentPlot = plotDirection(pPlot->getX_INLINE(), pPlot->getY_INLINE(), ((DirectionTypes)iI));
 		if (pAdjacentPlot != NULL)
@@ -13783,8 +13739,7 @@ void CvGame::doFoundCorporations()
 {
 	MEMORY_TRACE_FUNCTION();
 
-	int iI;
-	for (iI = 0; iI < GC.getNumCorporationInfos(); iI++)
+	for (int iI = 0; iI < GC.getNumCorporationInfos(); iI++)
 	{
 		doFoundCorporation((CorporationTypes)iI, false);
 	}

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -3344,11 +3344,6 @@ int CvGame::getSymbolID(int iSymbol)
 
 int CvGame::getAdjustedPopulationPercent(VictoryTypes eVictory) const
 {
-	int iPopulation;
-	int iBestPopulation;
-	int iNextBestPopulation;
-	int iI;
-
 	if (GC.getVictoryInfo(eVictory).getPopulationPercentLead() == 0)
 	{
 		return 0;
@@ -3359,14 +3354,14 @@ int CvGame::getAdjustedPopulationPercent(VictoryTypes eVictory) const
 		return 100;
 	}
 
-	iBestPopulation = 0;
-	iNextBestPopulation = 0;
+	int iBestPopulation = 0;
+	int iNextBestPopulation = 0;
 
-	for (iI = 0; iI < MAX_PC_TEAMS; iI++)
+	for (int iI = 0; iI < MAX_PC_TEAMS; iI++)
 	{
 		if (GET_TEAM((TeamTypes)iI).isAlive())
 		{
-			iPopulation = GET_TEAM((TeamTypes)iI).getTotalPopulation();
+			int iPopulation = GET_TEAM((TeamTypes)iI).getTotalPopulation();
 
 			if (iPopulation > iBestPopulation)
 			{
@@ -3384,7 +3379,7 @@ int CvGame::getAdjustedPopulationPercent(VictoryTypes eVictory) const
 }
 
 
-int CvGame::getProductionPerPopulation(HurryTypes eHurry)
+int CvGame::getProductionPerPopulation(HurryTypes eHurry) const
 {
 	if (NO_HURRY == eHurry)
 	{
@@ -3396,14 +3391,12 @@ int CvGame::getProductionPerPopulation(HurryTypes eHurry)
 
 int CvGame::getAdjustedLandPercent(VictoryTypes eVictory) const
 {
-	int iPercent;
-
 	if (GC.getVictoryInfo(eVictory).getLandPercent() == 0)
 	{
 		return 0;
 	}
 
-	iPercent = GC.getVictoryInfo(eVictory).getLandPercent();
+	int iPercent = GC.getVictoryInfo(eVictory).getLandPercent();
 
 	iPercent -= (countCivTeamsEverAlive() * 2);
 
@@ -3504,12 +3497,9 @@ int CvGame::countVote(const VoteTriggeredData& kData, PlayerVoteTypes eChoice) c
 
 int CvGame::countPossibleVote(VoteTypes eVote, VoteSourceTypes eVoteSource) const
 {
-	int iCount;
-	int iI;
+	int iCount = 0;
 
-	iCount = 0;
-
-	for (iI = 0; iI < MAX_PC_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 	{
 		if ( GET_PLAYER((PlayerTypes)iI).isAlive() )
 		{
@@ -3766,7 +3756,7 @@ int CvGame::countHumanPlayersAlive() const
 }
 
 
-int CvGame::countTotalCivPower()
+int CvGame::countTotalCivPower() const
 {
 	int iCount = 0;
 
@@ -3783,7 +3773,7 @@ int CvGame::countTotalCivPower()
 }
 
 
-int CvGame::countTotalNukeUnits()
+int CvGame::countTotalNukeUnits() const
 {
 	int iCount = 0;
 	for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
@@ -3799,18 +3789,15 @@ int CvGame::countTotalNukeUnits()
 }
 
 
-int CvGame::countKnownTechNumTeams(TechTypes eTech)
+int CvGame::countKnownTechNumTeams(TechTypes eTech) const
 {
 	int iCount = 0;
 
-	for (int iI = 0; iI < MAX_TEAMS; iI++)
+	for (int iI = 0; iI < MAX_PC_TEAMS; iI++)
 	{
-		if (GET_TEAM((TeamTypes)iI).isEverAlive())
+		if (GET_TEAM((TeamTypes)iI).isEverAlive() && GET_TEAM((TeamTypes)iI).isHasTech(eTech))
 		{
-			if (GET_TEAM((TeamTypes)iI).isHasTech(eTech) && !GET_TEAM((TeamTypes)iI).isNPC())
-			{
-				iCount++;
-			}
+			iCount++;
 		}
 	}
 
@@ -3818,7 +3805,7 @@ int CvGame::countKnownTechNumTeams(TechTypes eTech)
 }
 
 
-int CvGame::getNumFreeBonuses(BuildingTypes eBuilding)
+int CvGame::getNumFreeBonuses(BuildingTypes eBuilding) const
 {
 	if (GC.getBuildingInfo(eBuilding).getNumFreeBonuses() == -1)
 	{
@@ -3831,14 +3818,11 @@ int CvGame::getNumFreeBonuses(BuildingTypes eBuilding)
 }
 
 
-int CvGame::countReligionLevels(ReligionTypes eReligion)
+int CvGame::countReligionLevels(ReligionTypes eReligion) const
 {
-	int iCount;
-	int iI;
+	int iCount = 0;
 
-	iCount = 0;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -3849,7 +3833,7 @@ int CvGame::countReligionLevels(ReligionTypes eReligion)
 	return iCount;
 }
 
-int CvGame::countCorporationLevels(CorporationTypes eCorporation)
+int CvGame::countCorporationLevels(CorporationTypes eCorporation) const
 {
 	int iCount = 0;
 
@@ -3896,23 +3880,19 @@ void CvGame::replaceCorporation(CorporationTypes eCorporation1, CorporationTypes
 
 int CvGame::calculateReligionPercent(ReligionTypes eReligion) const
 {
-	CvCity* pLoopCity;
-	int iCount;
-	int iLoop;
-	int iI;
-
 	if (getTotalPopulation() == 0)
 	{
 		return 0;
 	}
 
-	iCount = 0;
+	int iCount = 0;
 
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
-			for (pLoopCity = GET_PLAYER((PlayerTypes)iI).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER((PlayerTypes)iI).nextCity(&iLoop))
+			int iLoop;
+			for (CvCity* pLoopCity = GET_PLAYER((PlayerTypes)iI).firstCity(&iLoop); pLoopCity != NULL; pLoopCity = GET_PLAYER((PlayerTypes)iI).nextCity(&iLoop))
 			{
 				if (pLoopCity->isHasReligion(eReligion))
 				{
@@ -3928,9 +3908,7 @@ int CvGame::calculateReligionPercent(ReligionTypes eReligion) const
 
 int CvGame::goldenAgeLength() const
 {
-	int iLength;
-
-	iLength = GC.getDefineINT("GOLDEN_AGE_LENGTH");
+	int iLength = GC.getDefineINT("GOLDEN_AGE_LENGTH");
 
 	iLength *= GC.getGameSpeedInfo(getGameSpeedType()).getGoldenAgePercent();
 	iLength /= 100;
@@ -3954,9 +3932,7 @@ int CvGame::victoryDelay(VictoryTypes eVictory) const
 
 int CvGame::getImprovementUpgradeTime(ImprovementTypes eImprovement) const
 {
-	int iTime;
-
-	iTime = GC.getImprovementInfo(eImprovement).getUpgradeTime();
+	int iTime = GC.getImprovementInfo(eImprovement).getUpgradeTime();
 
 	iTime *= GC.getGameSpeedInfo(getGameSpeedType()).getImprovementPercent();
 	iTime /= 100;
@@ -4005,15 +3981,13 @@ bool CvGame::canTrainNukes() const
 /************************************************************************************************/
 EraTypes CvGame::getHighestEra() const
 {
-	int iI;
 	int iHighestEra = 0;
-	int iLoopEra;
 	
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
-			iLoopEra = GET_PLAYER((PlayerTypes)iI).getCurrentEra();
+			int iLoopEra = GET_PLAYER((PlayerTypes)iI).getCurrentEra();
 
 			if(iLoopEra > iHighestEra)
 			{
@@ -4029,14 +4003,10 @@ EraTypes CvGame::getHighestEra() const
 /************************************************************************************************/
 EraTypes CvGame::getCurrentEra() const
 {
-	int iEra;
-	int iCount;
-	int iI;
+	int iEra = 0;
+	int iCount = 0;
 
-	iEra = 0;
-	iCount = 0;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -4339,7 +4309,7 @@ int CvGame::getTurnSlice() const
 
 int CvGame::getMinutesPlayed() const
 {
-	return (getTurnSlice() / gDLL->getTurnsPerMinute());
+	return (m_iTurnSlice / gDLL->getTurnsPerMinute());
 }
 
 
@@ -4353,7 +4323,7 @@ void CvGame::changeTurnSlice(int iChange)
 {
 	PROFILE_FUNC();
 
-	setTurnSlice(getTurnSlice() + iChange);
+	m_iTurnSlice += iChange;
 }
 
 
@@ -4371,13 +4341,13 @@ void CvGame::setCutoffSlice(int iNewValue)
 
 void CvGame::changeCutoffSlice(int iChange)
 {
-	setCutoffSlice(getCutoffSlice() + iChange);
+	m_iCutoffSlice += iChange;
 }
 
 
 int CvGame::getTurnSlicesRemaining()
 {
-	return (getCutoffSlice() - getTurnSlice());
+	return (m_iCutoffSlice - m_iTurnSlice);
 }
 
 
@@ -4416,7 +4386,7 @@ void CvGame::incrementTurnTimer(int iNumTurnSlices)
 }
 
 
-int CvGame::getMaxTurnLen()
+int CvGame::getMaxTurnLen() const
 {
 	if (isPitboss())
 	{
@@ -4469,7 +4439,7 @@ void CvGame::setTargetScore(int iNewValue)
 }
 
 
-int CvGame::getNumGameTurnActive()
+int CvGame::getNumGameTurnActive() const
 {
 	return m_iNumGameTurnActive;
 }
@@ -4477,12 +4447,9 @@ int CvGame::getNumGameTurnActive()
 
 int CvGame::countNumHumanGameTurnActive() const
 {
-	int iCount;
-	int iI;
+	int iCount = 0;
 
-	iCount = 0;
-
-	for (iI = 0; iI < MAX_PC_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isHuman())
 		{
@@ -4599,11 +4566,9 @@ bool CvGame::isFreeTrade() const
 
 void CvGame::changeFreeTradeCount(int iChange)
 {
-	bool bOldFreeTrade;
-
 	if (iChange != 0)
 	{
-		bOldFreeTrade = isFreeTrade();
+		bool bOldFreeTrade = isFreeTrade();
 
 		m_iFreeTradeCount = (m_iFreeTradeCount + iChange);
 		FAssert(getFreeTradeCount() >= 0);
@@ -4813,7 +4778,7 @@ void CvGame::initScoreCalculation()
 /*                                                                                 jdog5000     */
 /*                                                                                              */
 /************************************************************************************************/
-int CvGame::getAIAutoPlay(PlayerTypes iPlayer)
+int CvGame::getAIAutoPlay(PlayerTypes iPlayer) const
 {
 	return m_iAIAutoPlay[iPlayer];
 }
@@ -4828,12 +4793,12 @@ void CvGame::setAIAutoPlay(PlayerTypes iPlayer, int iNewValue, bool bForced)
 
 	if (GC.getLogging() )
 	{
-			TCHAR szOut[1024];
-			sprintf(szOut, "setAutoPlay called for player %d - set to: %d\n", iPlayer, iNewValue);
-			gDLL->messageControlLog(szOut);
+		TCHAR szOut[1024];
+		sprintf(szOut, "setAutoPlay called for player %d - set to: %d\n", iPlayer, iNewValue);
+		gDLL->messageControlLog(szOut);
 	}
 
-	int iOldValue= getAIAutoPlay(iPlayer);
+	int iOldValue = getAIAutoPlay(iPlayer);
 
 	if (iOldValue != iNewValue)
 	{
@@ -4861,9 +4826,9 @@ void CvGame::changeAIAutoPlay(PlayerTypes iPlayer, int iChange)
 }
 
 
-bool CvGame::isForcedAIAutoPlay(PlayerTypes iPlayer)
+bool CvGame::isForcedAIAutoPlay(PlayerTypes iPlayer) const
 {
-	FAssert(getForcedAIAutoPlay(iPlayer) >=0)
+	FAssert(getForcedAIAutoPlay(iPlayer) >= 0)
 
 	if(getForcedAIAutoPlay(iPlayer) > 0)
 	{
@@ -4872,7 +4837,7 @@ bool CvGame::isForcedAIAutoPlay(PlayerTypes iPlayer)
 	return false;
 }
 
-int CvGame::getForcedAIAutoPlay(PlayerTypes iPlayer)
+int CvGame::getForcedAIAutoPlay(PlayerTypes iPlayer) const
 {
 	return m_iForcedAIAutoPlay[iPlayer];
 }
@@ -4884,7 +4849,6 @@ void CvGame::setForcedAIAutoPlay(PlayerTypes iPlayer, int iNewValue, bool bForce
 	int iOldValue;
 	if(bForced == true)
 	{
-
 		iOldValue = getForcedAIAutoPlay(iPlayer);
 
 		if (iOldValue != iNewValue)
@@ -4948,7 +4912,7 @@ void CvGame::setLastNukeStrikePlot(CvPlot* pPlot)
 }
 // < M.A.D. Nukes End   >
 
-unsigned int CvGame::getInitialTime()
+unsigned int CvGame::getInitialTime() const
 {
 	return m_uiInitialTime;
 }
@@ -5480,8 +5444,6 @@ void CvGame::setFinalInitialized(bool bNewValue)
 
 	PROFILE_FUNC();
 
-	int iI;
-
 	if (isFinalInitialized() != bNewValue)
 	{
 		m_bFinalInitialized = bNewValue;
@@ -5492,7 +5454,7 @@ void CvGame::setFinalInitialized(bool bNewValue)
 
 			GC.getMapINLINE().updateIrrigated();
 
-			for (iI = 0; iI < MAX_TEAMS; iI++)
+			for (int iI = 0; iI < MAX_TEAMS; iI++)
 			{
 				if (GET_TEAM((TeamTypes)iI).isAlive())
 				{
@@ -5538,8 +5500,6 @@ bool CvGame::isPlayerOptionsSent() const
 
 void CvGame::sendPlayerOptions(bool bForce)
 {
-	int iI;
-
 	if (getActivePlayer() == NO_PLAYER)
 	{
 		return;
@@ -5549,7 +5509,7 @@ void CvGame::sendPlayerOptions(bool bForce)
 	{
 		m_bPlayerOptionsSent = true;
 
-		for (iI = 0; iI < NUM_PLAYEROPTION_TYPES; iI++)
+		for (int iI = 0; iI < NUM_PLAYEROPTION_TYPES; iI++)
 		{
 			gDLL->sendPlayerOption(((PlayerOptionTypes)iI), gDLL->getPlayerOption((PlayerOptionTypes)iI));
 		}
@@ -5817,9 +5777,6 @@ GameStateTypes CvGame::getGameState() const
 
 void CvGame::setGameState(GameStateTypes eNewValue)
 {
-	CvPopupInfo* pInfo;
-	int iI;
-
 	if (getGameState() != eNewValue)
 	{
 		m_eGameState = eNewValue;
@@ -5834,12 +5791,12 @@ void CvGame::setGameState(GameStateTypes eNewValue)
 
 			showEndGameSequence();
 
-			for (iI = 0; iI < MAX_PC_PLAYERS; iI++)
+			for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 			{
 				if (GET_PLAYER((PlayerTypes)iI).isHuman())
 				{
 					// One more turn?
-					pInfo = new CvPopupInfo(BUTTONPOPUP_EXTENDED_GAME);
+					CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_EXTENDED_GAME);
 					if (NULL != pInfo)
 					{
 						GET_PLAYER((PlayerTypes)iI).addPopup(pInfo);
@@ -6063,7 +6020,7 @@ void CvGame::setForceControl(ForceControlTypes eIndex, bool bEnabled)
 }
 
 
-int CvGame::getUnitCreatedCount(UnitTypes eIndex)
+int CvGame::getUnitCreatedCount(UnitTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumUnitInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6079,7 +6036,7 @@ void CvGame::incrementUnitCreatedCount(UnitTypes eIndex)
 }
 
 
-int CvGame::getUnitClassCreatedCount(UnitClassTypes eIndex)
+int CvGame::getUnitClassCreatedCount(UnitClassTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumUnitClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6087,7 +6044,7 @@ int CvGame::getUnitClassCreatedCount(UnitClassTypes eIndex)
 }
 
 
-bool CvGame::isUnitClassMaxedOut(UnitClassTypes eIndex, int iExtra)
+bool CvGame::isUnitClassMaxedOut(UnitClassTypes eIndex, int iExtra) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumUnitClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6111,7 +6068,7 @@ void CvGame::incrementUnitClassCreatedCount(UnitClassTypes eIndex)
 }
 
 
-int CvGame::getBuildingClassCreatedCount(BuildingClassTypes eIndex)
+int CvGame::getBuildingClassCreatedCount(BuildingClassTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumBuildingClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6119,7 +6076,7 @@ int CvGame::getBuildingClassCreatedCount(BuildingClassTypes eIndex)
 }
 
 
-bool CvGame::isBuildingClassMaxedOut(BuildingClassTypes eIndex, int iExtra)
+bool CvGame::isBuildingClassMaxedOut(BuildingClassTypes eIndex, int iExtra) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumBuildingClassInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6141,7 +6098,7 @@ void CvGame::incrementBuildingClassCreatedCount(BuildingClassTypes eIndex)
 }
 
 
-int CvGame::getProjectCreatedCount(ProjectTypes eIndex)
+int CvGame::getProjectCreatedCount(ProjectTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumProjectInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6149,7 +6106,7 @@ int CvGame::getProjectCreatedCount(ProjectTypes eIndex)
 }
 
 
-bool CvGame::isProjectMaxedOut(ProjectTypes eIndex, int iExtra)
+bool CvGame::isProjectMaxedOut(ProjectTypes eIndex, int iExtra) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumProjectInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6253,15 +6210,13 @@ bool CvGame::isVotePassed(VoteTypes eIndex) const
 
 void CvGame::setVoteOutcome(const VoteTriggeredData& kData, PlayerVoteTypes eNewValue)
 {
-	bool bOldPassed;
-
 	VoteTypes eIndex = kData.kVoteOption.eVote;
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumVoteInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
 
 	if (getVoteOutcome(eIndex) != eNewValue)
 	{
-		bOldPassed = isVotePassed(eIndex);
+		bool bOldPassed = isVotePassed(eIndex);
 
 		m_paiVoteOutcome[eIndex] = eNewValue;
 
@@ -6282,7 +6237,7 @@ void CvGame::setVoteOutcome(const VoteTriggeredData& kData, PlayerVoteTypes eNew
 }
 
 
-int CvGame::getReligionGameTurnFounded(ReligionTypes eIndex)
+int CvGame::getReligionGameTurnFounded(ReligionTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumReligionInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6290,9 +6245,9 @@ int CvGame::getReligionGameTurnFounded(ReligionTypes eIndex)
 }
 
 
-bool CvGame::isReligionFounded(ReligionTypes eIndex)
+bool CvGame::isReligionFounded(ReligionTypes eIndex) const
 {
-	return (getReligionGameTurnFounded(eIndex) != -1);
+	return (m_paiReligionGameTurnFounded[eIndex] != -1);
 }
 
 
@@ -6408,7 +6363,7 @@ void CvGame::checkGameStart()
 	}
 }
 
-int CvGame::countNumReligionsFounded()
+int CvGame::countNumReligionsFounded() const
 {
 	int iCount = 0;
 
@@ -6423,18 +6378,15 @@ int CvGame::countNumReligionsFounded()
 	return iCount;
 }
 
-int CvGame::countNumReligionTechsDiscovered()
+int CvGame::countNumReligionTechsDiscovered() const
 {
 	int iCount = 0;
 
 	for (int iI = 0; iI < GC.getNumReligionInfos(); iI++)
 	{
-		TechTypes eTech = TechTypes(GC.getReligionInfo((ReligionTypes)iI).getTechPrereq());
+		if( countKnownTechNumTeams((TechTypes)GC.getReligionInfo((ReligionTypes)iI).getTechPrereq()) > 0)
 		{
-			if( countKnownTechNumTeams(eTech) > 0)
-			{
-				iCount++;
-			}
+			iCount++;
 		}
 	}
 
@@ -6445,7 +6397,7 @@ int CvGame::countNumReligionTechsDiscovered()
 /************************************************************************************************/
 
 
-int CvGame::getCorporationGameTurnFounded(CorporationTypes eIndex)
+int CvGame::getCorporationGameTurnFounded(CorporationTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumCorporationInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6453,9 +6405,9 @@ int CvGame::getCorporationGameTurnFounded(CorporationTypes eIndex)
 }
 
 
-bool CvGame::isCorporationFounded(CorporationTypes eIndex)
+bool CvGame::isCorporationFounded(CorporationTypes eIndex) const
 {
-	return (getCorporationGameTurnFounded(eIndex) != -1);
+	return (m_paiCorporationGameTurnFounded[eIndex] != -1);
 }
 
 
@@ -6489,7 +6441,7 @@ void CvGame::setVictoryValid(VictoryTypes eIndex, bool bValid)
 }
 
 
-bool CvGame::isSpecialUnitValid(SpecialUnitTypes eIndex)
+bool CvGame::isSpecialUnitValid(SpecialUnitTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumSpecialUnitInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6505,7 +6457,7 @@ void CvGame::makeSpecialUnitValid(SpecialUnitTypes eIndex)
 }
 
 
-bool CvGame::isSpecialBuildingValid(SpecialBuildingTypes eIndex)
+bool CvGame::isSpecialBuildingValid(SpecialBuildingTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumSpecialBuildingInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6578,7 +6530,7 @@ void CvGame::setVoteChosen(int iSelection, int iVoteId)
 }
 
 
-CvCity* CvGame::getHolyCity(ReligionTypes eIndex)
+CvCity* CvGame::getHolyCity(ReligionTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumReligionInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -6700,7 +6652,7 @@ void CvGame::setHolyCity(ReligionTypes eIndex, CvCity* pNewValue, bool bAnnounce
 }
 
 
-CvCity* CvGame::getHeadquarters(CorporationTypes eIndex)
+CvCity* CvGame::getHeadquarters(CorporationTypes eIndex) const
 {
 	FAssertMsg(eIndex >= 0, "eIndex is expected to be non-negative (invalid Index)");
 	FAssertMsg(eIndex < GC.getNumCorporationInfos(), "eIndex is expected to be within maximum bounds (invalid Index)");
@@ -9212,9 +9164,7 @@ void CvGame::verifyCivics()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -9228,9 +9178,7 @@ void CvGame::updateTimers()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		if (GET_PLAYER((PlayerTypes)iI).isAlive())
 		{
@@ -9244,8 +9192,6 @@ void CvGame::updateTurnTimer()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
 	// Are we using a turn timer?
 	if (isMPOption(MPOPTION_TURN_TIMER))
 	{
@@ -9254,7 +9200,7 @@ void CvGame::updateTurnTimer()
 			// Has the turn expired?
 			if (getTurnSlice() > getCutoffSlice())
 			{
-				for (iI = 0; iI < MAX_PLAYERS; iI++)
+				for (int iI = 0; iI < MAX_PLAYERS; iI++)
 				{
 					if (GET_PLAYER((PlayerTypes)iI).isAlive() && GET_PLAYER((PlayerTypes)iI).isTurnActive())
 					{
@@ -9276,9 +9222,7 @@ void CvGame::testAlive()
 {
 	PROFILE_FUNC();
 
-	int iI;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
 		GET_PLAYER((PlayerTypes)iI).verifyAlive();
 	}
@@ -10101,13 +10045,13 @@ int CvGame::getIndexAfterLastDeal()
 }
 
 
-int CvGame::getNumDeals()
+int CvGame::getNumDeals() const
 {
 	return m_deals.getCount();
 }
 
 
- CvDeal* CvGame::getDeal(int iID)																		
+CvDeal* CvGame::getDeal(int iID)
 {
 	return ((CvDeal *)(m_deals.getAt(iID)));
 }
@@ -10119,25 +10063,25 @@ CvDeal* CvGame::addDeal()
 }
 
 
- void CvGame::deleteDeal(int iID)
+void CvGame::deleteDeal(int iID)
 {
 	m_deals.removeAt(iID);
 	gDLL->getInterfaceIFace()->setDirty(Foreign_Screen_DIRTY_BIT, true);
 }
 
-CvDeal* CvGame::firstDeal(int *pIterIdx, bool bRev)
+CvDeal* CvGame::firstDeal(int *pIterIdx, bool bRev) const
 {
 	return !bRev ? m_deals.beginIter(pIterIdx) : m_deals.endIter(pIterIdx);
 }
 
 
-CvDeal* CvGame::nextDeal(int *pIterIdx, bool bRev)
+CvDeal* CvGame::nextDeal(int *pIterIdx, bool bRev) const
 {
 	return !bRev ? m_deals.nextIter(pIterIdx) : m_deals.prevIter(pIterIdx);
 }
 
 
- CvRandom& CvGame::getMapRand()																					
+CvRandom& CvGame::getMapRand()
 {
 	return m_mapRand;
 }
@@ -10149,7 +10093,7 @@ int CvGame::getMapRandNum(int iNum, const char* pszLog)
 }
 
 
-CvRandom& CvGame::getSorenRand()																					
+CvRandom& CvGame::getSorenRand()
 {
 	return m_sorenRand;
 }
@@ -10371,14 +10315,11 @@ int CvGame::calculateOptionsChecksum()
 {
 	PROFILE_FUNC();
 
-	int iValue;
-	int iI, iJ;
+	int iValue = 0;
 
-	iValue = 0;
-
-	for (iI = 0; iI < MAX_PLAYERS; iI++)
+	for (int iI = 0; iI < MAX_PLAYERS; iI++)
 	{
-		for (iJ = 0; iJ < NUM_PLAYEROPTION_TYPES; iJ++)
+		for (int iJ = 0; iJ < NUM_PLAYEROPTION_TYPES; iJ++)
 		{
 			if (GET_PLAYER((PlayerTypes)iI).isOption((PlayerOptionTypes)iJ))
 			{
@@ -11717,31 +11658,25 @@ void CvGame::changeShrineBuilding(BuildingTypes eBuilding, ReligionTypes eReligi
 		m_aiShrineReligion[m_iShrineBuildingCount] = eReligion;
 		m_iShrineBuildingCount++;
 	}
-	
 }
 
-bool CvGame::culturalVictoryValid()
+bool CvGame::culturalVictoryValid() const
 {
-	if (m_iNumCultureVictoryCities > 0)
-	{
-		return true;
-	}
-
-	return false;
+	return (m_iNumCultureVictoryCities > 0);
 }
 
-int CvGame::culturalVictoryNumCultureCities()
+int CvGame::culturalVictoryNumCultureCities() const
 {
 	return m_iNumCultureVictoryCities;
 }
 
-CultureLevelTypes CvGame::culturalVictoryCultureLevel()
+CultureLevelTypes CvGame::culturalVictoryCultureLevel() const
 {
 	if (m_iNumCultureVictoryCities > 0)
 	{
 		return (CultureLevelTypes) m_eCultureVictoryCultureLevel;
 	}
-	
+
 	return NO_CULTURELEVEL;
 }
 
@@ -12664,21 +12599,21 @@ void CvGame::setWaterAnimalSpawnChance(int iNewValue)
 
 void CvGame::changeWaterAnimalSpawnChance(int iChange)
 {
-	setWaterAnimalSpawnChance(getWaterAnimalSpawnChance() + iChange);
+	m_iWaterAnimalSpawnChance += iChange;
 }
 
 #if defined QC_MASTERY_VICTORY
 
-bool CvGame::getStarshipLaunched(int ID)
+bool CvGame::getStarshipLaunched(int ID) const
 {
-  CvPlayer& kPlayer = GET_PLAYER((PlayerTypes)ID);
+	CvPlayer& kPlayer = GET_PLAYER((PlayerTypes)ID);
   
 	return starshipLaunched[kPlayer.getTeam()];
 }
 
-bool CvGame::getDiplomaticVictoryAchieved(int ID)
+bool CvGame::getDiplomaticVictoryAchieved(int ID) const
 {
-  CvPlayer& kPlayer = GET_PLAYER((PlayerTypes)ID);
+	CvPlayer& kPlayer = GET_PLAYER((PlayerTypes)ID);
 	
 	return diplomaticVictoryAchieved[kPlayer.getTeam()];
 }
@@ -12709,7 +12644,7 @@ void CvGame::setXResolution(int iNewValue)
 
 void CvGame::changeXResolution(int iChange)
 {
-	setXResolution(getXResolution() + iChange);
+	m_iXResolution += iChange;
 }
 
 int CvGame::getYResolution() const
@@ -12724,10 +12659,10 @@ void CvGame::setYResolution(int iNewValue)
 
 void CvGame::changeYResolution(int iChange)
 {
-	setYResolution(getYResolution() + iChange);
+	m_iYResolution += iChange;
 }
 
-int CvGame::getCutLosersCounter()
+int CvGame::getCutLosersCounter() const
 {
 	return m_iCutLosersCounter;
 }
@@ -12737,7 +12672,7 @@ void CvGame::changeCutLosersCounter(int iChange)
 	m_iCutLosersCounter += iChange;
 }
 
-int CvGame::getHighToLowCounter()
+int CvGame::getHighToLowCounter() const
 {
 	return m_iHighToLowCounter;
 }
@@ -12747,7 +12682,7 @@ void CvGame::changeHighToLowCounter(int iChange)
 	m_iHighToLowCounter += iChange;
 }
 
-int CvGame::getIncreasingDifficultyCounter()
+int CvGame::getIncreasingDifficultyCounter() const
 {
 	return m_iIncreasingDifficultyCounter;
 }
@@ -12773,7 +12708,7 @@ void CvGame::doFinalFive()
 				{
 					GET_PLAYER(getRankPlayer(countCivPlayersAlive() -1)).setAlive(false);
 					changeCutLosersCounter(getCutLosersCounter() * -1);
-					 for (iI = 0; iI < MAX_PLAYERS; iI++)
+					for (iI = 0; iI < MAX_PLAYERS; iI++)
 					{
 						if (GET_PLAYER((PlayerTypes)iI).isAlive())
 						{
@@ -13021,7 +12956,8 @@ void CvGame::doFlexibleDifficulty()
 						}
 					}
 				}
-			}		}
+			}
+		}
 	}
 
 	averageHandicaps();
@@ -13048,7 +12984,7 @@ void CvGame::averageHandicaps()
 	}
 }
 
-int CvGame::getMercyRuleCounter()
+int CvGame::getMercyRuleCounter() const
 {
 	return m_iMercyRuleCounter;
 }
@@ -13092,13 +13028,11 @@ void CvGame::clearLandmarks(bool bClear)
 
 void CvGame::pruneLandmarks()
 {
-	CvPlot* pLoopPlot;
-	int iWorldSize;
-	iWorldSize = GC.getMapINLINE().getWorldSize();
+	int iWorldSize = GC.getMapINLINE().getWorldSize();
 	
 	for (int iPlot = 0; iPlot < GC.getMapINLINE().numPlotsINLINE(); iPlot++)
 	{
-		pLoopPlot = GC.getMapINLINE().plotByIndexINLINE(iPlot);
+		CvPlot* pLoopPlot = GC.getMapINLINE().plotByIndexINLINE(iPlot);
 		if (pLoopPlot->getLandmarkType() != NO_LANDMARK)
 		{
 			removeAdjacentLandmarks(pLoopPlot, pLoopPlot, std::max(1, iWorldSize / 2));
@@ -13112,10 +13046,9 @@ void CvGame::removeAdjacentLandmarks(CvPlot* pCenterPlot, CvPlot* pExceptionPlot
 	{
 		return;
 	}
-	CvPlot* pAdjacentPlot;
 	for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 	{
-		pAdjacentPlot = plotDirection(pCenterPlot->getX_INLINE(), pCenterPlot->getY_INLINE(), ((DirectionTypes)iI));
+		CvPlot* pAdjacentPlot = plotDirection(pCenterPlot->getX_INLINE(), pCenterPlot->getY_INLINE(), ((DirectionTypes)iI));
 		if (pAdjacentPlot != NULL && (pExceptionPlot == NULL || pExceptionPlot != pAdjacentPlot))
 		{
 			if (pAdjacentPlot->getLandmarkType() != NO_LANDMARK)
@@ -13466,17 +13399,15 @@ char CvGame::getRandomConsonant()
 }
 CvWString CvGame::generateRandomWord(int iMaxLength)
 {
-	int iLength;
 	CvWString szName;
 	char chNextLetter;
 	
 	bool bBreak = false;
-	int iRand;
 	//4 letter word minimum
-	iLength = std::min(iMaxLength, std::max(4, getSorenRandNum(iMaxLength, "Random Word Length")));
+	int iLength = std::min(iMaxLength, std::max(4, getSorenRandNum(iMaxLength, "Random Word Length")));
 	for (int iI = 0; iI < iLength; iI++)
 	{
-		iRand = getSorenRandNum(1000, "RandomLetter");
+		int iRand = getSorenRandNum(1000, "RandomLetter");
 		if (iRand <= 381 || bBreak)
 		{
 			chNextLetter = getRandomVowel();
@@ -13497,7 +13428,7 @@ CvWString CvGame::generateRandomWord(int iMaxLength)
 	return szName;
 }
 
-bool CvGame::isValidName(CvWString szName)
+bool CvGame::isValidName(CvWString szName) const
 {
 	int iConsonantCount = 0;
 	int iVowelCount = 0;
@@ -13585,9 +13516,8 @@ CvWString CvGame::getRandomName(int iMaxLength)
 
 int CvGame::countDesert(CvPlot* pPlot)
 {
-	int iI;
 	int iDesert = 0;
-	for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 	{
 		CvPlot* pAdjacentPlot = plotDirection(pPlot->getX_INLINE(), pPlot->getY_INLINE(), ((DirectionTypes)iI));
 		if (pAdjacentPlot != NULL)
@@ -13608,11 +13538,10 @@ int CvGame::countDesert(CvPlot* pPlot)
 
 int CvGame::countJungle(CvPlot* pPlot, int iJungle)
 {
-	int iI;
 	//This is a big jungle
 	if (iJungle > GC.getDefineINT("MINIMUM_JUNGLE_SIZE") * 2)
 		return iJungle;
-	for (iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
+	for (int iI = 0; iI < NUM_DIRECTION_TYPES; ++iI)
 	{
 		CvPlot* pAdjacentPlot = plotDirection(pPlot->getX_INLINE(), pPlot->getY_INLINE(), ((DirectionTypes)iI));
 		if (pAdjacentPlot != NULL)
@@ -14615,7 +14544,7 @@ void CvGame::recalculateModifiers()
 	{
 		for (int iPlayer = 0; iPlayer < MAX_PLAYERS; iPlayer++)
 		{
-			if ((PlayerTypes)iPlayer != NO_PLAYER && GET_PLAYER((PlayerTypes)iPlayer).isAlive())
+			if (GET_PLAYER((PlayerTypes)iPlayer).isAlive())
 			{
 				GET_PLAYER((PlayerTypes)iPlayer).processVoteSourceBonus((VoteSourceTypes)iI, true);
 			}
@@ -14781,7 +14710,7 @@ void CvGame::logOOSSpecial(int iLocID, int iVar, int iVar2, int iVar3)
 	}
 }
 
-int CvGame::getTopCityCount()
+int CvGame::getTopCityCount() const
 {
 	int iCount = 0;
 	int iBest = 0;
@@ -14798,7 +14727,7 @@ int CvGame::getTopCityCount()
 	return iBest;
 }
 
-int CvGame::getTopPopCount()
+int CvGame::getTopPopCount() const
 {
 	int iCount = 0;
 	int iBest = 0;

--- a/Sources/CvGame.h
+++ b/Sources/CvGame.h
@@ -123,7 +123,7 @@ public:
 
 	int getSymbolID(int iSymbol);																	// Exposed to Python
 
-	int getProductionPerPopulation(HurryTypes eHurry);											// Exposed to Python
+	int getProductionPerPopulation(HurryTypes eHurry) const;											// Exposed to Python
 
 	int getAdjustedPopulationPercent(VictoryTypes eVictory) const;								// Exposed to Python
 	int getAdjustedLandPercent(VictoryTypes eVictory) const;											// Exposed to Python
@@ -146,14 +146,14 @@ public:
 	int countCivTeamsEverAlive() const;																	// Exposed to Python
 	int countHumanPlayersAlive() const;																	// Exposed to Python
 
-	int countTotalCivPower();																								// Exposed to Python
-	int countTotalNukeUnits();																							// Exposed to Python
-	int countKnownTechNumTeams(TechTypes eTech);														// Exposed to Python
-	int getNumFreeBonuses(BuildingTypes eBuilding);													// Exposed to Python
+	int countTotalCivPower() const;																								// Exposed to Python
+	int countTotalNukeUnits()const;																							// Exposed to Python
+	int countKnownTechNumTeams(TechTypes eTech) const;														// Exposed to Python
+	int getNumFreeBonuses(BuildingTypes eBuilding) const;													// Exposed to Python
 
-	int countReligionLevels(ReligionTypes eReligion);							// Exposed to Python 
+	int countReligionLevels(ReligionTypes eReligion) const;							// Exposed to Python 
 	int calculateReligionPercent(ReligionTypes eReligion) const;				// Exposed to Python
-	int countCorporationLevels(CorporationTypes eCorporation);							// Exposed to Python 
+	int countCorporationLevels(CorporationTypes eCorporation) const;							// Exposed to Python 
 	void replaceCorporation(CorporationTypes eCorporation1, CorporationTypes eCorporation2);
 
 	int goldenAgeLength() const;																					// Exposed to Python
@@ -248,12 +248,12 @@ public:
 	DllExport int getTurnSlicesRemaining();
 	void resetTurnTimer();
 	void incrementTurnTimer(int iNumTurnSlices);
-	int getMaxTurnLen();
+	int getMaxTurnLen() const;
 
 	int getTargetScore() const;																		// Exposed to Python
 	void setTargetScore(int iNewValue);														// Exposed to Python
 
-	int getNumGameTurnActive();																		// Exposed to Python
+	int getNumGameTurnActive() const;																		// Exposed to Python
 	DllExport int countNumHumanGameTurnActive() const;														// Exposed to Python
 	void changeNumGameTurnActive(int iChange);
 
@@ -308,13 +308,13 @@ public:
 /*                                                                                 jdog5000     */
 /*                                                                                              */
 /************************************************************************************************/
-	int getAIAutoPlay(PlayerTypes iPlayer);							// Exposed to Python
+	int getAIAutoPlay(PlayerTypes iPlayer) const;							// Exposed to Python
 		void setAIAutoPlay(PlayerTypes iPlayer, int iNewValue, bool bForced = false);
 	DllExport void setAIAutoPlayExternal(int iNewValue);					// Exposed to Python
 	void changeAIAutoPlay(PlayerTypes iPlayer, int iChange);
 	
-	bool isForcedAIAutoPlay(PlayerTypes iPlayer);																// Exposed to Python
-	int getForcedAIAutoPlay(PlayerTypes iPlayer);																// Exposed to Python
+	bool isForcedAIAutoPlay(PlayerTypes iPlayer) const;																// Exposed to Python
+	int getForcedAIAutoPlay(PlayerTypes iPlayer) const;																// Exposed to Python
 	void setForcedAIAutoPlay(PlayerTypes iPlayer, int iNewValue, bool bForced = false);																// Exposed to Python
 	void changeForcedAIAutoPlay(PlayerTypes iPlayer, int iNewValue);	
 /************************************************************************************************/
@@ -331,8 +331,8 @@ public:
 	void setWaterAnimalSpawnChance(int iNewValue);					// Exposed to Python
 	void changeWaterAnimalSpawnChance(int iChange);					// Exposed to Python
 #if defined QC_MASTERY_VICTORY
-	bool getStarshipLaunched(int ID);
-	bool getDiplomaticVictoryAchieved(int ID);
+	bool getStarshipLaunched(int ID) const;
+	bool getDiplomaticVictoryAchieved(int ID) const;
 #endif
 	int getCurrentVoteID() const;
 	void setCurrentVoteID(int iNewValue);
@@ -345,19 +345,19 @@ public:
 	void setYResolution(int iNewValue);					// Exposed to Python
 	void changeYResolution(int iChange);					// Exposed to Python
 	
-	int getCutLosersCounter();
+	int getCutLosersCounter() const;
 	void changeCutLosersCounter(int iChange);
-	int getHighToLowCounter();
+	int getHighToLowCounter() const;
 	void changeHighToLowCounter(int iChange);
-	int getIncreasingDifficultyCounter();
+	int getIncreasingDifficultyCounter() const;
 	void changeIncreasingDifficultyCounter(int iChange);
 
 	void averageHandicaps();
-	
-	int getMercyRuleCounter();
+
+	int getMercyRuleCounter() const;
 	void changeMercyRuleCounter(int iChange);
 	void setMercyRuleCounter(int iNewVal);
-	
+
 	int countPeaks(CvPlot* pPlot, bool bCountHill = false);
 	void markBayPlots(CvPlot* pPlot);
 	int countForest(CvPlot* pPlot, int iForest);
@@ -367,7 +367,7 @@ public:
 	int countJungle(CvPlot* pPlot, int iJungle);
 	char getRandomVowel();
 	char getRandomConsonant();
-	bool isValidName(CvWString szName);
+	bool isValidName(CvWString szName) const;
 	CvWString generateRandomWord(int iMaxLength);
 	CvWString getRandomName(int iMaxLength);
 	
@@ -418,8 +418,8 @@ public:
 	void toggleAnyoneHasUnitZoneOfControl();
 	//TB OOSSPECIAL
 	void logOOSSpecial(int iLocID, int iVar, int iVar2 = 0, int iVar3 = 0);
-	int getTopCityCount();
-	int getTopPopCount();
+	int getTopCityCount() const;
+	int getTopPopCount() const;
 	int getImprovementCount(ImprovementTypes eIndex) const;
 	void changeImprovementCount(ImprovementTypes eIndex, int iChange);
 protected:
@@ -440,7 +440,7 @@ public:
 /************************************************************************************************/
 /* Afforess	                         END                                                        */
 /************************************************************************************************/	
-	unsigned int getInitialTime();
+	unsigned int getInitialTime() const;
 	DllExport void setInitialTime(unsigned int uiNewValue);
 
 	bool isScoreDirty() const;																							// Exposed to Python
@@ -535,19 +535,19 @@ public:
 	bool isForcedControl(ForceControlTypes eIndex) const;												// Exposed to Python
 	void setForceControl(ForceControlTypes eIndex, bool bEnabled);
 
-	int getUnitCreatedCount(UnitTypes eIndex);																	// Exposed to Python
+	int getUnitCreatedCount(UnitTypes eIndex) const;																	// Exposed to Python
 	void incrementUnitCreatedCount(UnitTypes eIndex);
 
-	int getUnitClassCreatedCount(UnitClassTypes eIndex);												// Exposed to Python
-	bool isUnitClassMaxedOut(UnitClassTypes eIndex, int iExtra = 0);						// Exposed to Python
+	int getUnitClassCreatedCount(UnitClassTypes eIndex) const;												// Exposed to Python
+	bool isUnitClassMaxedOut(UnitClassTypes eIndex, int iExtra = 0) const;						// Exposed to Python
 	void incrementUnitClassCreatedCount(UnitClassTypes eIndex);
 
-	int getBuildingClassCreatedCount(BuildingClassTypes eIndex);								// Exposed to Python
-	bool isBuildingClassMaxedOut(BuildingClassTypes eIndex, int iExtra = 0);		// Exposed to Python
+	int getBuildingClassCreatedCount(BuildingClassTypes eIndex) const;								// Exposed to Python
+	bool isBuildingClassMaxedOut(BuildingClassTypes eIndex, int iExtra = 0) const;		// Exposed to Python
 	void incrementBuildingClassCreatedCount(BuildingClassTypes eIndex);
 
-	int getProjectCreatedCount(ProjectTypes eIndex);														// Exposed to Python
-	bool isProjectMaxedOut(ProjectTypes eIndex, int iExtra = 0);								// Exposed to Python
+	int getProjectCreatedCount(ProjectTypes eIndex) const;														// Exposed to Python
+	bool isProjectMaxedOut(ProjectTypes eIndex, int iExtra = 0) const;								// Exposed to Python
 	void incrementProjectCreatedCount(ProjectTypes eIndex, int iExtra = 1);
 
 	int getForceCivicCount(CivicTypes eIndex) const;														// Exposed to Python
@@ -562,10 +562,10 @@ public:
 	bool isVictoryValid(VictoryTypes eIndex) const;															// Exposed to Python
 	void setVictoryValid(VictoryTypes eIndex, bool bValid);
 
-	bool isSpecialUnitValid(SpecialUnitTypes eIndex);														// Exposed to Python  
+	bool isSpecialUnitValid(SpecialUnitTypes eIndex) const;														// Exposed to Python  
 	void makeSpecialUnitValid(SpecialUnitTypes eIndex);													// Exposed to Python
 
-	bool isSpecialBuildingValid(SpecialBuildingTypes eIndex);										// Exposed to Python
+	bool isSpecialBuildingValid(SpecialBuildingTypes eIndex) const;										// Exposed to Python
 	void makeSpecialBuildingValid(SpecialBuildingTypes eIndex, bool bAnnounce = false);									// Exposed to Python
 
 	//TB Nukefix (Reversal) Comment out the next two lines
@@ -576,8 +576,8 @@ public:
 
 	void setVoteChosen(int iSelection, int iVoteId);
 
-	int getReligionGameTurnFounded(ReligionTypes eIndex);												// Exposed to Python
-	bool isReligionFounded(ReligionTypes eIndex);																// Exposed to Python
+	int getReligionGameTurnFounded(ReligionTypes eIndex) const;												// Exposed to Python
+	bool isReligionFounded(ReligionTypes eIndex) const;																// Exposed to Python
 	void makeReligionFounded(ReligionTypes eIndex, PlayerTypes ePlayer);
 
 	int getTechGameTurnDiscovered(TechTypes eTech) const;												// Exposed to Python
@@ -594,8 +594,8 @@ public:
 /************************************************************************************************/
 	bool isGameStart();											// Exposed to Python
 
-	int countNumReligionsFounded();											// Exposed to Python
-	int countNumReligionTechsDiscovered();											// Exposed to Python
+	int countNumReligionsFounded() const;											// Exposed to Python
+	int countNumReligionTechsDiscovered() const;											// Exposed to Python
 
 	bool isTechCanFoundReligion(TechTypes eIndex) const;											// Exposed to Python
 	void setTechCanFoundReligion(TechTypes eIndex, bool bUsed);
@@ -603,14 +603,14 @@ public:
 /* LIMITED_RELIGIONS               END                                                          */
 /************************************************************************************************/
 
-	CvCity* getHolyCity(ReligionTypes eIndex);																	// Exposed to Python
+	CvCity* getHolyCity(ReligionTypes eIndex) const;																	// Exposed to Python
 	void setHolyCity(ReligionTypes eIndex, CvCity* pNewValue, bool bAnnounce);	// Exposed to Python
 
-	int getCorporationGameTurnFounded(CorporationTypes eIndex);												// Exposed to Python
-	bool isCorporationFounded(CorporationTypes eIndex);																// Exposed to Python
+	int getCorporationGameTurnFounded(CorporationTypes eIndex) const;												// Exposed to Python
+	bool isCorporationFounded(CorporationTypes eIndex) const;																// Exposed to Python
 	void makeCorporationFounded(CorporationTypes eIndex, PlayerTypes ePlayer);
 
-	CvCity* getHeadquarters(CorporationTypes eIndex);																	// Exposed to Python
+	CvCity* getHeadquarters(CorporationTypes eIndex) const;																	// Exposed to Python
 	void setHeadquarters(CorporationTypes eIndex, CvCity* pNewValue, bool bAnnounce);	// Exposed to Python
 
 	PlayerVoteTypes getPlayerVote(PlayerTypes eOwnerIndex, int iVoteId) const;			// Exposed to Python
@@ -631,13 +631,13 @@ public:
 	void addGreatPersonBornName(const CvWString& szName);													
 
 	DllExport int getIndexAfterLastDeal();																								// Exposed to Python	
-	int getNumDeals();																													// Exposed to Python	
+	int getNumDeals() const;																													// Exposed to Python	
 	DllExport CvDeal* getDeal(int iID);																										// Exposed to Python	
 	CvDeal* addDeal();																													
 	void deleteDeal(int iID);																										
 	// iteration																																					
-	CvDeal* firstDeal(int *pIterIdx, bool bRev=false);													// Exposed to Python									
-	CvDeal* nextDeal(int *pIterIdx, bool bRev=false);														// Exposed to Python									
+	CvDeal* firstDeal(int *pIterIdx, bool bRev=false) const;													// Exposed to Python									
+	CvDeal* nextDeal(int *pIterIdx, bool bRev=false) const;														// Exposed to Python									
 
 	VoteSelectionData* getVoteSelection(int iID) const;
 	VoteSelectionData* addVoteSelection(VoteSourceTypes eVoteSource);
@@ -714,9 +714,9 @@ public:
 	BuildingTypes getShrineBuilding(int eIndex, ReligionTypes eReligion = NO_RELIGION);
 	void changeShrineBuilding(BuildingTypes eBuilding, ReligionTypes eReligion, bool bRemove = false);
 
-	bool culturalVictoryValid();
-	int culturalVictoryNumCultureCities();
-	CultureLevelTypes culturalVictoryCultureLevel();
+	bool culturalVictoryValid() const;
+	int culturalVictoryNumCultureCities() const;
+	CultureLevelTypes culturalVictoryCultureLevel() const;
 	int getCultureThreshold(CultureLevelTypes eLevel) const;
 
 	int getPlotExtraYield(int iX, int iY, YieldTypes eYield) const;

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -9395,10 +9395,10 @@ bool CvUnit::setMADTargetPlot(int iX, int iY)
 			MEMORY_TRACK_EXEMPT();
 
 			szBuffer = gDLL->getText("TXT_KEY_NUKE_TARGET_SET_ON", getNameKey(), pCity->getNameKey());
-			AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_NUKE_EXPLODES", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+			AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_NUKE_EXPLODES", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 
 			szBuffer = gDLL->getText("Someone has targetted %s1 with a nuke!", pCity->getNameKey());
-			AddDLLMessage(pCity->getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_NUKE_EXPLODES", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+			AddDLLMessage(pCity->getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_NUKE_EXPLODES", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 		}
 
 		finishMoves();
@@ -10369,9 +10369,9 @@ bool CvUnit::airBomb(int iX, int iY)
 							MEMORY_TRACK_EXEMPT();
 
 							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
-							AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+							AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 							szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
-							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 						}
 					}
 				}
@@ -31020,16 +31020,13 @@ bool CvUnit::canAirBomb1At(const CvPlot* pPlot, int iX, int iY) const
 
 bool CvUnit::airBomb1(int iX, int iY)
 {
-	CvCity* pCity;
-	CvPlot* pPlot;
 	CvWString szBuffer;
-	bool bBitter = true;
 
 	if (!canAirBomb1At(plot(), iX, iY))
 	{
 		return false;
 	}
-	pPlot = GC.getMapINLINE().plotINLINE(iX, iY);
+	CvPlot* pPlot = GC.getMapINLINE().plotINLINE(iX, iY);
 	if (interceptTest(pPlot))
 	{
 		return true;
@@ -31044,104 +31041,101 @@ bool CvUnit::airBomb1(int iX, int iY)
 /************************************************************************************************/
 /* RevolutionDCM	             Battle Effects END                                             */
 /************************************************************************************************/
-	pCity = pPlot->getPlotCity();
-	if (bBitter)
+	CvCity* pCity = pPlot->getPlotCity();
+	if (pCity != NULL)
 	{
-		if (pCity != NULL)
+		pCity->changeDefenseDamage(airBombCurrRate());
+		bool bBarb = pCity->isHominid();
+		//TB Combat Mods begin
+		int iMax = MAX_INT;
+		if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 		{
-			pCity->changeDefenseDamage(airBombCurrRate());
-			bool bBarb = pCity->isHominid();
-			//TB Combat Mods begin
-			int iMax = MAX_INT;
-			if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-			{
-				iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-			}
-			changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
-			//TB Combat Mods end
-
-			MEMORY_TRACK_EXEMPT();
-
-			szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_DEFENSES_REDUCED_TO", pCity->getNameKey(), pCity->getDefenseModifier(false), getNameKey());
-			AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-
-			szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_DEFENSES_REDUCED_TO", getNameKey(), pCity->getNameKey(), pCity->getDefenseModifier(false));
-			AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE());
+			iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
 		}
-		else
+		changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
+		//TB Combat Mods end
+
+		MEMORY_TRACK_EXEMPT();
+
+		szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_DEFENSES_REDUCED_TO", pCity->getNameKey(), pCity->getDefenseModifier(false), getNameKey());
+		AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+
+		szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_DEFENSES_REDUCED_TO", getNameKey(), pCity->getNameKey(), pCity->getDefenseModifier(false));
+		AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE());
+	}
+	else
+	{
+		if (pPlot->getImprovementType() != NO_IMPROVEMENT)
 		{
-			if (pPlot->getImprovementType() != NO_IMPROVEMENT)
+			if (GC.getGameINLINE().getSorenRandNum(airBombCurrRate(), "Air Bomb - Offense") >=
+					GC.getGameINLINE().getSorenRandNum(GC.getImprovementInfo(pPlot->getImprovementType()).getAirBombDefense(), "Air Bomb - Defense"))
 			{
-				if (GC.getGameINLINE().getSorenRandNum(airBombCurrRate(), "Air Bomb - Offense") >=
-						GC.getGameINLINE().getSorenRandNum(GC.getImprovementInfo(pPlot->getImprovementType()).getAirBombDefense(), "Air Bomb - Defense"))
+				{
+					MEMORY_TRACK_EXEMPT();
+
+					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_DESTROYED_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
+				}
+
+				if (pPlot->isOwned())
 				{
 					{
 						MEMORY_TRACK_EXEMPT();
 
-						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_DESTROYED_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
+						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_IMP_WAS_DESTROYED", GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide(), getNameKey(), GET_PLAYER(getOwnerINLINE()).getCivilizationAdjectiveKey());
+						AddDLLMessage(pPlot->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_PILLAGED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
 					}
-
-					if (pPlot->isOwned())
+					bool bBarb = GET_PLAYER(pPlot->getOwnerINLINE()).isHominid();
+					//TB Combat Mods begin
+					int iMax = MAX_INT;
+					if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 					{
-						{
-							MEMORY_TRACK_EXEMPT();
-
-							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_IMP_WAS_DESTROYED", GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide(), getNameKey(), GET_PLAYER(getOwnerINLINE()).getCivilizationAdjectiveKey());
-							AddDLLMessage(pPlot->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_PILLAGED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-						}
-						bool bBarb = GET_PLAYER(pPlot->getOwnerINLINE()).isHominid();
-						//TB Combat Mods begin
-						int iMax = MAX_INT;
-						if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-						{
-							iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-						}
-						changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pPlot->getOwnerINLINE() == getOwnerINLINE());
-						//TB Combat Mods end
+						iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
 					}
+					changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pPlot->getOwnerINLINE() == getOwnerINLINE());
+					//TB Combat Mods end
+				}
 
-					pPlot->setImprovementType((ImprovementTypes)(GC.getImprovementInfo(pPlot->getImprovementType()).getImprovementPillage()));
-					
-					CvUnit* pLoopUnit;
-					CLLNode<IDInfo>* pUnitNode;
-					//Afflict
-					int iDistanceAttackCommunicability = 0;
-					bool bAffliction = false;
-					if (GC.getGameINLINE().isOption(GAMEOPTION_OUTBREAKS_AND_AFFLICTIONS))
-					{
-						for (int iI = 0; iI < GC.getNumPromotionLineInfos(); iI++)
-						{ 
-							if (GC.getPromotionLineInfo((PromotionLineTypes)iI).isAffliction() && !GC.getPromotionLineInfo((PromotionLineTypes)iI).isCritical())
+				pPlot->setImprovementType((ImprovementTypes)(GC.getImprovementInfo(pPlot->getImprovementType()).getImprovementPillage()));
+				
+				CvUnit* pLoopUnit;
+				CLLNode<IDInfo>* pUnitNode;
+				//Afflict
+				int iDistanceAttackCommunicability = 0;
+				bool bAffliction = false;
+				if (GC.getGameINLINE().isOption(GAMEOPTION_OUTBREAKS_AND_AFFLICTIONS))
+				{
+					for (int iI = 0; iI < GC.getNumPromotionLineInfos(); iI++)
+					{ 
+						if (GC.getPromotionLineInfo((PromotionLineTypes)iI).isAffliction() && !GC.getPromotionLineInfo((PromotionLineTypes)iI).isCritical())
+						{
+							//Distance Communicability 
+							iDistanceAttackCommunicability = getDistanceAttackCommunicability((PromotionLineTypes)iI);
+							bool bDistAttComm = iDistanceAttackCommunicability > 0;
+							PromotionLineTypes eAfflictionLine = ((PromotionLineTypes)iI);
+							bool bAffonAtt = (hasAfflictOnAttackType(eAfflictionLine) && isAfflictOnAttackTypeDistance(eAfflictionLine));
+							if (bDistAttComm || bAffonAtt)
 							{
-								//Distance Communicability 
-								iDistanceAttackCommunicability = getDistanceAttackCommunicability((PromotionLineTypes)iI);
-								bool bDistAttComm = iDistanceAttackCommunicability > 0;
-								PromotionLineTypes eAfflictionLine = ((PromotionLineTypes)iI);
-								bool bAffonAtt = (hasAfflictOnAttackType(eAfflictionLine) && isAfflictOnAttackTypeDistance(eAfflictionLine));
-								if (bDistAttComm || bAffonAtt)
+								bAffliction = true;
+								pUnitNode = pPlot->headUnitNode();
+								while (pUnitNode != NULL)
 								{
-									bAffliction = true;
-									pUnitNode = pPlot->headUnitNode();
-									while (pUnitNode != NULL)
+									pLoopUnit = ::getUnit(pUnitNode->m_data);
+									pUnitNode = pPlot->nextUnitNode(pUnitNode);
+									if (bDistAttComm)
 									{
-										pLoopUnit = ::getUnit(pUnitNode->m_data);
-										pUnitNode = pPlot->nextUnitNode(pUnitNode);
-										if (bDistAttComm)
+										if (pLoopUnit->checkContractDisease(eAfflictionLine, iDistanceAttackCommunicability))
 										{
-											if (pLoopUnit->checkContractDisease(eAfflictionLine, iDistanceAttackCommunicability))
-											{
-												pLoopUnit->afflict(eAfflictionLine);
-											}
+											pLoopUnit->afflict(eAfflictionLine);
 										}
-										if (bAffonAtt)
+									}
+									if (bAffonAtt)
+									{
+										int iAttackersPoisonChance = getAfflictOnAttackTypeProbability(eAfflictionLine) - pLoopUnit->fortitudeTotal() - pLoopUnit->getUnitAfflictionTolerance(eAfflictionLine);
+										int iAttackersPoisonRollResult = GC.getGameINLINE().getSorenRandNum(100, "AttackersPoisonRoll");
+										if (iAttackersPoisonRollResult < iAttackersPoisonChance)
 										{
-											int iAttackersPoisonChance = getAfflictOnAttackTypeProbability(eAfflictionLine) - pLoopUnit->fortitudeTotal() - pLoopUnit->getUnitAfflictionTolerance(eAfflictionLine);
-											int iAttackersPoisonRollResult = GC.getGameINLINE().getSorenRandNum(100, "AttackersPoisonRoll");
-											if (iAttackersPoisonRollResult < iAttackersPoisonChance)
-											{
-												pLoopUnit->afflict(eAfflictionLine, true, this);
-											}
+											pLoopUnit->afflict(eAfflictionLine, true, this);
 										}
 									}
 								}
@@ -31149,13 +31143,13 @@ bool CvUnit::airBomb1(int iX, int iY)
 						}
 					}
 				}
-				else
-				{
-					MEMORY_TRACK_EXEMPT();
+			}
+			else
+			{
+				MEMORY_TRACK_EXEMPT();
 
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_FAIL_DESTROY_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMB_FAILS", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
-				}
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_FAIL_DESTROY_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMB_FAILS", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
 			}
 		}
 	}
@@ -31235,7 +31229,6 @@ bool CvUnit::airBomb2(int iX, int iY)
 	CvPlot* pPlot;
 	CvWString szBuffer;
 	int build, iI, iAttempts, iMaxAttempts;
-	bool bBitter = true;
 	bool bNoTarget = true;
 	bool abTech1 = false;
 	bool abTech2 = false;
@@ -31279,114 +31272,111 @@ bool CvUnit::airBomb2(int iX, int iY)
 			}
 		}
 	}
-	if (bBitter)
+	if (pCity != NULL)
 	{
-		if (pCity != NULL)
+		buildingList.clear();
+		for (iI = 0; iI < GC.getNumBuildingInfos(); iI++)
 		{
-			buildingList.clear();
-			for (iI = 0; iI < GC.getNumBuildingInfos(); iI++)
+			if (GC.getBuildingInfo((BuildingTypes)iI).getDCMAirbombMission() == 2)
 			{
-				if (GC.getBuildingInfo((BuildingTypes)iI).getDCMAirbombMission() == 2)
+				buildingList.insertAtEnd(iI);
+			}
+		}
+		if (buildingList.getLength() > 0)
+		{
+			iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
+			build = buildingList.nodeNum(iI)->m_data;
+			if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
+			{
+				bNoTarget = false;
+			}
+			if (abTech1)
+			{
+				iAttempts = 0;
+				if (abTech2)
 				{
-					buildingList.insertAtEnd(iI);
+					iMaxAttempts = 8;
+				}
+				else
+				{
+					iMaxAttempts = 4;
+				}
+				while (bNoTarget)
+				{
+					iAttempts++;
+					iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
+					build = buildingList.nodeNum(iI)->m_data;
+					if (pCity->getNumRealBuilding((BuildingTypes)build) > 0 || iAttempts > iMaxAttempts)
+					{
+						bNoTarget = false;
+					}
 				}
 			}
-			if (buildingList.getLength() > 0)
+			if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
 			{
-				iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
-				build = buildingList.nodeNum(iI)->m_data;
-				if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
+				bNoTarget = false;
+				bool bBarb = pCity->isHominid();
+				//TB Combat Mod begin
+				int iMax = MAX_INT;
+				if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 				{
-					bNoTarget = false;
+					iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
 				}
-				if (abTech1)
+				changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
+				//TB Combat Mod end
+				pCity->setNumRealBuilding((BuildingTypes)build, 0);
+
 				{
-					iAttempts = 0;
-					if (abTech2)
-					{
-						iMaxAttempts = 8;
-					}
-					else
-					{
-						iMaxAttempts = 4;
-					}
-					while (bNoTarget)
-					{
-						iAttempts++;
-						iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
-						build = buildingList.nodeNum(iI)->m_data;
-						if (pCity->getNumRealBuilding((BuildingTypes)build) > 0 || iAttempts > iMaxAttempts)
+					MEMORY_TRACK_EXEMPT();
+
+					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB2SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
+					AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB2SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+				}
+
+				CvUnit* pLoopUnit;
+				CLLNode<IDInfo>* pUnitNode;
+				//Afflict
+				int iDistanceAttackCommunicability = 0;
+				bool bAffliction = false;
+				if (GC.getGameINLINE().isOption(GAMEOPTION_OUTBREAKS_AND_AFFLICTIONS))
+				{
+					for (int iI = 0; iI < GC.getNumPromotionLineInfos(); iI++)
+					{ 
+						if (GC.getPromotionLineInfo((PromotionLineTypes)iI).isAffliction() && !GC.getPromotionLineInfo((PromotionLineTypes)iI).isCritical())
 						{
-							bNoTarget = false;
-						}
-					}
-				}
-				if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
-				{
-					bNoTarget = false;
-					bool bBarb = pCity->isHominid();
-					//TB Combat Mod begin
-					int iMax = MAX_INT;
-					if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-					{
-						iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-					}
-					changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
-					//TB Combat Mod end
-					pCity->setNumRealBuilding((BuildingTypes)build, 0);
-
-					{
-						MEMORY_TRACK_EXEMPT();
-
-						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB2SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
-						AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB2SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-					}
-
-					CvUnit* pLoopUnit;
-					CLLNode<IDInfo>* pUnitNode;
-					//Afflict
-					int iDistanceAttackCommunicability = 0;
-					bool bAffliction = false;
-					if (GC.getGameINLINE().isOption(GAMEOPTION_OUTBREAKS_AND_AFFLICTIONS))
-					{
-						for (int iI = 0; iI < GC.getNumPromotionLineInfos(); iI++)
-						{ 
-							if (GC.getPromotionLineInfo((PromotionLineTypes)iI).isAffliction() && !GC.getPromotionLineInfo((PromotionLineTypes)iI).isCritical())
+							//Distance Communicability 
+							iDistanceAttackCommunicability = getDistanceAttackCommunicability((PromotionLineTypes)iI);
+							bool bDistAttComm = iDistanceAttackCommunicability > 0;
+							PromotionLineTypes eAfflictionLine = ((PromotionLineTypes)iI);
+							bool bAffonAtt = (hasAfflictOnAttackType(eAfflictionLine) && isAfflictOnAttackTypeDistance(eAfflictionLine));
+							if (bDistAttComm || bAffonAtt)
 							{
-								//Distance Communicability 
-								iDistanceAttackCommunicability = getDistanceAttackCommunicability((PromotionLineTypes)iI);
-								bool bDistAttComm = iDistanceAttackCommunicability > 0;
-								PromotionLineTypes eAfflictionLine = ((PromotionLineTypes)iI);
-								bool bAffonAtt = (hasAfflictOnAttackType(eAfflictionLine) && isAfflictOnAttackTypeDistance(eAfflictionLine));
-								if (bDistAttComm || bAffonAtt)
+								bAffliction = true;
+								pUnitNode = pPlot->headUnitNode();
+								while (pUnitNode != NULL)
 								{
-									bAffliction = true;
-									pUnitNode = pPlot->headUnitNode();
-									while (pUnitNode != NULL)
+									pLoopUnit = ::getUnit(pUnitNode->m_data);
+									pUnitNode = pPlot->nextUnitNode(pUnitNode);
+									if (bDistAttComm)
 									{
-										pLoopUnit = ::getUnit(pUnitNode->m_data);
-										pUnitNode = pPlot->nextUnitNode(pUnitNode);
-										if (bDistAttComm)
+										if (pLoopUnit->checkContractDisease(eAfflictionLine, iDistanceAttackCommunicability))
 										{
-											if (pLoopUnit->checkContractDisease(eAfflictionLine, iDistanceAttackCommunicability))
-											{
-												pLoopUnit->afflict(eAfflictionLine);
-											}
-											if (pCity != NULL)
-											{
-												pCity->changePromotionLineAfflictionAttackCommunicability(eAfflictionLine, iDistanceAttackCommunicability);
-											}
+											pLoopUnit->afflict(eAfflictionLine);
 										}
-										if (bAffonAtt)
+										if (pCity != NULL)
 										{
-											int iAttackersPoisonChance = getAfflictOnAttackTypeProbability(eAfflictionLine) - pLoopUnit->fortitudeTotal() - pLoopUnit->getUnitAfflictionTolerance(eAfflictionLine);
-											int iAttackersPoisonRollResult = GC.getGameINLINE().getSorenRandNum(100, "AttackersPoisonRoll");
-											if (iAttackersPoisonRollResult < iAttackersPoisonChance)
-											{
-												pLoopUnit->afflict(eAfflictionLine, true, this);
-											}
+											pCity->changePromotionLineAfflictionAttackCommunicability(eAfflictionLine, iDistanceAttackCommunicability);
+										}
+									}
+									if (bAffonAtt)
+									{
+										int iAttackersPoisonChance = getAfflictOnAttackTypeProbability(eAfflictionLine) - pLoopUnit->fortitudeTotal() - pLoopUnit->getUnitAfflictionTolerance(eAfflictionLine);
+										int iAttackersPoisonRollResult = GC.getGameINLINE().getSorenRandNum(100, "AttackersPoisonRoll");
+										if (iAttackersPoisonRollResult < iAttackersPoisonChance)
+										{
+											pLoopUnit->afflict(eAfflictionLine, true, this);
 										}
 									}
 								}
@@ -31394,32 +31384,32 @@ bool CvUnit::airBomb2(int iX, int iY)
 						}
 					}
 				}
-				else
-				{
-					MEMORY_TRACK_EXEMPT();
-
-					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB2FAIL", pCity->getNameKey());
-					AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB2FAIL", pCity->getNameKey());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-				}
 			}
-			if(bNoTarget)
+			else
 			{
-				if(pCity->getPopulation() > 1)
+				MEMORY_TRACK_EXEMPT();
+
+				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB2FAIL", pCity->getNameKey());
+				AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB2FAIL", pCity->getNameKey());
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+			}
+		}
+		if(bNoTarget)
+		{
+			if(pCity->getPopulation() > 1)
+			{
+				if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 2)
 				{
-					if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 2)
+					pCity->changePopulation(-1);
+
 					{
-						pCity->changePopulation(-1);
+						MEMORY_TRACK_EXEMPT();
 
-						{
-							MEMORY_TRACK_EXEMPT();
-
-							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
-							AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-							szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
-							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-						}
+						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
+						AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 					}
 				}
 			}
@@ -31500,7 +31490,6 @@ bool CvUnit::airBomb3(int iX, int iY)
 	CvWString szBuffer;
 	int build, iI, iAttempts, iMaxAttempts;
 	bool bNoTarget = true;
-	bool bBitter = true;
 	bool abTech1 = false;
 	bool abTech2 = false;
 	CLinkList<int> buildingList;
@@ -31544,99 +31533,96 @@ bool CvUnit::airBomb3(int iX, int iY)
 			}
 		}
 	}
-	if (bBitter)
+	if (pCity != NULL)
 	{
-		if (pCity != NULL)
+		buildingList.clear();
+		for (iI = 0; iI < GC.getNumBuildingInfos(); iI++)
 		{
-			buildingList.clear();
-			for (iI = 0; iI < GC.getNumBuildingInfos(); iI++)
+			if (GC.getBuildingInfo((BuildingTypes)iI).getDCMAirbombMission() == 3)
 			{
-				if (GC.getBuildingInfo((BuildingTypes)iI).getDCMAirbombMission() == 3)
+				buildingList.insertAtEnd(iI);
+			}
+		}
+		if (buildingList.getLength() > 0)
+		{
+			iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
+			build = buildingList.nodeNum(iI)->m_data;
+			if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
+			{
+				bNoTarget = false;
+			}
+			if (abTech1)
+			{
+				iAttempts = 0;
+				if (abTech2)
 				{
-					buildingList.insertAtEnd(iI);
+					iMaxAttempts = 8;
+				}
+				else
+				{
+					iMaxAttempts = 4;
+				}
+				while (bNoTarget)
+				{
+					iAttempts++;
+					iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
+					build = buildingList.nodeNum(iI)->m_data;
+					if (pCity->getNumRealBuilding((BuildingTypes)build) > 0 || iAttempts > iMaxAttempts)
+					{
+						bNoTarget = false;
+					}
 				}
 			}
-			if (buildingList.getLength() > 0)
+			if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
 			{
-				iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
-				build = buildingList.nodeNum(iI)->m_data;
-				if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
+				pCity->setNumRealBuilding((BuildingTypes)build, 0);
+				bool bBarb = pCity->isHominid();
+				//TB Combat Mods begin
+				int iMax = MAX_INT;
+				if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 				{
-					bNoTarget = false;
+					iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
 				}
-				if (abTech1)
+				changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
+				//TB Combat Mods end
+
 				{
-					iAttempts = 0;
-					if (abTech2)
-					{
-						iMaxAttempts = 8;
-					}
-					else
-					{
-						iMaxAttempts = 4;
-					}
-					while (bNoTarget)
-					{
-						iAttempts++;
-						iI = GC.getGameINLINE().getSorenRandNum(buildingList.getLength(), "Airbomb building");
-						build = buildingList.nodeNum(iI)->m_data;
-						if (pCity->getNumRealBuilding((BuildingTypes)build) > 0 || iAttempts > iMaxAttempts)
-						{
-							bNoTarget = false;
-						}
-					}
+					MEMORY_TRACK_EXEMPT();
+
+					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB3SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
+					AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB3SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 				}
-				if (pCity->getNumRealBuilding((BuildingTypes)build) > 0)
+				bSuccess = true;
+			}
+			else
+			{
+				MEMORY_TRACK_EXEMPT();
+
+				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB3FAIL", pCity->getNameKey());
+				AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB3FAIL", pCity->getNameKey());
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+			}
+		}
+		if(bNoTarget)
+		{
+			if(pCity->getPopulation() > 1)
+			{
+				if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
 				{
-					pCity->setNumRealBuilding((BuildingTypes)build, 0);
-					bool bBarb = pCity->isHominid();
-					//TB Combat Mods begin
-					int iMax = MAX_INT;
-					if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-					{
-						iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-					}
-					changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
-					//TB Combat Mods end
+					pCity->changePopulation(-1);
 
 					{
 						MEMORY_TRACK_EXEMPT();
 
-						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB3SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
-						AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB3SUCCESS", GC.getBuildingInfo((BuildingTypes)build).getTextKeyWide(), pCity->getNameKey());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
+						AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 					}
 					bSuccess = true;
-				}
-				else
-				{
-					MEMORY_TRACK_EXEMPT();
-
-					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB3FAIL", pCity->getNameKey());
-					AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB3FAIL", pCity->getNameKey());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-				}
-			}
-			if(bNoTarget)
-			{
-				if(pCity->getPopulation() > 1)
-				{
-					if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
-					{
-						pCity->changePopulation(-1);
-
-						{
-							MEMORY_TRACK_EXEMPT();
-
-							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
-							AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-							szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
-							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-						}
-						bSuccess = true;
-					}
 				}
 			}
 		}
@@ -31812,7 +31798,6 @@ bool CvUnit::airBomb4(int iX, int iY)
 	bool bSuccess = false;
 	int iDamage, iCount;
 	int iUnitDamage;
-	bool bBitter = true;
 	bool bNoTarget = true;
 
 	if (!canAirBomb4At(plot(), iX, iY))
@@ -31859,86 +31844,83 @@ bool CvUnit::airBomb4(int iX, int iY)
 			pUnit = pLoopUnit;
 		}
 	}
-	if (bBitter)
-	{
 //		if (pCity != NULL)
+	{
+		if (pUnit != NULL)
 		{
-			if (pUnit != NULL)
+			bNoTarget = false;
+			if (pCity != NULL)
 			{
-				bNoTarget = false;
-				if (pCity != NULL)
+				bool bBarb = pCity->isHominid();
+				//TB Combat Mods begin
+				int iMax = MAX_INT;
+				if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 				{
-					bool bBarb = pCity->isHominid();
-					//TB Combat Mods begin
-					int iMax = MAX_INT;
-					if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-					{
-						iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-					}
-					changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
-					//TB Combat Mods end
+					iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
 				}
-				iDamage = (airCombatDamage(pUnit) * 2);
-				iUnitDamage = std::max(pUnit->getDamage(), std::min((pUnit->getDamage() + iDamage), airCombatLimit(pUnit)));
+				changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
+				//TB Combat Mods end
+			}
+			iDamage = (airCombatDamage(pUnit) * 2);
+			iUnitDamage = std::max(pUnit->getDamage(), std::min((pUnit->getDamage() + iDamage), airCombatLimit(pUnit)));
+
+			{
+				MEMORY_TRACK_EXEMPT();
+
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_ARE_ATTACKED_BY_AIR", pUnit->getNameKey(), getNameKey(), -(((iUnitDamage - pUnit->getDamage()) * 100) / pUnit->maxHitPoints()));
+				AddDLLMessage(pUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_AIR_ATTACK", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_ATTACK_BY_AIR", getNameKey(), pUnit->getNameKey(), -(((iUnitDamage - pUnit->getDamage()) * 100) / pUnit->maxHitPoints()));
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_AIR_ATTACKED", MESSAGE_TYPE_INFO, pUnit->getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+			}
+			bSuccess = true;
+			pUnit->setDamage(iUnitDamage, getOwnerINLINE());
+			//TB Combat Mod begin
+			if (dealsColdDamage())
+			{
+				pUnit->setColdDamage(iUnitDamage);
+			}
+			//TB Combat mod end
+			if (GC.getGameINLINE().getSorenRandNum(100, "Spin the dice") < 50)
+			{
+				pUnit->setDamage(pUnit->maxHitPoints());
 
 				{
 					MEMORY_TRACK_EXEMPT();
 
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_ARE_ATTACKED_BY_AIR", pUnit->getNameKey(), getNameKey(), -(((iUnitDamage - pUnit->getDamage()) * 100) / pUnit->maxHitPoints()));
-					AddDLLMessage(pUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_AIR_ATTACK", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_ATTACK_BY_AIR", getNameKey(), pUnit->getNameKey(), -(((iUnitDamage - pUnit->getDamage()) * 100) / pUnit->maxHitPoints()));
-					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_AIR_ATTACKED", MESSAGE_TYPE_INFO, pUnit->getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-				}
-				bSuccess = true;
-				pUnit->setDamage(iUnitDamage, getOwnerINLINE());
-				//TB Combat Mod begin
-				if (dealsColdDamage())
-				{
-					pUnit->setColdDamage(iUnitDamage);
-				}
-				//TB Combat mod end
-				if (GC.getGameINLINE().getSorenRandNum(100, "Spin the dice") < 50)
-				{
-					pUnit->setDamage(pUnit->maxHitPoints());
-
-					{
-						MEMORY_TRACK_EXEMPT();
-
-						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMYSINK_AIRBOMB4SUCCESS", pUnit->getNameKey());
-						AddDLLMessage(pUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-						szBuffer = gDLL->getText("TXT_KEY_MISC_YOUSINK_AIRBOMB4SUCCESS", pUnit->getNameKey());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-					}
+					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMYSINK_AIRBOMB4SUCCESS", pUnit->getNameKey());
+					AddDLLMessage(pUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+					szBuffer = gDLL->getText("TXT_KEY_MISC_YOUSINK_AIRBOMB4SUCCESS", pUnit->getNameKey());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
 				}
 			}
-			else
-			{
-				MEMORY_TRACK_EXEMPT();
+		}
+		else
+		{
+			MEMORY_TRACK_EXEMPT();
 
-				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB4FAIL", pCity->getNameKey());
-				AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB4FAIL", pCity->getNameKey());
-				AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-			}
-			if(bNoTarget)
+			szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB4FAIL", pCity->getNameKey());
+			AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+			szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB4FAIL", pCity->getNameKey());
+			AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+		}
+		if(bNoTarget)
+		{
+			if (pCity != NULL)
 			{
-				if (pCity != NULL)
+				if(pCity->getPopulation() > 1)
 				{
-					if(pCity->getPopulation() > 1)
+					if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
 					{
-						if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
+						pCity->changePopulation(-1);
+						bSuccess = true;
+
 						{
-							pCity->changePopulation(-1);
-							bSuccess = true;
+							MEMORY_TRACK_EXEMPT();
 
-							{
-								MEMORY_TRACK_EXEMPT();
-
-								szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
-								AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-								szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
-								AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
-							}
+							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
+							AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+							szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
+							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
 						}
 					}
 				}
@@ -32071,7 +32053,6 @@ bool CvUnit::airBomb5(int iX, int iY)
 	CvPlot* pPlot;
 	CvWString szBuffer;
 	bool bNoTarget = true;
-	bool bBitter = true;
 	bool bSuccess = false;
 
 	if (!canAirBomb5At(plot(), iX, iY))
@@ -32095,60 +32076,57 @@ bool CvUnit::airBomb5(int iX, int iY)
 /************************************************************************************************/
 	pCity = pPlot->getPlotCity();
 
-	if (bBitter)
+	if (pCity != NULL)
 	{
-		if (pCity != NULL)
+		if (GC.getGameINLINE().getSorenRandNum(100, "Airbomb") < 50)
 		{
-			if (GC.getGameINLINE().getSorenRandNum(100, "Airbomb") < 50)
-			{
-				bNoTarget = false;
-				pCity->setProduction(pCity->getProduction() / 2);
-				bSuccess = true;
+			bNoTarget = false;
+			pCity->setProduction(pCity->getProduction() / 2);
+			bSuccess = true;
 
-				{
-					MEMORY_TRACK_EXEMPT();
-
-					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB5SUCCESS", pCity->getNameKey());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB5SUCCESS", pCity->getNameKey());
-					AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-				}
-				bool bBarb = pCity->isHominid();
-				//TB Combat Mods begin
-				int iMax = MAX_INT;
-				if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
-				{
-					iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
-				}
-				changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
-				//TB Combat Mods end
-			}
-			else
 			{
 				MEMORY_TRACK_EXEMPT();
 
-				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB5FAIL", pCity->getNameKey());
-				AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB5FAIL", pCity->getNameKey());
-				AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB5SUCCESS", pCity->getNameKey());
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB5SUCCESS", pCity->getNameKey());
+				AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 			}
-			if(bNoTarget)
+			bool bBarb = pCity->isHominid();
+			//TB Combat Mods begin
+			int iMax = MAX_INT;
+			if (!GC.getGameINLINE().isOption(GAMEOPTION_INFINITE_XP))
 			{
-				if(pCity->getPopulation() > 1)
+				iMax += (GC.getDefineINT("BARBARIAN_MAX_XP_VALUE"));
+			}
+			changeExperience(GC.getDefineINT("MIN_EXPERIENCE_PER_COMBAT"), bBarb ? iMax : -1, !bBarb, pCity->getOwnerINLINE() == getOwnerINLINE());
+			//TB Combat Mods end
+		}
+		else
+		{
+			MEMORY_TRACK_EXEMPT();
+
+			szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB5FAIL", pCity->getNameKey());
+			AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+			szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB5FAIL", pCity->getNameKey());
+			AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+		}
+		if(bNoTarget)
+		{
+			if(pCity->getPopulation() > 1)
+			{
+				if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
 				{
-					if(GC.getGameINLINE().getSorenRandNum(5, "Airbomb population") < 1)
+					pCity->changePopulation(-1);
+					bSuccess = true;
+
 					{
-						pCity->changePopulation(-1);
-						bSuccess = true;
+						MEMORY_TRACK_EXEMPT();
 
-						{
-							MEMORY_TRACK_EXEMPT();
-
-							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
-							AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-							szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
-							AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
-						}
+						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_AIRBOMB_POP");
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
+						szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_AIRBOMB_POP");
+						AddDLLMessage(pCity->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCity->getX_INLINE(), pCity->getY_INLINE(), true, true);
 					}
 				}
 			}
@@ -32439,9 +32417,9 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 						MEMORY_TRACK_EXEMPT();
 
 						szBuffer = gDLL->getText("TXT_KEY_HAS_RANGED_BOMBARD_ATTACKED", getNameKey());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
 						szBuffer = gDLL->getText("TXT_KEY_HAS_BEEN_RANGED_BOMBARD_ATTACKED", getNameKey());
-						AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
+						AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
 					}
 					rBombardCombat(pPlot, pLoopUnit);
 					changeExperience100(100, maxXPValue(), true, pLoopUnit->getOwnerINLINE() == getOwnerINLINE(), false/*this was too corruptable with SM - split to bombatd and get tons of GG pts(!pPlot->isHominid() || GC.getGameINLINE().isOption(GAMEOPTION_BARBARIAN_GENERALS))*/);
@@ -32451,9 +32429,9 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 					MEMORY_TRACK_EXEMPT();
 
 					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_BOMB_MISSED", getNameKey());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE());
 					szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_BOMB_MISSED", getNameKey());
-					AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE(), true, true);
+					AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE(), true, true);
 				}
 			}
 /************************************************************************************************/
@@ -32490,9 +32468,9 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 					MEMORY_TRACK_EXEMPT();
 
 					szBuffer = gDLL->getText("TXT_KEY_HAS_RANGED_BOMBARD_ATTACKED", getNameKey());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
 					szBuffer = gDLL->getText("TXT_KEY_HAS_BEEN_RANGED_BOMBARD_ATTACKED", getNameKey());
-					AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
+					AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
 				}
 				rBombardCombat(pPlot, pLoopUnit);
 				changeExperience100(100, maxXPValue(), true, pLoopUnit->getOwnerINLINE() == getOwnerINLINE(), false/*this was too corruptable with SM - split to bombatd and get tons of GG pts(!pPlot->isHominid() || GC.getGameINLINE().isOption(GAMEOPTION_BARBARIAN_GENERALS))*/);
@@ -32502,9 +32480,9 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 				MEMORY_TRACK_EXEMPT();
 
 				szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_BOMB_MISSED", getNameKey());
-				AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE());
+				AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE());
 				szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_BOMB_MISSED", getNameKey());
-				AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE(), true, true);
+				AddDLLMessage(pLoopUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE(), true, true);
 			}
 /************************************************************************************************/
 /* RevolutionDCM	                  Start		 05/31/10                        Afforess       */
@@ -32527,11 +32505,11 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 						MEMORY_TRACK_EXEMPT();
 
 						szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_DESTROYED_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
 						if (pPlot->isOwned())
 						{
 							szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_IMP_WAS_DESTROYED", GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide(), getNameKey(), GET_PLAYER(getOwnerINLINE()).getCivilizationAdjectiveKey());
-							AddDLLMessage(pPlot->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
+							AddDLLMessage(pPlot->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_PILLAGE", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE(), true, true);
 						}
 					}
 					pPlot->setImprovementType((ImprovementTypes)(GC.getImprovementInfo(pPlot->getImprovementType()).getImprovementPillage()));
@@ -32542,7 +32520,7 @@ bool CvUnit::bombardRanged(int iX, int iY, bool sAttack)
 					MEMORY_TRACK_EXEMPT();
 
 					szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_UNIT_FAIL_DESTROY_IMP", getNameKey(), GC.getImprovementInfo(pPlot->getImprovementType()).getTextKeyWide());
-					AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMB_FAILS", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
+					AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMB_FAILS", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pPlot->getX_INLINE(), pPlot->getY_INLINE());
 				}
 			}
 /************************************************************************************************/
@@ -32958,10 +32936,10 @@ bool CvUnit::archerBombard(int iX, int iY, bool supportAttack)
 		MEMORY_TRACK_EXEMPT();
 
 		szBuffer = gDLL->getText("TXT_KEY_MISC_YOU_BOMB_MISSED", getNameKey());
-		AddDLLMessage(getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
+		AddDLLMessage(getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARDED", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), getX_INLINE(), getY_INLINE(), true, true);
 		szBuffer = gDLL->getText("TXT_KEY_MISC_ENEMY_BOMB_MISSED", getNameKey());
 		// RevolutionDCM - Archer Bombard fix - text display
-		AddDLLMessage(pLoopUnit->getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
+		AddDLLMessage(pLoopUnit->getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_BOMBARD", MESSAGE_TYPE_INFO, NULL, (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), getX_INLINE(), getY_INLINE());
 	}
 	if (bTarget)
 	{
@@ -33379,8 +33357,8 @@ float CvUnit::doVictoryInfluence(CvUnit* pLoserUnit, bool bAttacking, bool bWith
 
 						CvWString szBuffer;
 						szBuffer.Format(L"City militia has emerged! Resistance: %.1f%%", fResistence);	
-						AddDLLMessage(pLoserUnit->getOwnerINLINE(), false, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pLoserPlot->getX_INLINE(), pLoserPlot->getY_INLINE(), true, true);
-						AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pLoserPlot->getX_INLINE(), pLoserPlot->getY_INLINE());
+						AddDLLMessage(pLoserUnit->getOwnerINLINE(), false, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_GREEN"), pLoserPlot->getX_INLINE(), pLoserPlot->getY_INLINE(), true, true);
+						AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pLoserPlot->getX_INLINE(), pLoserPlot->getY_INLINE());
 					}
 				}
 			}
@@ -33463,7 +33441,7 @@ void CvUnit::influencePlots(CvPlot* pCentralPlot, PlayerTypes eTargetPlayer, flo
 
 //	CvWString szBuffer;
 //	szBuffer.Format(L"Factors: %.1f, %.1f, %.1f, %.1f, %.1f, %.1f, %.3f, %d", fBaseCombatInfluence, fLocationMultiplier, fGameSpeedMultiplier, fPlotDistanceFactor, fExperienceMultiplier, fWarlordMultiplier, fBaseMultiplier, iInfluenceRadius);	
-//	AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCentralPlot->getX_INLINE(), pCentralPlot->getY_INLINE());
+//	AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), pCentralPlot->getX_INLINE(), pCentralPlot->getY_INLINE());
 
 	for (int iDX = -iInfluenceRadius; iDX <= iInfluenceRadius; iDX++)
 	{
@@ -33626,7 +33604,7 @@ float CvUnit::doPillageInfluence()
  
 //	CvWString szBuffer;
 //	szBuffer.Format(L"Factors: %.1f, %.1f, %d, Result: %.3f, ", fGameSpeedMultiplier, fBasePillageInfluence, iTargetCulture, fInfluenceRatio);	
-//	AddDLLMessage(getOwnerINLINE(), true, GC.getDefineINT("EVENT_MESSAGE_TIME"), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), plot()->getX_INLINE(), plot()->getY_INLINE());
+//	AddDLLMessage(getOwnerINLINE(), true, GC.getEVENT_MESSAGE_TIME(), szBuffer, "AS2D_UNIT_BUILD_UNIT", MESSAGE_TYPE_INFO, getButton(), (ColorTypes)GC.getInfoTypeForString("COLOR_RED"), plot()->getX_INLINE(), plot()->getY_INLINE());
 
 	return fInfluenceRatio;
 }


### PR DESCRIPTION
CvGame: Added const to methods.
CvGame: Moved function variable declarations. (let me know if that's too annoying)
CvGame: Reduced a loop's size from MAX_PLAYERS (51) to MAX_PC_PLAYERS (40) and removed if(!isNPC()).
CvGame: Removed if(iter != NO_PLAYER) from a loop that starts with 0.
CvUnit: Changed GC.getDefineINT("EVENT_MESSAGE_TIME") calls to GC.getEVENT_MESSAGE_TIME()
CvUnit: Removed a pointless function variable named bBitter from about 5 DCM airBomb methods.

- I don't think bBitter is an upcoming TB thing, but I can change this pull request if I'm wrong.