### PR TITLE
Rework nonfatal asset removal warning

### DIFF
--- a/Assets/XML/GameText/PopUp_CIV4GameText.xml
+++ b/Assets/XML/GameText/PopUp_CIV4GameText.xml
@@ -170,6 +170,15 @@
 		<Russian>«Максимальная совместимость» позволяет загружать сохраненные игры в более поздние версии мода (в большинстве случаев), но с ней несколько дольше и медленнее загружаются старые сохранения. В настоящее время эта функция находится в стадии бета-версии.[NEWLINE]"Оригинальный BTS" - это формат сохранения, который ранее использовался в классической Civ4. Он более компактен и загружается немного быстрее стары сохранения, но обычно не поддерживает загрузку игры между новыми версиями мода.</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_POPUP_NON_FATAL_FORMAT_LOAD_ERROR</Tag>
+		<English>Non-fatal load warning</English>
+		<French>Avertissement Non-fatal</French>
+		<Italian>Avviso di caricamento non fatale</Italian>
+		<Polish>Nie-krytyczne ostrzeżenie wczytywania</Polish>
+		<Spanish>Error no crítico al cargar</Spanish>
+		<Russian>Предупреждение о некритической ошибке в загрузке</Russian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_POPUP_OLD_GAME_SAVE_FORMAT</Tag>
 		<English>Original BTS</English>
 		<Italian>BTS originale</Italian>

--- a/Sources/CvDLLButtonPopup.cpp
+++ b/Sources/CvDLLButtonPopup.cpp
@@ -720,6 +720,9 @@ void CvDLLButtonPopup::OnOkClicked(CvPopup* pPopup, PopupReturn *pPopupReturn, C
 		}
 		break;
 
