### PR TITLE
fix(Tech): getting more than one free tech in a single turn now works

### DIFF
--- a/Sources/CvDLLWidgetData.cpp
+++ b/Sources/CvDLLWidgetData.cpp
@@ -1393,7 +1393,7 @@ void CvDLLWidgetData::doResearch(CvWidgetDataStruct &widgetDataStruct)
 			);
 			return;
 		}
-		kPlayer.setChoosingFreeTech(false);
+		kPlayer.endChoosingFreeTech();
 	}
 	if (widgetDataStruct.m_iData1 > 0
 	&& !GET_PLAYER(GC.getGame().getActivePlayer()).hasValidBuildings((TechTypes)widgetDataStruct.m_iData1))

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -253,7 +253,7 @@ m_cachedBonusCount(NULL)
 	setDoNotBotherStatus(NO_PLAYER);
 
 	// Free Tech Popup Fix
-	m_bChoosingFreeTech = false;
+	m_iChoosingFreeTech = 0;
 	m_bChoosingReligion = false;
 
 	m_zobristValue = GC.getGame().getSorenRand().getInt();
@@ -989,7 +989,7 @@ void CvPlayer::reset(PlayerTypes eID, bool bConstructorCall)
 	setTurnHadUIInteraction(false);
 
 	// Free Tech Popup Fix
-	m_bChoosingFreeTech = false;
+	m_iChoosingFreeTech = 0;
 
 	m_bDisableHuman = false;
 
@@ -4608,12 +4608,20 @@ bool CvPlayer::hasBusyUnit() const
 
 bool CvPlayer::isChoosingFreeTech() const
 {
-	return m_bChoosingFreeTech;
+	return (m_iChoosingFreeTech > 0);
 }
 
-void CvPlayer::setChoosingFreeTech(bool bValue)
+void CvPlayer::startChoosingFreeTech()
 {
-	m_bChoosingFreeTech = bValue;
+	m_iChoosingFreeTech++;
+}
+
+void CvPlayer::endChoosingFreeTech()
+{
+	if (m_iChoosingFreeTech > 0)
+	{
+		m_iChoosingFreeTech--;
+	}
 }
 
 
@@ -4621,7 +4629,7 @@ void CvPlayer::chooseTech(int iDiscover, CvWString szText, bool bFront)
 {
 	if (iDiscover > 0)
 	{
-		setChoosingFreeTech(true);
+		startChoosingFreeTech();
 	}
 
 	CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_CHOOSETECH);
@@ -20268,7 +20276,7 @@ void CvPlayer::read(FDataStreamBase* pStream)
 
 					if ( pInfo->getButtonPopupType() == BUTTONPOPUP_CHOOSETECH && pInfo->getData1() > 0 )
 					{
-						setChoosingFreeTech(true);
+						startChoosingFreeTech();
 					}
 				}
 			}

--- a/Sources/CvPlayer.h
+++ b/Sources/CvPlayer.h
@@ -225,7 +225,8 @@ public:
 	DllExport bool hasBusyUnit() const;
 
 	bool isChoosingFreeTech() const;
-	void setChoosingFreeTech(bool bValue);
+	void startChoosingFreeTech();
+	void endChoosingFreeTech();
 	void chooseTech(int iDiscover = 0, CvWString szText = CvWString(), bool bFront = false);
 
 	int calculateScore(bool bFinal = false, bool bVictory = false) const;
@@ -1893,7 +1894,7 @@ protected:
 
 	int m_bDoNotBotherStatus;
 
-	bool m_bChoosingFreeTech;
+	int m_iChoosingFreeTech;
 
 	PlayerTypes m_eID;
 	LeaderHeadTypes m_ePersonalityType;


### PR DESCRIPTION
https://github.com/caveman2cosmos/Caveman2Cosmos/issues/312
fix #312

Just needed a count of outstanding free techs to select.
The thing breaking it looks like some very old code to stop people selecting the free tech over and over.  