### PR TITLE
Added back the assert for getInfoTypeForString calls that come from python

### DIFF
--- a/Sources/CyGlobalContext.cpp
+++ b/Sources/CyGlobalContext.cpp
@@ -462,7 +462,7 @@ CvPropertyInfo* CyGlobalContext::getPropertyInfo(int i) const
 
 int CyGlobalContext::getInfoTypeForString(const char* szInfoType) const
 {
-	return GC.getInfoTypeForString(szInfoType, true);
+	return GC.getInfoTypeForString(szInfoType);
 }
 /************************************************************************************************/
 /* Afforess	                  Start		 03/18/10                                               */


### PR DESCRIPTION
Id like to go a step further and get rid of the ability to hide asserts for getInfoTypeForString altogether.
It doesn't make sense to have references to xml types that don't exist.