+	case BUTTONPOPUP_SAVE_INFO_LOST:
+		break;
+
 	case BUTTONPOPUP_MODIFIER_RECALCULATION:
 		{
 			if (1 == pPopupReturn->getButtonClicked())
@@ -1121,6 +1124,10 @@ bool CvDLLButtonPopup::launchButtonPopup(CvPopup* pPopup, CvPopupInfo &info)
 		case BUTTONPOPUP_GET_SAVE_FORMAT:
 		{
 			return launchGetSaveFormatPopup(pPopup, info);
+		}
+		case BUTTONPOPUP_SAVE_INFO_LOST:
+		{
+			return launchGetSaveInfoLostPopup(pPopup, info);
 		}
 		case BUTTONPOPUP_MODIFIER_RECALCULATION:
 		{
@@ -2892,6 +2899,18 @@ bool CvDLLButtonPopup::launchGetSaveFormatPopup(CvPopup* pPopup, CvPopupInfo &in
 	gDLL->getInterfaceIFace()->popupAddGenericButton(pPopup, gDLL->getText("TXT_KEY_POPUP_NEW_GAME_SAVE_FORMAT").c_str(), NULL, 1, WIDGET_GENERAL);
 
 	gDLL->getInterfaceIFace()->popupLaunch(pPopup, false, POPUPSTATE_IMMEDIATE);
+	return true;
+}
+
+bool CvDLLButtonPopup::launchGetSaveInfoLostPopup(CvPopup* pPopup, CvPopupInfo &info)
+{
+	CvWString szBuffer = gDLL->getText("TXT_KEY_POPUP_NON_FATAL_FORMAT_LOAD_ERROR");
+
+	gDLL->getInterfaceIFace()->popupSetHeaderString(pPopup, szBuffer);
+
+	gDLL->getInterfaceIFace()->popupSetBodyString(pPopup, info.getText());
+
+	gDLL->getInterfaceIFace()->popupLaunch(pPopup);
 	return true;
 }
 

--- a/Sources/CvDLLButtonPopup.h
+++ b/Sources/CvDLLButtonPopup.h
@@ -64,20 +64,12 @@ private:
 	bool launchFreeColonyPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchLaunchPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchFoundReligionPopup(CvPopup* pPopup, CvPopupInfo &info);
-	//	Koshling - added to allow user to choose game save format
 	bool launchGetSaveFormatPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchGetSaveInfoLostPopup(CvPopup* pPopup, CvPopupInfo &info);
-	// AIAndy - added to recommend modifier recalculation
 	bool launchModifierRecalculationPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchNameListPopup(CvPopup* pPopup, CvPopupInfo &info);
-	// ls612: Added City Go-To popup.
 	bool launchGoToCityPopup(CvPopup* pPopup, CvPopupInfo &info);
 
-/************************************************************************************************/
-/* Afforess	                  Start		 09/19/10                                               */
-/*                                                                                              */
-/*                                                                                              */
-/************************************************************************************************/
 	bool invasionPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchSelectShadowUnitPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchSelectDiscoveryTechPopup(CvPopup* pPopup, CvPopupInfo &info);

--- a/Sources/CvDLLButtonPopup.h
+++ b/Sources/CvDLLButtonPopup.h
@@ -64,11 +64,20 @@ private:
 	bool launchFreeColonyPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchLaunchPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchFoundReligionPopup(CvPopup* pPopup, CvPopupInfo &info);
+	//	Koshling - added to allow user to choose game save format
 	bool launchGetSaveFormatPopup(CvPopup* pPopup, CvPopupInfo &info);
+	bool launchGetSaveInfoLostPopup(CvPopup* pPopup, CvPopupInfo &info);
+	// AIAndy - added to recommend modifier recalculation
 	bool launchModifierRecalculationPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchNameListPopup(CvPopup* pPopup, CvPopupInfo &info);
+	// ls612: Added City Go-To popup.
 	bool launchGoToCityPopup(CvPopup* pPopup, CvPopupInfo &info);
 
+/************************************************************************************************/
+/* Afforess	                  Start		 09/19/10                                               */
+/*                                                                                              */
+/*                                                                                              */
+/************************************************************************************************/
 	bool invasionPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchSelectShadowUnitPopup(CvPopup* pPopup, CvPopupInfo &info);
 	bool launchSelectDiscoveryTechPopup(CvPopup* pPopup, CvPopupInfo &info);

--- a/Sources/CvEnums.h
+++ b/Sources/CvEnums.h
@@ -633,6 +633,7 @@ enum ButtonPopupTypes
 /* Afforess	                     END                                                            */
 /************************************************************************************************/
 	BUTTONPOPUP_GET_SAVE_FORMAT,	//	Koshling - user choose save format dialog
+	BUTTONPOPUP_SAVE_INFO_LOST,		//	Non-fatal warning that some entities could not be instantiated
 
 	BUTTONPOPUP_MODIFIER_RECALCULATION,  // Ask user if he wants to recalculated modifiers when DLL or assets have changed
 	BUTTONPOPUP_NAME_LIST,

--- a/Sources/CvTaggedSaveFormatWrapper.cpp
+++ b/Sources/CvTaggedSaveFormatWrapper.cpp
@@ -3976,6 +3976,16 @@ CvTaggedSaveFormatWrapper::close()
 {
 	if ( m_inUse )
 	{
+		foreach_(const CvWString& it, m_warnings)
+		{
+			CvPopupInfo* pInfo = new CvPopupInfo(BUTTONPOPUP_SAVE_INFO_LOST);
+			if (NULL != pInfo)
+			{
+				pInfo->setText(it.c_str());
+				gDLL->getInterfaceIFace()->addPopup(pInfo);
+			}
+		}
+
 		reset(false);
 
 		m_inUse = false;


### PR DESCRIPTION
Make it less confusing for players.
Maybe limit it to assert/debug DLL types - players themselves doesn't need to see it.
Or output it to XML log.
Make it scrollable instead of requiring clicking multiple times

HandleRecoverableIncompatibleSave in CvTaggedSaveFormatWrapper.cpp on line 3179 contains message itself