### PR TITLE
switched a loop for unit build types to foreach_

### DIFF
--- a/Sources/CvInfos.h
+++ b/Sources/CvInfos.h
@@ -2244,9 +2244,10 @@ public:
 
 	bool isPrereqOrCivics(int i) const;
 
-	int getBuild(int i) const;
+	const std::vector<BuildTypes>& getBuilds() const { return m_workerBuilds; }
+	BuildTypes getBuild(int i) const;
 	short getNumBuilds() const;
-	bool hasBuild(int i) const;
+	bool hasBuild(BuildTypes e) const;
 
 	int getPrereqAndBuilding(int i) const;
 	int getNumPrereqAndBuildings() const;
@@ -2408,7 +2409,7 @@ protected:
 	int m_iPrereqAndTech;
 	int m_iPrereqAndBonus;
 
-	std::vector<int> m_workerBuilds;
+	std::vector<BuildTypes> m_workerBuilds;
 	std::vector<int> m_aiPrereqAndBuildings;
 	std::vector<int> m_aiPrereqOrBuildings;
 

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -10186,7 +10186,7 @@ int CvPlayer::getImprovementUpgradeRateModifier() const
 
 void CvPlayer::changeImprovementUpgradeRateModifier(int iChange)
 {
-	m_iImprovementUpgradeRateModifier = (m_iImprovementUpgradeRateModifier + iChange);
+	m_iImprovementUpgradeRateModifier += iChange;
 }
 
 
@@ -10198,7 +10198,7 @@ int CvPlayer::getMilitaryProductionModifier() const
 
 void CvPlayer::changeMilitaryProductionModifier(int iChange)
 {
-	m_iMilitaryProductionModifier = (m_iMilitaryProductionModifier + iChange);
+	m_iMilitaryProductionModifier += iChange;
 }
 
 
@@ -10210,7 +10210,7 @@ int CvPlayer::getSpaceProductionModifier() const
 
 void CvPlayer::changeSpaceProductionModifier(int iChange)
 {
-	m_iSpaceProductionModifier = (m_iSpaceProductionModifier + iChange);
+	m_iSpaceProductionModifier += iChange;
 }
 
 
@@ -10222,17 +10222,13 @@ int CvPlayer::getCityDefenseModifier() const
 
 void CvPlayer::changeCityDefenseModifier(int iChange)
 {
-	m_iCityDefenseModifier = (m_iCityDefenseModifier + iChange);
+	m_iCityDefenseModifier += iChange;
 }
 
 
 bool CvPlayer::isNonStateReligionCommerce() const
 {
-	if (m_iNonStateReligionCommerceCount > 0)
-	{
-		return true;
-	}
-	return false;
+	return m_iNonStateReligionCommerceCount > 0;
 }
 
 void CvPlayer::changeNonStateReligionCommerce(int iNewValue)
@@ -10250,11 +10246,7 @@ void CvPlayer::changeNonStateReligionCommerce(int iNewValue)
 
 bool CvPlayer::isUpgradeAnywhere() const
 {
-	if(m_iUpgradeAnywhereCount > 0)
-	{
-		return true;
-	}
-	return false;
+	return m_iUpgradeAnywhereCount > 0;
 }
 
 void CvPlayer::changeUpgradeAnywhere(int iNewValue)

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -17091,9 +17091,7 @@ CvPlot* CvUnit::plot() const
 {
 	//FAssertMsg(isInViewport(), "Can't get plot of unit that is not in the viewport");
 	//FAssertMsg(!isUsingDummyEntities(), "Can't get plot of unit that is using dummy entities");
-	CvPlot* plot = GC.getMap().plotSorenINLINE(getX(), getY());
-	FAssert(plot != NULL);
-	return plot;
+	return GC.getMap().plotSorenINLINE(getX(), getY());
 }
 
 CvPlot* CvUnit::plotExternal() const

