### PR TITLE
irishhombre mod mod.

### DIFF
--- a/Assets/XML/Units/Subdue_Animals_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/Subdue_Animals_CIV4UnitInfos.xml
@@ -2285,6 +2285,8 @@
 				<BuildingType>BUILDING_MASTER_HUNTER</BuildingType>
 				<BuildingType>BUILDING_LION_MYTH</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_CAT_MYTH</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAVE_LION_MYTH</BuildingType>
 				<BuildingType>BUILDING_CAVE_LION_STORY</BuildingType>
 				<BuildingType>BUILDING_CAVE_LION_STORIES</BuildingType>
@@ -10156,6 +10158,8 @@
 				<BuildingType>BUILDING_MARSUPIAL_CAGE</BuildingType>
 				<BuildingType>BUILDING_MARSUPIAL_MYTH</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_MYTH</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORIES</BuildingType>
 				<BuildingType>BUILDING_BOXING_KANGAROO</BuildingType>
 				<BuildingType>BUILDING_ROO_HERD</BuildingType>
 				<BuildingType>BUILDING_KANGAROO_CAMP</BuildingType>

--- a/Assets/XML/Units/zDepend_Entertainer_Animals_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/zDepend_Entertainer_Animals_CIV4UnitInfos.xml
@@ -4,179 +4,389 @@
 		<UnitInfo>
 			<Type>UNIT_BARD</Type>
 			<Buildings>
+				<BuildingType>BUILDING_AARDVARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_AARDVARK_STORY</BuildingType>
+				<BuildingType>BUILDING_AFRICANELEPHANT_STORIES</BuildingType>
 				<BuildingType>BUILDING_AFRICANELEPHANT_STORY</BuildingType>
+				<BuildingType>BUILDING_AFRICANGREY_STORIES</BuildingType>
 				<BuildingType>BUILDING_AFRICANGREY_STORY</BuildingType>
+				<BuildingType>BUILDING_AFRICAN_PENGUIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_AFRICAN_PENGUIN_STORY</BuildingType>
+				<BuildingType>BUILDING_ANTEATER_STORIES</BuildingType>
 				<BuildingType>BUILDING_ANTEATER_STORY</BuildingType>
+				<BuildingType>BUILDING_ARCTICFOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_ARCTICFOX_STORY</BuildingType>
+				<BuildingType>BUILDING_ARMADILLO_STORIES</BuildingType>
 				<BuildingType>BUILDING_ARMADILLO_STORY</BuildingType>
+				<BuildingType>BUILDING_ASIANBEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_ASIANBEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_ASIANELEPHANT_STORIES</BuildingType>
 				<BuildingType>BUILDING_ASIANELEPHANT_STORY</BuildingType>
+				<BuildingType>BUILDING_BABIRUSA_STORIES</BuildingType>
 				<BuildingType>BUILDING_BABIRUSA_STORY</BuildingType>
+				<BuildingType>BUILDING_BADGER_STORIES</BuildingType>
 				<BuildingType>BUILDING_BADGER_STORY</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BAIRDS_TAPIR_STORY</BuildingType>
+				<BuildingType>BUILDING_BALLPYTHON_STORIES</BuildingType>
 				<BuildingType>BUILDING_BALLPYTHON_STORY</BuildingType>
+				<BuildingType>BUILDING_BARBARYAPE_STORIES</BuildingType>
 				<BuildingType>BUILDING_BARBARYAPE_STORY</BuildingType>
+				<BuildingType>BUILDING_BARNOWL_STORIES</BuildingType>
 				<BuildingType>BUILDING_BARNOWL_STORY</BuildingType>
+				<BuildingType>BUILDING_BARREDOWL_STORIES</BuildingType>
 				<BuildingType>BUILDING_BARREDOWL_STORY</BuildingType>
+				<BuildingType>BUILDING_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_BEAVER_STORIES</BuildingType>
 				<BuildingType>BUILDING_BEAVER_STORY</BuildingType>
+				<BuildingType>BUILDING_BENGALTIGER_STORIES</BuildingType>
 				<BuildingType>BUILDING_BENGALTIGER_STORY</BuildingType>
+				<BuildingType>BUILDING_BISON_STORIES</BuildingType>
 				<BuildingType>BUILDING_BISON_STORY</BuildingType>
+				<BuildingType>BUILDING_BLACK_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BLACK_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_BLACK_RHINO_STORIES</BuildingType>
 				<BuildingType>BUILDING_BLACK_RHINO_STORY</BuildingType>
+				<BuildingType>BUILDING_BOAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BOAR_STORY</BuildingType>
+				<BuildingType>BUILDING_BONGO_STORIES</BuildingType>
 				<BuildingType>BUILDING_BONGO_STORY</BuildingType>
+				<BuildingType>BUILDING_BOOBY_STORIES</BuildingType>
 				<BuildingType>BUILDING_BOOBY_STORY</BuildingType>
+				<BuildingType>BUILDING_BRAZILIAN_TAPIR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BRAZILIAN_TAPIR_STORY</BuildingType>
+				<BuildingType>BUILDING_BROWN_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_BROWN_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_BUFFALO_STORIES</BuildingType>
 				<BuildingType>BUILDING_BUFFALO_STORY</BuildingType>
