### PR TITLE
CI: Downgrade to Ubuntu 18.04 to avoid get-pip

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -18,7 +18,7 @@ jobs:
                       --rm \
                       --interactive \
                       --volume ${{ github.workspace }}:/host_dir \
-                      --workdir /host_dir ubuntu:20.04 \
+                      --workdir /host_dir ubuntu:18.04 \
                       bash -c \
                       "./Tools/Lint/setup.sh && python3 Tools/Lint/pylint.py --python-versions ${{ matrix.python-version }}"
     python-unit-tests:
@@ -35,6 +35,6 @@ jobs:
                       --rm \
                       --interactive \
                       --volume ${{ github.workspace }}:/host_dir \
-                      --workdir /host_dir ubuntu:20.04 \
+                      --workdir /host_dir ubuntu:18.04 \
                       bash -c \
                       "./Test/Python3/setup.sh && pytest -c Test/Python3/pytest.ini ."

--- a/Tools/Lint/setup.sh
+++ b/Tools/Lint/setup.sh
@@ -11,22 +11,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 apt-get --quiet --assume-yes update || exit $?
 
 apt-get --quiet --assume-yes install \
-    curl \
-    python2 \
+    python2.7 \
+    python-pip \
     python3 \
     python3-pip ||
     exit $?
-
-TEMP_DIR=$(mktemp --tmpdir --directory install-pip-for-python-2-XXXX) || exit $?
-
-cd "$TEMP_DIR" || exit $?
-
-GET_PIP_SCRIPT="get-pip.py"
-
-curl https://bootstrap.pypa.io/get-pip.py --output "$GET_PIP_SCRIPT" || exit $?
-python2 "$GET_PIP_SCRIPT" || exit $?
-
-cd - || exit $?
-rm --recursive "$TEMP_DIR" || exit $?
 
 echo "Setup finished"


### PR DESCRIPTION
There have been a recent update to the `get-pip.py` script for
installing `pip` for python 2.7. This updated causes installing pip to
fail with the following error message:
```
Traceback (most recent call last):
  File "get-pip.py", line 24226, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpG8aJb5/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```

This commit downgrades the Ubuntu version from 20.04 to 18.04 to avoid
using this script. Ubuntu 18.04 can install pip from the default repo,
avoiding `get-pip.py` entirely.

Another benefit is that it simplifies the setup script as well.