--- a/Sources/CvUnit.h
+++ b/Sources/CvUnit.h
@@ -909,7 +909,9 @@ public:
 
 	bool isAnimal() const;
 	bool isNoBadGoodies() const;
+
 	bool isOnlyDefensive() const;
+	void changeOnlyDefensiveCount(int iChange);
 
 	bool hasRBombardForceAbility() const;
 	int getRBombardForceAbilityCount() const;
@@ -1803,7 +1805,7 @@ protected:
 	int m_iDCMBombRange;
 	int m_iDCMBombAccuracy;
 	int m_iHealUnitCombatCount;
-	std::vector<int> m_aiExtraBuildTypes;
+	std::vector<BuildTypes> m_aeExtraBuildTypes;
 
 	DomainTypes m_eNewDomainCargo;
 	SpecialUnitTypes m_eNewSpecialCargo;
@@ -2832,33 +2834,27 @@ public:
 	void processLoadedSpecialUnit(bool bChange, SpecialUnitTypes eSpecialUnit);
 
 	bool hasBuild(BuildTypes eBuild) const;
-	bool isExtraBuild(BuildTypes eBuild) const;
-	int getExtraBuildType(int i) const;
-	int getNumExtraBuildTypes() const;
+	//bool isExtraBuild(BuildTypes eBuild) const;
+	//BuildTypes getExtraBuildType(int i) const;
+	//int getNumExtraBuildTypes() const;
 	void changeExtraBuildType(bool bChange, BuildTypes eBuild);
 
 	bool isExcile() const;
-	int getExcileCount() const;
 	void changeExcileCount(int iChange);
 
 	bool isPassage() const;
-	int getPassageCount() const;
 	void changePassageCount(int iChange);
 
 	bool isNoNonOwnedCityEntry() const;
-	int getNoNonOwnedCityEntryCount() const;
 	void changeNoNonOwnedCityEntryCount(int iChange);
 
 	bool isBarbCoExist() const;
-	int getBarbCoExistCount() const;
 	void changeBarbCoExistCount(int iChange);
 
 	bool isBlendIntoCity() const;
-	int getBlendIntoCityCount() const;
 	void changeBlendIntoCityCount(int iChange);
 
 	bool isUpgradeAnywhere() const;
-	int getUpgradeAnywhereCount() const;
 	void changeUpgradeAnywhereCount(int iChange);
 
 	bool hasVisibilityType(InvisibleTypes eInvisibleType) const;
@@ -2984,9 +2980,6 @@ public:
 
 	void reveal();
 	bool isRevealed() const;
-
-	int getOnlyDefensiveCount() const;
-	void changeOnlyDefensiveCount(int iChange);
 
 	void doSetDefaultStatuses();
 

--- a/Sources/CvUnitInfo.cpp
+++ b/Sources/CvUnitInfo.cpp
@@ -1243,7 +1243,7 @@ bool CvUnitInfo::isPrereqOrCivics(int i) const
 }
 
 
-int CvUnitInfo::getBuild(int i) const
+BuildTypes CvUnitInfo::getBuild(int i) const
 {
 	return m_workerBuilds[i];
 }
@@ -1251,9 +1251,9 @@ short CvUnitInfo::getNumBuilds() const
 {
 	return m_workerBuilds.size();
 }
-bool CvUnitInfo::hasBuild(int i) const
+bool CvUnitInfo::hasBuild(BuildTypes e) const
 {
-	return find(m_workerBuilds.begin(), m_workerBuilds.end(), i) != m_workerBuilds.end();
+	return algo::contains(m_workerBuilds, e);
 }
 
 int CvUnitInfo::getNumPrereqAndBuildings() const


### PR DESCRIPTION
Matt: this loop
// Toffer - ToDo
//	- Should limit loop to only UnitInfo builds and the extra builds for this unit.
//	- Both are vectors and are both referenced in the CvUnit::hasBuild() function.

Matt: switched this to a boost function, but it's probly not much faster.
// Toffer - This can't be faster than just doing an erase of the element with the build id; can it?