+				<BuildingType>BUILDING_CAIMAN_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAIMAN_STORY</BuildingType>
+				<BuildingType>BUILDING_CAPUCHIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAPUCHIN_STORY</BuildingType>
+				<BuildingType>BUILDING_CAPYBARA_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAPYBARA_STORY</BuildingType>
+				<BuildingType>BUILDING_CARIBOU_STORIES</BuildingType>
 				<BuildingType>BUILDING_CARIBOU_STORY</BuildingType>
+				<BuildingType>BUILDING_CASSOWARY_STORIES</BuildingType>
 				<BuildingType>BUILDING_CASSOWARY_STORY</BuildingType>
+				<BuildingType>BUILDING_CAVE_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAVE_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_CAVE_LION_STORIES</BuildingType>
 				<BuildingType>BUILDING_CAVE_LION_STORY</BuildingType>
+				<BuildingType>BUILDING_CHEETAH_STORIES</BuildingType>
 				<BuildingType>BUILDING_CHEETAH_STORY</BuildingType>
+				<BuildingType>BUILDING_CHIMPANZEE_STORIES</BuildingType>
 				<BuildingType>BUILDING_CHIMPANZEE_STORY</BuildingType>
+				<BuildingType>BUILDING_COBRA_STORIES</BuildingType>
 				<BuildingType>BUILDING_COBRA_STORY</BuildingType>
+				<BuildingType>BUILDING_COD_STORIES</BuildingType>
 				<BuildingType>BUILDING_COD_STORY</BuildingType>
+				<BuildingType>BUILDING_CRAB_STORIES</BuildingType>
 				<BuildingType>BUILDING_CRAB_STORY</BuildingType>
+				<BuildingType>BUILDING_CROCODILE_STORIES</BuildingType>
 				<BuildingType>BUILDING_CROCODILE_STORY</BuildingType>
+				<BuildingType>BUILDING_CROW_STORIES</BuildingType>
 				<BuildingType>BUILDING_CROW_STORY</BuildingType>
+				<BuildingType>BUILDING_CUSCUS_STORIES</BuildingType>
 				<BuildingType>BUILDING_CUSCUS_STORY</BuildingType>
+				<BuildingType>BUILDING_DART_FROG_STORIES</BuildingType>
 				<BuildingType>BUILDING_DART_FROG_STORY</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORIES</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORY</BuildingType>
+				<BuildingType>BUILDING_DHOLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_DHOLE_STORY</BuildingType>
+				<BuildingType>BUILDING_DINGO_STORIES</BuildingType>
 				<BuildingType>BUILDING_DINGO_STORY</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORIES</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORY</BuildingType>
+				<BuildingType>BUILDING_DUCK_STORIES</BuildingType>
 				<BuildingType>BUILDING_DUCK_STORY</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORIES</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORY</BuildingType>
+				<BuildingType>BUILDING_EAGLE_BALD_STORIES</BuildingType>
 				<BuildingType>BUILDING_EAGLE_BALD_STORY</BuildingType>
+				<BuildingType>BUILDING_EAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_EAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_ELASMOTHERIUM_STORIES</BuildingType>
 				<BuildingType>BUILDING_ELASMOTHERIUM_STORY</BuildingType>
+				<BuildingType>BUILDING_EMPEROR_PENGUIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_EMPEROR_PENGUIN_STORY</BuildingType>
+				<BuildingType>BUILDING_EMU_STORIES</BuildingType>
 				<BuildingType>BUILDING_EMU_STORY</BuildingType>
+				<BuildingType>BUILDING_EWOLF_STORIES</BuildingType>
 				<BuildingType>BUILDING_EWOLF_STORY</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORIES</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORY</BuildingType>
+				<BuildingType>BUILDING_FENNECFOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_FENNECFOX_STORY</BuildingType>
+				<BuildingType>BUILDING_GALAPAGOS_PENGUIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_GALAPAGOS_PENGUIN_STORY</BuildingType>
+				<BuildingType>BUILDING_GALAPAGOS_TORTOISE_STORIES</BuildingType>
 				<BuildingType>BUILDING_GALAPAGOS_TORTOISE_STORY</BuildingType>
+				<BuildingType>BUILDING_GATOR_ASIAN_STORIES</BuildingType>
 				<BuildingType>BUILDING_GATOR_ASIAN_STORY</BuildingType>
+				<BuildingType>BUILDING_GATOR_STORIES</BuildingType>
 				<BuildingType>BUILDING_GATOR_STORY</BuildingType>
+				<BuildingType>BUILDING_GAZELLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_GAZELLE_STORY</BuildingType>
+				<BuildingType>BUILDING_GELADA_STORIES</BuildingType>
 				<BuildingType>BUILDING_GELADA_STORY</BuildingType>
+				<BuildingType>BUILDING_GEMSBOK_STORIES</BuildingType>
 				<BuildingType>BUILDING_GEMSBOK_STORY</BuildingType>
+				<BuildingType>BUILDING_GERENUK_STORIES</BuildingType>
 				<BuildingType>BUILDING_GERENUK_STORY</BuildingType>
