### PR TITLE
CI: Enable commit tests to be run on PRs

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,5 +1,5 @@
 name: Commit jobs
-on: push
+on: [push, pull_request]
 jobs:
     pylint:
         name: Linting - Pylint


### PR DESCRIPTION
Since commit `988d258110af5268cc2f66047f8c1e1262f8ad44` commit tests are
now run when pushed inside the repo, but PRs from forked repos does not
trigger a run. This is problematic when accepting PRs from outside the
repo, potential errors will only be discovered after merging, which is
bad.

By adding the trigger `pull_request`, all PRs to any branches in the
repo, will trigger a Github Actions run.