### PR TITLE
CI: Run XMLValidator in Github Actions

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -38,3 +38,15 @@ jobs:
                       --workdir /host_dir ubuntu:18.04 \
                       bash -c \
                       "./Test/Python3/setup.sh && pytest -c Test/Python3/pytest.ini ."
+    validate-xmls:
+        name: Validate XMLs
+        runs-on: windows-2019
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v2
+              with:
+                  lfs: true
+            - name: Run XmlValidator
+              working-directory: ${{ github.workspace }}/Tools
+              run: |
+                  ${{ github.workspace }}/Tools/XmlValidator.exe -a


### PR DESCRIPTION
Since knowing that all XMLs are valid is critical for a successful
build, all of the XMLs in the repo are now checked on each push/PR to
the repo from the outside.

Hopefully this will make it easier for external contributors to know
that their XMLs are valid before a potential merge. The reason for this
is that although the validator is currently run in `Appveyor` today, it
is not easy to replicate the setup for getting `Appveyor` to run on a
forked repo. With `Github Actions`, all of this is handled for the user.

One drawback with this approach is that with this commit merged the
validation is run twice. But the benefit of reducing the chance of
breaking master should outweigh this drawback.