+				<BuildingType>BUILDING_GHARIAL_STORIES</BuildingType>
 				<BuildingType>BUILDING_GHARIAL_STORY</BuildingType>
+				<BuildingType>BUILDING_GIRAFFE_STORIES</BuildingType>
 				<BuildingType>BUILDING_GIRAFFE_STORY</BuildingType>
+				<BuildingType>BUILDING_GLYPTO_STORIES</BuildingType>
 				<BuildingType>BUILDING_GLYPTO_STORY</BuildingType>
+				<BuildingType>BUILDING_GORILLA_STORIES</BuildingType>
 				<BuildingType>BUILDING_GORILLA_STORY</BuildingType>
+				<BuildingType>BUILDING_GREATWHITE_SHARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_GREATWHITE_SHARK_STORY</BuildingType>
+				<BuildingType>BUILDING_GREY_WOLF_STORIES</BuildingType>
 				<BuildingType>BUILDING_GREY_WOLF_STORY</BuildingType>
+				<BuildingType>BUILDING_GRIZZLY_STORIES</BuildingType>
 				<BuildingType>BUILDING_GRIZZLY_STORY</BuildingType>
+				<BuildingType>BUILDING_GULL_STORIES</BuildingType>
 				<BuildingType>BUILDING_GULL_STORY</BuildingType>
+				<BuildingType>BUILDING_HAAST_EAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_HAAST_EAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_HAMMERHEAD_SHARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_HAMMERHEAD_SHARK_STORY</BuildingType>
+				<BuildingType>BUILDING_HARPYEAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_HARPYEAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_HAWK_STORIES</BuildingType>
 				<BuildingType>BUILDING_HAWK_STORY</BuildingType>
+				<BuildingType>BUILDING_HIPPOPOTAMUS_STORIES</BuildingType>
 				<BuildingType>BUILDING_HIPPOPOTAMUS_STORY</BuildingType>
+				<BuildingType>BUILDING_HIPPOS_STORIES</BuildingType>
 				<BuildingType>BUILDING_HIPPOS_STORY</BuildingType>
+				<BuildingType>BUILDING_HORNED_OWL_STORIES</BuildingType>
 				<BuildingType>BUILDING_HORNED_OWL_STORY</BuildingType>
+				<BuildingType>BUILDING_HUMPBACK_STORIES</BuildingType>
 				<BuildingType>BUILDING_HUMPBACK_STORY</BuildingType>
+				<BuildingType>BUILDING_HYENA_STORIES</BuildingType>
 				<BuildingType>BUILDING_HYENA_STORY</BuildingType>
+				<BuildingType>BUILDING_IBEX_STORIES</BuildingType>
 				<BuildingType>BUILDING_IBEX_STORY</BuildingType>
+				<BuildingType>BUILDING_IGUANA_STORIES</BuildingType>
 				<BuildingType>BUILDING_IGUANA_STORY</BuildingType>
+				<BuildingType>BUILDING_IMPALA_STORIES</BuildingType>
 				<BuildingType>BUILDING_IMPALA_STORY</BuildingType>
+				<BuildingType>BUILDING_INDIAN_RHINO_STORIES</BuildingType>
 				<BuildingType>BUILDING_INDIAN_RHINO_STORY</BuildingType>
+				<BuildingType>BUILDING_JAGUAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_JAGUAR_STORY</BuildingType>
+				<BuildingType>BUILDING_JAVA_RHINO_STORIES</BuildingType>
 				<BuildingType>BUILDING_JAVA_RHINO_STORY</BuildingType>
+				<BuildingType>BUILDING_KANGAROO_GREY_STORIES</BuildingType>
+				<BuildingType>BUILDING_KANGAROO_GREY_STORIES</BuildingType>
 				<BuildingType>BUILDING_KANGAROO_GREY_STORY</BuildingType>
 				<BuildingType>BUILDING_KANGAROO_GREY_STORY</BuildingType>
+				<BuildingType>BUILDING_KANGAROO_RED_STORIES</BuildingType>
 				<BuildingType>BUILDING_KANGAROO_RED_STORY</BuildingType>
+				<BuildingType>BUILDING_KOALA_STORIES</BuildingType>
 				<BuildingType>BUILDING_KOALA_STORY</BuildingType>
+				<BuildingType>BUILDING_KOMODO_DRAGON_STORIES</BuildingType>
 				<BuildingType>BUILDING_KOMODO_DRAGON_STORY</BuildingType>
+				<BuildingType>BUILDING_KOOKABURRA_STORIES</BuildingType>
 				<BuildingType>BUILDING_KOOKABURRA_STORY</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORIES</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORY</BuildingType>
+				<BuildingType>BUILDING_LION_STORIES</BuildingType>
 				<BuildingType>BUILDING_LION_STORY</BuildingType>
+				<BuildingType>BUILDING_LIZARD_STORIES</BuildingType>
 				<BuildingType>BUILDING_LIZARD_STORY</BuildingType>
+				<BuildingType>BUILDING_LLAMA_STORIES</BuildingType>
 				<BuildingType>BUILDING_LLAMA_STORY</BuildingType>
+				<BuildingType>BUILDING_LOON_STORIES</BuildingType>
+				<BuildingType>BUILDING_LOON_STORY</BuildingType>
+				<BuildingType>BUILDING_LYNX_STORIES</BuildingType>
 				<BuildingType>BUILDING_LYNX_STORY</BuildingType>
