### PR TITLE
added default AI yield weight values to c2c ini file

### DIFF
--- a/Caveman2Cosmos.ini
+++ b/Caveman2Cosmos.ini
@@ -33,3 +33,11 @@ Name = Caveman2Cosmos
 
 ; Description of Mod
 Description = Total Conversion
+
+[AI]
+
+FoodWeight = 18
+
+ProductionWeight = 10
+
+CommerceWeight = 6

--- a/Sources/CvGlobals.cpp
+++ b/Sources/CvGlobals.cpp
@@ -20,6 +20,7 @@
 #include "CyGlobalContext.h"
 #include "FVariableSystem.h"
 #include "CvImprovementInfo.h"
+#include "OutputRatios.h"
 #include <time.h>
 #include <sstream>
 
@@ -117,13 +118,6 @@ cvInternalGlobals::cvInternalGlobals()
 	, m_statsReporter(NULL)
 	, m_diplomacyScreen(NULL)
 	, m_mpDiplomacyScreen(NULL)
-	//, m_pathFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_interfacePathFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_stepFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_routeFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_borderFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_areaFinders(bst::array<FAStar*, NUM_MAPS>())
-	//, m_plotGroupFinders(bst::array<FAStar*, NUM_MAPS>())
 	, m_aiPlotDirectionX(NULL)
 	, m_aiPlotDirectionY(NULL)
 	, m_aiPlotCardinalDirectionX(NULL)
@@ -423,6 +417,8 @@ void cvInternalGlobals::init()
 	CvPlayerAI::initStatics();
 	CvTeamAI::initStatics();
 	CyGlobalContext::initStatics();
+
+	OutputRatios::readDefaultWeightsFromIniFile();
 
 	COPY(m_aiPlotDirectionX, aiPlotDirectionX, int);
 	COPY(m_aiPlotDirectionY, aiPlotDirectionY, int);

--- a/Sources/OutputRatios.cpp
+++ b/Sources/OutputRatios.cpp
@@ -1,8 +1,17 @@
+#include "CvGameCoreDLL.h"
+#include "CvDLLIniParserIFaceBase.h"
 #include "OutputRatios.h"
 
 #include <algorithm>
 #include <string>
 
+YieldArray OutputRatios::default_weight = { 18, 10, 6 };
+
+OutputRatios::OutputRatios()
+	: food_ratio(default_weight[YIELD_FOOD])
+	, production_ratio(default_weight[YIELD_PRODUCTION])
+	, commerce_ratio(default_weight[YIELD_COMMERCE])
+{}
 OutputRatios::OutputRatios(const int food, const int production, const int commerce)
 {
 	const int totalOutput = std::max(1, food + production + commerce);
@@ -13,21 +22,21 @@ OutputRatios::OutputRatios(const int food, const int production, const int comme
 }
 void OutputRatios::WeightOutputs(const int foodWeight, const int productionWeight, const int commerceWeight)
 {
-	food_ratio = food_ratio * foodWeight;
-	production_ratio = production_ratio * productionWeight;
-	commerce_ratio = commerce_ratio * commerceWeight;
+	food_ratio *= foodWeight;
+	production_ratio *= productionWeight;
+	commerce_ratio *= commerceWeight;
 }
 void OutputRatios::WeightFood(const int foodWeight)
 {
-	food_ratio = food_ratio * foodWeight;
+	food_ratio *= foodWeight;
 }
 void OutputRatios::WeightProduction(const int productionWeight)
 {
-	production_ratio = production_ratio * productionWeight;
+	production_ratio *= productionWeight;
 }
 void OutputRatios::WeightCommerce(const int commerceWeight)
 {
-	commerce_ratio = commerce_ratio * commerceWeight;
+	commerce_ratio *= commerceWeight;
 }
 
 int OutputRatios::CalculateOutputValue(const int food, const int production, const int commerce) const
@@ -35,3 +44,24 @@ int OutputRatios::CalculateOutputValue(const int food, const int production, con
 	return (food_ratio * food) + (production_ratio * production) + (commerce_ratio * commerce);
 }
 
+void OutputRatios::readDefaultWeightsFromIniFile()
+{
+	CvDLLIniParserIFaceBase* parserIFace = gDLL->getIniParserIFace();
+
+	FIniParser* parser = parserIFace->create((getModDir() + "/Caveman2Cosmos.ini").c_str());
+	FAssert(parser != NULL);
+
+	const bool bSectionSet = parserIFace->SetGroupKey(parser, "AI");
+	FAssertMsg(bSectionSet, "Ini file section not found: AI");
+
+	const bool bFoodSet = parserIFace->GetKeyValue(parser, "FoodWeight", &default_weight[YIELD_FOOD]);
+	FAssertMsg(bFoodSet, "Ini file option not found: FoodWeight");
+
+	const bool bProductionSet = parserIFace->GetKeyValue(parser, "ProductionWeight", &default_weight[YIELD_PRODUCTION]);
+	FAssertMsg(bProductionSet, "Ini file option not found: ProductionWeight");
+
+	const bool bCommerceSet = parserIFace->GetKeyValue(parser, "CommerceWeight", &default_weight[YIELD_COMMERCE]);
+	FAssertMsg(bCommerceSet, "Ini file option not found: CommerceWeight");
+
+	parserIFace->destroy(parser);
+}

--- a/Sources/OutputRatios.h
+++ b/Sources/OutputRatios.h
@@ -4,15 +4,19 @@
 #define CIV_OUTPUTRATIOS_H
 struct OutputRatios
 {
+	OutputRatios();
 	OutputRatios(int food, int production, int commerce);
 	void WeightOutputs(int foodWeight, int productionWeight, int commerceWeight);
 	void WeightFood(int foodWeight);
 	void WeightProduction(int productionWeight);
 	void WeightCommerce(int commerceWeight);
 	int CalculateOutputValue(int food, int production, int commerce) const;
+	static void readDefaultWeightsFromIniFile();
 	int food_ratio;
 	int production_ratio;
 	int commerce_ratio;
+private:
+	static YieldArray default_weight;
 };
 
 #endif


### PR DESCRIPTION
You can use the OutputRatios constructor with no parameters to start with defaults.
Feel free to change or delete this stuff.
The ini file probably needs some comments.