+				<BuildingType>BUILDING_MACAW_STORIES</BuildingType>
 				<BuildingType>BUILDING_MACAW_STORY</BuildingType>
+				<BuildingType>BUILDING_MACKEREL_STORIES</BuildingType>
 				<BuildingType>BUILDING_MACKEREL_STORY</BuildingType>
+				<BuildingType>BUILDING_MALAYAN_TAPIR_STORIES</BuildingType>
 				<BuildingType>BUILDING_MALAYAN_TAPIR_STORY</BuildingType>
+				<BuildingType>BUILDING_MANDRILL_STORIES</BuildingType>
 				<BuildingType>BUILDING_MANDRILL_STORY</BuildingType>
+				<BuildingType>BUILDING_MANEDWOLF_STORIES</BuildingType>
 				<BuildingType>BUILDING_MANEDWOLF_STORY</BuildingType>
+				<BuildingType>BUILDING_MARLIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_MARLIN_STORY</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORIES</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORY</BuildingType>
+				<BuildingType>BUILDING_MOA_STORIES</BuildingType>
 				<BuildingType>BUILDING_MOA_STORY</BuildingType>
+				<BuildingType>BUILDING_MONOTREMES_STORIES</BuildingType>
 				<BuildingType>BUILDING_MONOTREMES_STORY</BuildingType>
+				<BuildingType>BUILDING_MOOSE_STORIES</BuildingType>
 				<BuildingType>BUILDING_MOOSE_STORY</BuildingType>
+				<BuildingType>BUILDING_MOUNTAIN_TAPIR_STORIES</BuildingType>
 				<BuildingType>BUILDING_MOUNTAIN_TAPIR_STORY</BuildingType>
+				<BuildingType>BUILDING_MUSKOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_MUSKOX_STORY</BuildingType>
+				<BuildingType>BUILDING_NEW_W_MONKEY_STORIES</BuildingType>
 				<BuildingType>BUILDING_NEW_W_MONKEY_STORY</BuildingType>
+				<BuildingType>BUILDING_NILECROC_STORIES</BuildingType>
 				<BuildingType>BUILDING_NILECROC_STORY</BuildingType>
+				<BuildingType>BUILDING_NILE_MONITOR_STORIES</BuildingType>
 				<BuildingType>BUILDING_NILE_MONITOR_STORY</BuildingType>
+				<BuildingType>BUILDING_NUMBAT_STORIES</BuildingType>
 				<BuildingType>BUILDING_NUMBAT_STORY</BuildingType>
+				<BuildingType>BUILDING_OKAPI_STORIES</BuildingType>
 				<BuildingType>BUILDING_OKAPI_STORY</BuildingType>
+				<BuildingType>BUILDING_OLD_W_MONKEY_STORIES</BuildingType>
 				<BuildingType>BUILDING_OLD_W_MONKEY_STORY</BuildingType>
+				<BuildingType>BUILDING_OPOSSUM_STORIES</BuildingType>
 				<BuildingType>BUILDING_OPOSSUM_STORY</BuildingType>
+				<BuildingType>BUILDING_ORANGUTAN_STORIES</BuildingType>
 				<BuildingType>BUILDING_ORANGUTAN_STORY</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORIES</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORY</BuildingType>
+				<BuildingType>BUILDING_OSTRICH_STORIES</BuildingType>
 				<BuildingType>BUILDING_OSTRICH_STORY</BuildingType>
+				<BuildingType>BUILDING_OXPECKER_STORIES</BuildingType>
 				<BuildingType>BUILDING_OXPECKER_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORY</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORIES</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORY</BuildingType>
+				<BuildingType>BUILDING_PANDA_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_PANDA_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_PANTHER_STORIES</BuildingType>
 				<BuildingType>BUILDING_PANTHER_STORY</BuildingType>
+				<BuildingType>BUILDING_PARROT_STORIES</BuildingType>
 				<BuildingType>BUILDING_PARROT_STORY</BuildingType>
+				<BuildingType>BUILDING_PEACOCK_STORIES</BuildingType>
 				<BuildingType>BUILDING_PEACOCK_STORY</BuildingType>
+				<BuildingType>BUILDING_PENGUIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_PENGUIN_STORY</BuildingType>
+				<BuildingType>BUILDING_PHEASANT_STORIES</BuildingType>
 				<BuildingType>BUILDING_PHEASANT_STORY</BuildingType>
+				<BuildingType>BUILDING_PIGEON_STORIES</BuildingType>
 				<BuildingType>BUILDING_PIGEON_STORY</BuildingType>
+				<BuildingType>BUILDING_PLATYPUS_STORIES</BuildingType>
 				<BuildingType>BUILDING_PLATYPUS_STORY</BuildingType>
+				<BuildingType>BUILDING_POLAR_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_POLAR_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_POSSUM_STORIES</BuildingType>
 				<BuildingType>BUILDING_POSSUM_STORY</BuildingType>
+				<BuildingType>BUILDING_PUFFADDER_STORIES</BuildingType>
 				<BuildingType>BUILDING_PUFFADDER_STORY</BuildingType>
+				<BuildingType>BUILDING_PYGMYHIPPO_STORIES</BuildingType>
 				<BuildingType>BUILDING_PYGMYHIPPO_STORY</BuildingType>
+				<BuildingType>BUILDING_QUOLL_STORIES</BuildingType>
 				<BuildingType>BUILDING_QUOLL_STORY</BuildingType>
+				<BuildingType>BUILDING_RACCOON_STORIES</BuildingType>
 				<BuildingType>BUILDING_RACCOON_STORY</BuildingType>
+				<BuildingType>BUILDING_RATEL_STORIES</BuildingType>
 				<BuildingType>BUILDING_RATEL_STORY</BuildingType>
+				<BuildingType>BUILDING_RAVEN_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAVEN_STORY</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORIES</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORY</BuildingType>
+				<BuildingType>BUILDING_RAY_EAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAY_EAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_RAY_MANTA_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAY_MANTA_STORY</BuildingType>
+				<BuildingType>BUILDING_RAZORBILL_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAZORBILL_STORY</BuildingType>
+				<BuildingType>BUILDING_REDFOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_REDFOX_STORY</BuildingType>
+				<BuildingType>BUILDING_REDPANDA_STORIES</BuildingType>
 				<BuildingType>BUILDING_REDPANDA_STORY</BuildingType>
+				<BuildingType>BUILDING_REEF_SHARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_REEF_SHARK_STORY</BuildingType>
+				<BuildingType>BUILDING_RHEA_STORIES</BuildingType>
 				<BuildingType>BUILDING_RHEA_STORY</BuildingType>
+				<BuildingType>BUILDING_RIVER_CROC_STORIES</BuildingType>
 				<BuildingType>BUILDING_RIVER_CROC_STORY</BuildingType>
+				<BuildingType>BUILDING_ROCKHOPPER_PENGUIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_ROCKHOPPER_PENGUIN_STORY</BuildingType>
+				<BuildingType>BUILDING_SABRETOOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_SABRETOOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_SAIGA_STORIES</BuildingType>
 				<BuildingType>BUILDING_SAIGA_STORY</BuildingType>
+				<BuildingType>BUILDING_SALTWATER_CROC_STORIES</BuildingType>
 				<BuildingType>BUILDING_SALTWATER_CROC_STORY</BuildingType>
+				<BuildingType>BUILDING_SEAEAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEAEAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORY</BuildingType>
+				<BuildingType>BUILDING_SEALION_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEALION_STORY</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORY</BuildingType>
+				<BuildingType>BUILDING_SECRETARYBIRD_STORIES</BuildingType>
 				<BuildingType>BUILDING_SECRETARYBIRD_STORY</BuildingType>
+				<BuildingType>BUILDING_SHARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_SHARK_STORY</BuildingType>
+				<BuildingType>BUILDING_SIBERIAN_TIGER_STORIES</BuildingType>
 				<BuildingType>BUILDING_SIBERIAN_TIGER_STORY</BuildingType>
+				<BuildingType>BUILDING_SKUNK_STORIES</BuildingType>
 				<BuildingType>BUILDING_SKUNK_STORY</BuildingType>
+				<BuildingType>BUILDING_SLOTH_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_SLOTH_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_SNAKES_STORIES</BuildingType>
 				<BuildingType>BUILDING_SNAKES_STORY</BuildingType>
+				<BuildingType>BUILDING_SNOW_LEOPARD_STORIES</BuildingType>
 				<BuildingType>BUILDING_SNOW_LEOPARD_STORY</BuildingType>
+				<BuildingType>BUILDING_SPECTACLED_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_SPECTACLED_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_SUN_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_SUN_BEAR_STORY</BuildingType>
+				<BuildingType>BUILDING_TARANTULA_STORIES</BuildingType>
 				<BuildingType>BUILDING_TARANTULA_STORY</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORIES</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORY</BuildingType>
+				<BuildingType>BUILDING_TERN_STORIES</BuildingType>
 				<BuildingType>BUILDING_TERN_STORY</BuildingType>
+				<BuildingType>BUILDING_THYLACINE_STORIES</BuildingType>
 				<BuildingType>BUILDING_THYLACINE_STORY</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORIES</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORY</BuildingType>
+				<BuildingType>BUILDING_TREESLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_TREESLOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORIES</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORY</BuildingType>
+				<BuildingType>BUILDING_TURKEY_STORIES</BuildingType>
 				<BuildingType>BUILDING_TURKEY_STORY</BuildingType>
+				<BuildingType>BUILDING_VIPER_STORIES</BuildingType>
 				<BuildingType>BUILDING_VIPER_STORY</BuildingType>
+				<BuildingType>BUILDING_VULTURE_STORIES</BuildingType>
 				<BuildingType>BUILDING_VULTURE_STORY</BuildingType>
+				<BuildingType>BUILDING_WALLAROO_STORIES</BuildingType>
 				<BuildingType>BUILDING_WALLAROO_STORY</BuildingType>
+				<BuildingType>BUILDING_WALRUS_STORIES</BuildingType>
 				<BuildingType>BUILDING_WALRUS_STORY</BuildingType>
+				<BuildingType>BUILDING_WARTHOG_STORIES</BuildingType>
 				<BuildingType>BUILDING_WARTHOG_STORY</BuildingType>
+				<BuildingType>BUILDING_WHALESHARK_STORIES</BuildingType>
 				<BuildingType>BUILDING_WHALESHARK_STORY</BuildingType>
+				<BuildingType>BUILDING_WHITE_RHINO_STORIES</BuildingType>
 				<BuildingType>BUILDING_WHITE_RHINO_STORY</BuildingType>
+				<BuildingType>BUILDING_WILDEBEEST_STORIES</BuildingType>
 				<BuildingType>BUILDING_WILDEBEEST_STORY</BuildingType>
+				<BuildingType>BUILDING_WOLVERINE_STORIES</BuildingType>
 				<BuildingType>BUILDING_WOLVERINE_STORY</BuildingType>
+				<BuildingType>BUILDING_WOMBAT_STORIES</BuildingType>
 				<BuildingType>BUILDING_WOMBAT_STORY</BuildingType>
+				<BuildingType>BUILDING_ZEBRA_STORIES</BuildingType>
 				<BuildingType>BUILDING_ZEBRA_STORY</BuildingType>
 			</Buildings>
 		</UnitInfo>
@@ -271,12 +481,18 @@
 				<BuildingType>BUILDING_CUSCUS_STORY</BuildingType>
 				<BuildingType>BUILDING_DART_FROG_STORIES</BuildingType>
 				<BuildingType>BUILDING_DART_FROG_STORY</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORIES</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORY</BuildingType>
 				<BuildingType>BUILDING_DHOLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_DHOLE_STORY</BuildingType>
 				<BuildingType>BUILDING_DINGO_STORIES</BuildingType>
 				<BuildingType>BUILDING_DINGO_STORY</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORIES</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORY</BuildingType>
 				<BuildingType>BUILDING_DUCK_STORIES</BuildingType>
 				<BuildingType>BUILDING_DUCK_STORY</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORIES</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORY</BuildingType>
 				<BuildingType>BUILDING_EAGLE_BALD_STORIES</BuildingType>
 				<BuildingType>BUILDING_EAGLE_BALD_STORY</BuildingType>
 				<BuildingType>BUILDING_EAGLE_STORIES</BuildingType>
@@ -289,6 +505,8 @@
 				<BuildingType>BUILDING_EMU_STORY</BuildingType>
 				<BuildingType>BUILDING_EWOLF_STORIES</BuildingType>
 				<BuildingType>BUILDING_EWOLF_STORY</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORIES</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORY</BuildingType>
 				<BuildingType>BUILDING_FENNECFOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_FENNECFOX_STORY</BuildingType>
 				<BuildingType>BUILDING_GALAPAGOS_PENGUIN_STORIES</BuildingType>
@@ -365,12 +583,16 @@
 				<BuildingType>BUILDING_KOMODO_DRAGON_STORY</BuildingType>
 				<BuildingType>BUILDING_KOOKABURRA_STORIES</BuildingType>
 				<BuildingType>BUILDING_KOOKABURRA_STORY</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORIES</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORY</BuildingType>
 				<BuildingType>BUILDING_LION_STORIES</BuildingType>
 				<BuildingType>BUILDING_LION_STORY</BuildingType>
 				<BuildingType>BUILDING_LIZARD_STORIES</BuildingType>
 				<BuildingType>BUILDING_LIZARD_STORY</BuildingType>
 				<BuildingType>BUILDING_LLAMA_STORIES</BuildingType>
 				<BuildingType>BUILDING_LLAMA_STORY</BuildingType>
+				<BuildingType>BUILDING_LOON_STORIES</BuildingType>
+				<BuildingType>BUILDING_LOON_STORY</BuildingType>
 				<BuildingType>BUILDING_LYNX_STORIES</BuildingType>
 				<BuildingType>BUILDING_LYNX_STORY</BuildingType>
 				<BuildingType>BUILDING_MACAW_STORIES</BuildingType>
@@ -385,6 +607,8 @@
 				<BuildingType>BUILDING_MANEDWOLF_STORY</BuildingType>
 				<BuildingType>BUILDING_MARLIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_MARLIN_STORY</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORIES</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORY</BuildingType>
 				<BuildingType>BUILDING_MOA_STORIES</BuildingType>
 				<BuildingType>BUILDING_MOA_STORY</BuildingType>
 				<BuildingType>BUILDING_MONOTREMES_STORIES</BuildingType>
@@ -411,16 +635,26 @@
 				<BuildingType>BUILDING_OPOSSUM_STORY</BuildingType>
 				<BuildingType>BUILDING_ORANGUTAN_STORIES</BuildingType>
 				<BuildingType>BUILDING_ORANGUTAN_STORY</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORIES</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORY</BuildingType>
 				<BuildingType>BUILDING_OSTRICH_STORIES</BuildingType>
 				<BuildingType>BUILDING_OSTRICH_STORY</BuildingType>
 				<BuildingType>BUILDING_OXPECKER_STORIES</BuildingType>
 				<BuildingType>BUILDING_OXPECKER_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORY</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORIES</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORY</BuildingType>
 				<BuildingType>BUILDING_PANDA_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_PANDA_BEAR_STORY</BuildingType>
 				<BuildingType>BUILDING_PANTHER_STORIES</BuildingType>
@@ -453,6 +687,8 @@
 				<BuildingType>BUILDING_RATEL_STORY</BuildingType>
 				<BuildingType>BUILDING_RAVEN_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAVEN_STORY</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORIES</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORY</BuildingType>
 				<BuildingType>BUILDING_RAY_EAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAY_EAGLE_STORY</BuildingType>
 				<BuildingType>BUILDING_RAY_MANTA_STORIES</BuildingType>
@@ -479,8 +715,12 @@
 				<BuildingType>BUILDING_SALTWATER_CROC_STORY</BuildingType>
 				<BuildingType>BUILDING_SEAEAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEAEAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORY</BuildingType>
 				<BuildingType>BUILDING_SEALION_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEALION_STORY</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORY</BuildingType>
 				<BuildingType>BUILDING_SECRETARYBIRD_STORIES</BuildingType>
 				<BuildingType>BUILDING_SECRETARYBIRD_STORY</BuildingType>
 				<BuildingType>BUILDING_SHARK_STORIES</BuildingType>
@@ -501,12 +741,18 @@
 				<BuildingType>BUILDING_SUN_BEAR_STORY</BuildingType>
 				<BuildingType>BUILDING_TARANTULA_STORIES</BuildingType>
 				<BuildingType>BUILDING_TARANTULA_STORY</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORIES</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORY</BuildingType>
 				<BuildingType>BUILDING_TERN_STORIES</BuildingType>
 				<BuildingType>BUILDING_TERN_STORY</BuildingType>
 				<BuildingType>BUILDING_THYLACINE_STORIES</BuildingType>
 				<BuildingType>BUILDING_THYLACINE_STORY</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORIES</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORY</BuildingType>
 				<BuildingType>BUILDING_TREESLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_TREESLOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORIES</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORY</BuildingType>
 				<BuildingType>BUILDING_TURKEY_STORIES</BuildingType>
 				<BuildingType>BUILDING_TURKEY_STORY</BuildingType>
 				<BuildingType>BUILDING_VIPER_STORIES</BuildingType>
@@ -624,12 +870,18 @@
 				<BuildingType>BUILDING_CUSCUS_STORY</BuildingType>
 				<BuildingType>BUILDING_DART_FROG_STORIES</BuildingType>
 				<BuildingType>BUILDING_DART_FROG_STORY</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORIES</BuildingType>
+				<BuildingType>BUILDING_DESERT_TORTOISE_STORY</BuildingType>
 				<BuildingType>BUILDING_DHOLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_DHOLE_STORY</BuildingType>
 				<BuildingType>BUILDING_DINGO_STORIES</BuildingType>
 				<BuildingType>BUILDING_DINGO_STORY</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORIES</BuildingType>
+				<BuildingType>BUILDING_DOLPHIN_STORY</BuildingType>
 				<BuildingType>BUILDING_DUCK_STORIES</BuildingType>
 				<BuildingType>BUILDING_DUCK_STORY</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORIES</BuildingType>
+				<BuildingType>BUILDING_DUGONG_STORY</BuildingType>
 				<BuildingType>BUILDING_EAGLE_BALD_STORIES</BuildingType>
 				<BuildingType>BUILDING_EAGLE_BALD_STORY</BuildingType>
 				<BuildingType>BUILDING_EAGLE_STORIES</BuildingType>
@@ -642,6 +894,8 @@
 				<BuildingType>BUILDING_EMU_STORY</BuildingType>
 				<BuildingType>BUILDING_EWOLF_STORIES</BuildingType>
 				<BuildingType>BUILDING_EWOLF_STORY</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORIES</BuildingType>
+				<BuildingType>BUILDING_FLAMINGO_STORY</BuildingType>
 				<BuildingType>BUILDING_FENNECFOX_STORIES</BuildingType>
 				<BuildingType>BUILDING_FENNECFOX_STORY</BuildingType>
 				<BuildingType>BUILDING_GALAPAGOS_PENGUIN_STORIES</BuildingType>
@@ -718,12 +972,16 @@
 				<BuildingType>BUILDING_KOMODO_DRAGON_STORY</BuildingType>
 				<BuildingType>BUILDING_KOOKABURRA_STORIES</BuildingType>
 				<BuildingType>BUILDING_KOOKABURRA_STORY</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORIES</BuildingType>
+				<BuildingType>BUILDING_KRAKEN_STORY</BuildingType>
 				<BuildingType>BUILDING_LION_STORIES</BuildingType>
 				<BuildingType>BUILDING_LION_STORY</BuildingType>
 				<BuildingType>BUILDING_LIZARD_STORIES</BuildingType>
 				<BuildingType>BUILDING_LIZARD_STORY</BuildingType>
 				<BuildingType>BUILDING_LLAMA_STORIES</BuildingType>
 				<BuildingType>BUILDING_LLAMA_STORY</BuildingType>
+				<BuildingType>BUILDING_LOON_STORIES</BuildingType>
+				<BuildingType>BUILDING_LOON_STORY</BuildingType>
 				<BuildingType>BUILDING_LYNX_STORIES</BuildingType>
 				<BuildingType>BUILDING_LYNX_STORY</BuildingType>
 				<BuildingType>BUILDING_MACAW_STORIES</BuildingType>
@@ -738,6 +996,8 @@
 				<BuildingType>BUILDING_MANEDWOLF_STORY</BuildingType>
 				<BuildingType>BUILDING_MARLIN_STORIES</BuildingType>
 				<BuildingType>BUILDING_MARLIN_STORY</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORIES</BuildingType>
+				<BuildingType>BUILDING_MINKIE_WHALE_STORY</BuildingType>
 				<BuildingType>BUILDING_MOA_STORIES</BuildingType>
 				<BuildingType>BUILDING_MOA_STORY</BuildingType>
 				<BuildingType>BUILDING_MONOTREMES_STORIES</BuildingType>
@@ -764,16 +1024,26 @@
 				<BuildingType>BUILDING_OPOSSUM_STORY</BuildingType>
 				<BuildingType>BUILDING_ORANGUTAN_STORIES</BuildingType>
 				<BuildingType>BUILDING_ORANGUTAN_STORY</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORIES</BuildingType>
+				<BuildingType>BUILDING_ORCA_STORY</BuildingType>
 				<BuildingType>BUILDING_OSTRICH_STORIES</BuildingType>
 				<BuildingType>BUILDING_OSTRICH_STORY</BuildingType>
 				<BuildingType>BUILDING_OXPECKER_STORIES</BuildingType>
 				<BuildingType>BUILDING_OXPECKER_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_BIRD_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_DOG_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_CAT_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_GROUNDSLOTH_STORY</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_PALEOLITHIC_MAMMOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORIES</BuildingType>
+				<BuildingType>BUILDING_PALEOLITHIC_MARSUPIAL_STORY</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORIES</BuildingType>
+				<BuildingType>BUILDING_PROCOPTODON_STORY</BuildingType>
 				<BuildingType>BUILDING_PANDA_BEAR_STORIES</BuildingType>
 				<BuildingType>BUILDING_PANDA_BEAR_STORY</BuildingType>
 				<BuildingType>BUILDING_PANTHER_STORIES</BuildingType>
@@ -806,6 +1076,8 @@
 				<BuildingType>BUILDING_RATEL_STORY</BuildingType>
 				<BuildingType>BUILDING_RAVEN_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAVEN_STORY</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORIES</BuildingType>
+				<BuildingType>BUILDING_RAYS_STORY</BuildingType>
 				<BuildingType>BUILDING_RAY_EAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_RAY_EAGLE_STORY</BuildingType>
 				<BuildingType>BUILDING_RAY_MANTA_STORIES</BuildingType>
@@ -832,8 +1104,12 @@
 				<BuildingType>BUILDING_SALTWATER_CROC_STORY</BuildingType>
 				<BuildingType>BUILDING_SEAEAGLE_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEAEAGLE_STORY</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEA_OTTER_STORY</BuildingType>
 				<BuildingType>BUILDING_SEALION_STORIES</BuildingType>
 				<BuildingType>BUILDING_SEALION_STORY</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORIES</BuildingType>
+				<BuildingType>BUILDING_SEATURTLE_STORY</BuildingType>
 				<BuildingType>BUILDING_SECRETARYBIRD_STORIES</BuildingType>
 				<BuildingType>BUILDING_SECRETARYBIRD_STORY</BuildingType>
 				<BuildingType>BUILDING_SHARK_STORIES</BuildingType>
@@ -854,12 +1130,18 @@
 				<BuildingType>BUILDING_SUN_BEAR_STORY</BuildingType>
 				<BuildingType>BUILDING_TARANTULA_STORIES</BuildingType>
 				<BuildingType>BUILDING_TARANTULA_STORY</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORIES</BuildingType>
+				<BuildingType>BUILDING_BAIRDS_TAPIR_STORY</BuildingType>
 				<BuildingType>BUILDING_TERN_STORIES</BuildingType>
 				<BuildingType>BUILDING_TERN_STORY</BuildingType>
 				<BuildingType>BUILDING_THYLACINE_STORIES</BuildingType>
 				<BuildingType>BUILDING_THYLACINE_STORY</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORIES</BuildingType>
+				<BuildingType>BUILDING_TOUCAN_STORY</BuildingType>
 				<BuildingType>BUILDING_TREESLOTH_STORIES</BuildingType>
 				<BuildingType>BUILDING_TREESLOTH_STORY</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORIES</BuildingType>
+				<BuildingType>BUILDING_TUNA_STORY</BuildingType>
 				<BuildingType>BUILDING_TURKEY_STORIES</BuildingType>
 				<BuildingType>BUILDING_TURKEY_STORY</BuildingType>
 				<BuildingType>BUILDING_VIPER_STORIES</BuildingType>


### PR DESCRIPTION
irishhombre: It always irritated me that entertainers could not build all stories so I fixed it. While I was at I also fixed Paleolithic cats and marsupials. Paleolithic cats stories can be built both by cave lions and entertainers. Paleolithic marsupials can be built by both procoptodons and entertainers.