### PR TITLE
City culture plot cache

### DIFF
--- a/Assets/XML/A_New_Dawn_GlobalDefines.xml
+++ b/Assets/XML/A_New_Dawn_GlobalDefines.xml
@@ -120,7 +120,7 @@
 	</Define>
 	<Define>
 		<DefineName>PEAK_EXTRA_MOVEMENT</DefineName>
-		<iDefineIntVal>3</iDefineIntVal>
+		<iDefineIntVal>2</iDefineIntVal> <!-- Applied on top of base 3 cost if lacking bMoveFastPeaks tech -->
 	</Define>
 	<Define>
 		<DefineName>PEAK_BUILD_TIME_MODIFIER</DefineName>

--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -1477,11 +1477,11 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ACTION_NEEDS_CULTURE_BORDER</Tag>
-		<English>[COLOR_WARNING_TEXT]Must be within our Cultural Borders.[COLOR_REVERT]</English>
-		<French>[COLOR_WARNING_TEXT]Uniquement à l'intérieur de nos frontières culturelles.[COLOR_REVERT]</French>
-		<German>[COLOR_WARNING_TEXT]Muss sich innerhalb unserer kulturellen Grenzen befinden.[COLOR_REVERT]</German>
-		<Italian>[COLOR_WARNING_TEXT]Bisogna essere all'interno dei propri confini culturali.[COLOR_REVERT]</Italian>
-		<Spanish>[COLOR_WARNING_TEXT]Ha de estar dentro de las fronteras de nuestra cultura.[COLOR_REVERT]</Spanish>
+		<English>[COLOR_WARNING_TEXT]Must be within Cultural Borders owned by of one of our cities.[COLOR_REVERT]</English>
+		<!-- <French>[COLOR_WARNING_TEXT]Uniquement à l'intérieur de nos frontières culturelles.[COLOR_REVERT]</French> -->
+		<!-- <German>[COLOR_WARNING_TEXT]Muss sich innerhalb unserer kulturellen Grenzen befinden.[COLOR_REVERT]</German> -->
+		<!-- <Italian>[COLOR_WARNING_TEXT]Bisogna essere all'interno dei propri confini culturali.[COLOR_REVERT]</Italian> -->
+		<!-- <Spanish>[COLOR_WARNING_TEXT]Ha de estar dentro de las fronteras de nuestra cultura.[COLOR_REVERT]</Spanish> -->
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ACTION_NEEDS_OUT_RIVAL_CULTURE_BORDER</Tag>

--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -15734,6 +15734,10 @@
 		<Russian>Âëàäåëåö</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_MISC_NO_CITY_INFLUENCE</Tag>
+		<English>Not in %s1_CivAdj city influence.</English>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_MISC_PEACE_TREATY</Tag>
 		<English>Peace Treaty (%d1_Num Turns)</English>
 		<French>Traité de paix (%d1_Num tours)</French>

--- a/Assets/XML/Technologies/CIV4TechInfos.xml
+++ b/Assets/XML/Technologies/CIV4TechInfos.xml
@@ -5558,7 +5558,6 @@
 			<Era>C2C_ERA_ANCIENT</Era>
 			<iAsset>24</iAsset>
 			<bTrade>1</bTrade>
-			<bIrrigation>1</bIrrigation>
 			<iGridX>26</iGridX>
 			<iGridY>7</iGridY>
 			<Flavors>
@@ -11268,7 +11267,6 @@
 			<Sound>AS2D_TECH_CARTOGRAPHY</Sound>
 			<SoundMP>AS2D_TECH_CARTOGRAPHY</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/Mapmaking.dds</Button>
-			<bMoveFastPeaks>1</bMoveFastPeaks>
 		</TechInfo>
 		<TechInfo>
 			<Type>TECH_CHARTERS</Type>
@@ -12698,6 +12696,7 @@
 			<Sound>AS2D_TECH_COLONIALISM</Sound>
 			<SoundMP>AS2D_TECH_COLONIALISM</SoundMP>
 			<Button>Art/Interface/Buttons/TechTree/colonialism.dds</Button>
+			<bMoveFastPeaks>1</bMoveFastPeaks>
 		</TechInfo>
 		<TechInfo>
 			<Type>TECH_WEATHER_FORECASTING</Type>

--- a/Assets/XML/Terrain/CIV4FeatureInfos.xml
+++ b/Assets/XML/Terrain/CIV4FeatureInfos.xml
@@ -235,7 +235,7 @@
 			<EffectType>EFFECT_BIRDSCATTER</EffectType>
 			<iEffectProbability>15</iEffectProbability>
 			<iAdvancedStartRemoveCost>40</iAdvancedStartRemoveCost>
-			<iCultureDistance>3</iCultureDistance>
+			<iCultureDistance>2</iCultureDistance>
 			<PropertyManipulators>
 				<PropertySource>
 					<PropertySourceType>PROPERTYSOURCE_CONSTANT</PropertySourceType>
@@ -1955,7 +1955,7 @@
 				</FootstepSound>
 			</FootstepSounds>
 			<WorldSoundscapeAudioScript>ASSS_OASIS_SELECT_AMB</WorldSoundscapeAudioScript>
-			<iCultureDistance>2</iCultureDistance>
+			<iCultureDistance>1</iCultureDistance>
 			<PropertyManipulators>
 				<PropertySource>
 					<PropertySourceType>PROPERTYSOURCE_CONSTANT</PropertySourceType>
@@ -2596,7 +2596,7 @@
 				</FootstepSound>
 			</FootstepSounds>
 			<GrowthSound>NONE</GrowthSound>
-			<iCultureDistance>2</iCultureDistance>
+			<iCultureDistance>1</iCultureDistance>
 			<PropertyManipulators>
 				<PropertySource>
 					<PropertySourceType>PROPERTYSOURCE_CONSTANT</PropertySourceType>
@@ -5844,6 +5844,7 @@
 			<iAppearance>-1</iAppearance>
 			<bNoCity>1</bNoCity>
 			<bNukeImmune>1</bNukeImmune>
+			<bIgnoreTerrainCulture>1</bIgnoreTerrainCulture>
 			<TerrainBooleans>
 				<TerrainBoolean>
 					<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>

--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -8741,7 +8741,7 @@
 			<iAdvancedStartCost>50</iAdvancedStartCost>
 			<bOutsideBorders>1</bOutsideBorders>
 			<iCulture>30</iCulture>
-			<iCultureRange>1<iCultureRange>
+			<iCultureRange>1</iCultureRange>
 			<TechYieldChanges>
 				<TechYieldChange>
 					<PrereqTech>TECH_WIRELESS_ELECTRICITY</PrereqTech>

--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -8740,6 +8740,8 @@
 			<bPeakImprovement>1</bPeakImprovement>
 			<iAdvancedStartCost>50</iAdvancedStartCost>
 			<bOutsideBorders>1</bOutsideBorders>
+			<iCulture>30</iCulture>
+			<iCultureRange>1<iCultureRange>
 			<TechYieldChanges>
 				<TechYieldChange>
 					<PrereqTech>TECH_WIRELESS_ELECTRICITY</PrereqTech>
@@ -9672,7 +9674,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
-			<iCulture>10</iCulture>
+			<iCulture>20</iCulture>
 			<iVisibilityChange>4</iVisibilityChange>
 			<iSeeFrom>2</iSeeFrom>
 			<iUniqueRange>0</iUniqueRange>
@@ -9762,7 +9764,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
-			<iCulture>4</iCulture>
+			<iCulture>10</iCulture>
 			<ImprovementPillage>IMPROVEMENT_STONE_WATCHTOWER</ImprovementPillage>
 			<ImprovementUpgrade>IMPROVEMENT_RADAR_TOWER</ImprovementUpgrade>
 			<iVisibilityChange>3</iVisibilityChange>
@@ -9854,7 +9856,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
-			<iCulture>2</iCulture>
+			<iCulture>4</iCulture>
 			<ImprovementPillage>IMPROVEMENT_WOODEN_WATCHTOWER</ImprovementPillage>
 			<ImprovementUpgrade>IMPROVEMENT_STEEL_WATCHTOWER</ImprovementUpgrade>
 			<iVisibilityChange>2</iVisibilityChange>
@@ -9947,7 +9949,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
-			<iCulture>1</iCulture>
+			<iCulture>2</iCulture>
 			<ImprovementUpgrade>IMPROVEMENT_STONE_WATCHTOWER</ImprovementUpgrade>
 			<iVisibilityChange>1</iVisibilityChange>
 			<iUniqueRange>0</iUniqueRange>

--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -10267,6 +10267,7 @@
 			<iUniqueRange>2</iUniqueRange>
 			<bBombardable>1</bBombardable>
 			<bUpgradeRequiresFortify>1</bUpgradeRequiresFortify>
+			<bIsUniversalTradeBonusProvider>1</bIsUniversalTradeBonusProvider>
 		</ImprovementInfo>
 		<!-- Fortified Cave -> Fortified Cave w/Cache -->
 		<!-- Kill Switchpoint: Sedentary Lifestyle -->
@@ -10294,6 +10295,8 @@
 			<iUniqueRange>2</iUniqueRange>
 			<bBombardable>1</bBombardable>
 			<bUpgradeRequiresFortify>1</bUpgradeRequiresFortify>
+			<bIsUniversalTradeBonusProvider>1</bIsUniversalTradeBonusProvider>
+			<!-- Trade provider technically necessary otherwise players would need to build palisades on caves tiles w/resources -->
 		</ImprovementInfo>
 		<!-- Palisade -> Fort -->
 		<!-- Kill Switchpoint: Sedentary Lifestyle -->
@@ -10386,6 +10389,7 @@
 			<iUniqueRange>2</iUniqueRange>
 			<bBombardable>1</bBombardable>
 			<bUpgradeRequiresFortify>1</bUpgradeRequiresFortify>
+			<bIsUniversalTradeBonusProvider>1</bIsUniversalTradeBonusProvider>
 		</ImprovementInfo>
 		<!-- Abatis -> Palisade -->
 		<ImprovementInfo>

--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -7493,6 +7493,8 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
+			<iCulture>40</iCulture>
+			<iCultureRange>2</iCultureRange>
 			<ImprovementPillage>IMPROVEMENT_TOWN</ImprovementPillage>
 			<TechYieldChanges>
 				<TechYieldChange>
@@ -7658,6 +7660,8 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
+			<iCulture>20</iCulture>
+			<iCultureRange>1</iCultureRange>
 			<ImprovementPillage>IMPROVEMENT_VILLAGE</ImprovementPillage>
 			<ImprovementUpgrade>IMPROVEMENT_SUBURBS</ImprovementUpgrade>
 			<TechYieldChanges>
@@ -7804,6 +7808,8 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
+			<iCulture>10</iCulture>
+			<iCultureRange>1</iCultureRange>
 			<ImprovementPillage>IMPROVEMENT_HAMLET</ImprovementPillage>
 			<ImprovementUpgrade>IMPROVEMENT_TOWN</ImprovementUpgrade>
 			<TechYieldChanges>
@@ -7940,6 +7946,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
+			<iCulture>5</iCulture>
 			<ImprovementPillage>IMPROVEMENT_COTTAGE</ImprovementPillage>
 			<ImprovementUpgrade>IMPROVEMENT_VILLAGE</ImprovementUpgrade>
 			<TechYieldChanges>
@@ -7995,6 +8002,7 @@
 					<bMakesValid>1</bMakesValid>
 				</TerrainMakesValid>
 			</TerrainMakesValids>
+			<iCulture>2</iCulture>
 			<ImprovementUpgrade>IMPROVEMENT_HAMLET</ImprovementUpgrade>
 		</ImprovementInfo>
 		<!-- Manufacturing Complex | End -->

--- a/Assets/XML/Terrain/CIV4TerrainInfos.xml
+++ b/Assets/XML/Terrain/CIV4TerrainInfos.xml
@@ -5811,7 +5811,7 @@
 			<ArtDefineTag>ART_DEF_TERRAIN_HILL</ArtDefineTag>
 			<bWaterTerrain>1</bWaterTerrain>
 			<iBuildModifier>25</iBuildModifier>
-			<iCultureDistance>2</iCultureDistance> <!-- dll increases penalty 1 for missing bCanFoundOnPeaks -->
+			<iCultureDistance>1</iCultureDistance> <!-- dll increases penalty 1 for missing: bBridgeBuilding, bCanFoundOnPeaks -->
 			<iMovement>1</iMovement>
 			<Button>Art/Interface\Buttons\WorldBuilder\Terrain_Hill.dds</Button>
 			<FootstepSounds>

--- a/Assets/XML/Terrain/CIV4TerrainInfos.xml
+++ b/Assets/XML/Terrain/CIV4TerrainInfos.xml
@@ -729,7 +729,7 @@
 			<ArtDefineTag>ART_DEF_TERRAIN_BADLAND</ArtDefineTag>
 			<bFound>1</bFound>
 			<iBuildModifier>75</iBuildModifier>
-			<iCultureDistance>2</iCultureDistance>
+			<iCultureDistance>1</iCultureDistance>
 			<iDefense>20</iDefense>
 			<iHealthPercent>-15</iHealthPercent>
 			<iMovement>2</iMovement>
@@ -1887,7 +1887,7 @@
 			<Civilopedia>TXT_KEY_TERRAIN_PERMAFROST_PEDIA</Civilopedia>
 			<bFound>1</bFound>
 			<iBuildModifier>55</iBuildModifier>
-			<iCultureDistance>2</iCultureDistance>
+			<iCultureDistance>3</iCultureDistance>
 			<iHealthPercent>-25</iHealthPercent>
 			<iMovement>3</iMovement>
 			<FootstepSounds>
@@ -2028,7 +2028,7 @@
 			<bFoundCoast>1</bFoundCoast>
 			<bFoundFreshWater>1</bFoundFreshWater>
 			<iBuildModifier>100</iBuildModifier>
-			<iCultureDistance>3</iCultureDistance>
+			<iCultureDistance>4</iCultureDistance>
 			<iHealthPercent>-50</iHealthPercent>
 			<iMovement>4</iMovement>
 			<Button>Art/Interface\Buttons\WorldBuilder\Terrain_Ice.dds</Button>

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -16124,7 +16124,7 @@ void CvCity::doPlotCulture(PlayerTypes ePlayer, int iCultureRate)
 
 		if (iCultureDistance <= iCultureLevel && plotX->isPotentialCityWorkForArea(area()))
 		{
-			// changeCulture includes a check to culture value upward
+			// changeCulture includes a check to bump culture value upward
 			// to ensure plot cannot be lost thru decay even if culture gain is too small
 			plotX->changeCulture(
 				ePlayer,
@@ -16132,6 +16132,7 @@ void CvCity::doPlotCulture(PlayerTypes ePlayer, int iCultureRate)
 				// Toffer - Only update plot ownership when the culture of non-owners increase.
 				plotX->getOwner() != ePlayer
 			);
+			plotX->setInCultureRangeOfCityByPlayer(ePlayer);
 		}
 	}
 }

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -6574,7 +6574,8 @@ int CvCity::calculateCultureDistance(const CvPlot* mainPlot, int iMaxDistance) c
 			if (mainPlot->isHills())
 			{
 				terrainDistance += GC.getTerrainInfo(GC.getTERRAIN_HILL()).getCultureDistance()
-					+ !GET_TEAM(getTeam()).isCanFoundOnPeaks();
+					+ !GET_TEAM(getTeam()).isCanFoundOnPeaks()
+					+ !GET_TEAM(getTeam()).isBridgeBuilding();
 			}
 		}
 	}

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -6647,7 +6647,7 @@ int CvCity::calculateCultureDistance(const CvPlot* mainPlot, int iMaxDistance) c
 			if (neighborDist == 0)
 			{
 				netDistanceModifier += mainPlot->isRiverCrossing(directionXY(mainPlot, adjacentPlot)) * (extraRiverPenalty);
-				netDistanceModifier /= 2;
+				netDistanceModifier /= 3;
 			}
 			else
 			{

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -10338,7 +10338,7 @@ void CvCityAI::AI_findBestImprovementForPlot(const CvPlot* pPlot, plotInfo* plot
 		const CvImprovementInfo& potentialImprovementInfo = GC.getImprovementInfo(ePotentialImprovement);
 
 		// check if improvement is a fort or watchtower, then its a no.
-		if (potentialImprovementInfo.isActsAsCity() || potentialImprovementInfo.getVisibilityChange() > 0) continue;
+		if (potentialImprovementInfo.isMilitaryStructure()) continue;
 
 		// check if improvement can be built by team
 		if (!pPlot->canBuildImprovement(ePotentialImprovement, getTeam())) continue;

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -7775,7 +7775,7 @@ namespace {
 	};
 };
 
-//
+
 // Only used for improvement upgrading.
 int CvCityAI::AI_getImprovementValue(const CvPlot* pPlot, ImprovementTypes eImprovement, int iFoodPriority, int iProductionPriority, int iCommercePriority, int iFoodChange) const
 {
@@ -7811,33 +7811,33 @@ int CvCityAI::AI_getImprovementValue(const CvPlot* pPlot, ImprovementTypes eImpr
 	if (improvement.isCarriesIrrigation()) iValue += 200;
 
 	const int iCultureRange = improvement.getCultureRange() + 1;
-	iValue += 4 * improvement.getCulture() * iCultureRange * iCultureRange;
+	// Blaze: Comment out culture&range to not overvalue cottage line.
+	// iValue += 4 * improvement.getCulture() * iCultureRange * iCultureRange;
 
-	int iMilitaryValue = 3 * improvement.getAirBombDefense();
+	// We should only be caring about military stats on military improvements; others are incidential
+	if (improvement.isMilitaryStructure())
+	{
+		int iMilitaryValue = 3 * improvement.getAirBombDefense();
 
-	if (improvement.isZOCSource()) iMilitaryValue += 200;
+		if (improvement.isZOCSource()) iMilitaryValue += 200;
 
-	iMilitaryValue += 2 * (5 * improvement.getVisibilityChange() + 2 * improvement.getSeeFrom());
+		iMilitaryValue += 2 * (5 * improvement.getVisibilityChange() + 2 * improvement.getSeeFrom());
 
-	const int iDefense = improvement.getDefenseModifier();
-	if (iDefense < 0)
-	{
-		iMilitaryValue -= iDefense * iDefense;
-	}
-	else if (iDefense > 0)
-	{
-		iMilitaryValue += iDefense * iDefense;
-	}
-	if (improvement.isActsAsCity())
-	{
-		iMilitaryValue *= (2 + iCultureRange);
-	}
-	else if (improvement.isUpgradeRequiresFortify())
-	{
+		const int iDefense = improvement.getDefenseModifier();
+		if (iDefense < 0)
+		{
+			iMilitaryValue -= iDefense * iDefense;
+		}
+		else if (iDefense > 0)
+		{
+			iMilitaryValue += iDefense * iDefense;
+		}
+
+		iMilitaryValue *= (1 + iCultureRange);
 		iMilitaryValue *= 5;
 		iMilitaryValue /= 3;
+		iValue += iMilitaryValue;
 	}
-	iValue += iMilitaryValue;
 
 	const ImprovementTypes eFinalUpgrade = finalImprovementUpgrade(eImprovement);
 	FAssert(eFinalUpgrade != NO_IMPROVEMENT);

--- a/Sources/CvDLLWidgetData.cpp
+++ b/Sources/CvDLLWidgetData.cpp
@@ -2731,21 +2731,20 @@ void CvDLLWidgetData::parseActionHelp(CvWidgetDataStruct &widgetDataStruct, CvWS
 				{
 					if (eImprovement != NO_IMPROVEMENT)
 					{
-						if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam())
+						if (improvement->isOutsideBorders())
 						{
-							if (improvement->isOutsideBorders())
-							{
-								if (pMissionPlot->getTeam() != NO_TEAM)
-								{
-									szBuffer.append(NEWLINE);
-									szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_OUT_RIVAL_CULTURE_BORDER"));
-								}
-							}
-							else
+							if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam() &&
+								pMissionPlot->getTeam() != NO_TEAM)
 							{
 								szBuffer.append(NEWLINE);
-								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_CULTURE_BORDER"));
+								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_OUT_RIVAL_CULTURE_BORDER"));
 							}
+						}
+						else if (!pMissionPlot->isInCultureRangeOfCityByPlayer(pHeadSelectedUnit->getOwner()) ||
+								  pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam())
+						{
+							szBuffer.append(NEWLINE);
+							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_CULTURE_BORDER"));
 						}
 
 						if ((ePlotBonus == NO_BONUS || !improvement->isImprovementBonusTrade(ePlotBonus))

--- a/Sources/CvDLLWidgetData.cpp
+++ b/Sources/CvDLLWidgetData.cpp
@@ -2742,9 +2742,9 @@ void CvDLLWidgetData::parseActionHelp(CvWidgetDataStruct &widgetDataStruct, CvWS
 							}
 						}
 						// Fail when on territory owned by non-teammate
-						// OR when outside influence of tile owner; this enables building on valid territory of teammates.
+						// OR when outside influence of tile owner; this (should) enable building on valid territory of teammates.
 						// NOTE: This prevents workers removing forts when in territory influenced by teammate. Also does not allow
-						// 		building on a tile owned by teammate but only influenced by you (rare occurrance though for it not to be a fort tile
+						// 		building on a tile owned by teammate but only influenced by you (rare occurrance though for it not to be a fort tile)
 						else if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam()
 							 || !pMissionPlot->isInCultureRangeOfCityByPlayer(pMissionPlot->getOwner()))
 						{

--- a/Sources/CvDLLWidgetData.cpp
+++ b/Sources/CvDLLWidgetData.cpp
@@ -2731,6 +2731,7 @@ void CvDLLWidgetData::parseActionHelp(CvWidgetDataStruct &widgetDataStruct, CvWS
 				{
 					if (eImprovement != NO_IMPROVEMENT)
 					{
+						// Anywhere builds only fail in non-team/neutral territory
 						if (improvement->isOutsideBorders())
 						{
 							if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam() &&
@@ -2740,8 +2741,12 @@ void CvDLLWidgetData::parseActionHelp(CvWidgetDataStruct &widgetDataStruct, CvWS
 								szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_OUT_RIVAL_CULTURE_BORDER"));
 							}
 						}
-						else if (!pMissionPlot->isInCultureRangeOfCityByPlayer(pHeadSelectedUnit->getOwner()) ||
-								  pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam())
+						// Fail when on territory owned by non-teammate
+						// OR when outside influence of tile owner; this enables building on valid territory of teammates.
+						// NOTE: This prevents workers removing forts when in territory influenced by teammate. Also does not allow
+						// 		building on a tile owned by teammate but only influenced by you (rare occurrance though for it not to be a fort tile
+						else if (pMissionPlot->getTeam() != pHeadSelectedUnit->getTeam()
+							 || !pMissionPlot->isInCultureRangeOfCityByPlayer(pMissionPlot->getOwner()))
 						{
 							szBuffer.append(NEWLINE);
 							szBuffer.append(gDLL->getText("TXT_KEY_ACTION_NEEDS_CULTURE_BORDER"));

--- a/Sources/CvGameTextMgr.cpp
+++ b/Sources/CvGameTextMgr.cpp
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------
 //
 //  *****************   Civilization IV   ********************
 //
@@ -8780,19 +8780,19 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 						pOwner.getCivilizationAdjective(), pPlot->getCulture(ePlotOwner)
 					)
 				);
-				{
-					const int iRate = pPlot->getCultureRateLastTurn(ePlotOwner);
+				if (pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner)) szString.append(L"(C)");
 
-					if (iRate > 0)
-					{
-						szString.append(CvWString::format(L" + %d)\n", iRate));
-					}
-					else if (iRate < 0)
-					{
-						szString.append(CvWString::format(L" - %d)\n", -iRate));
-					}
-					else szString.append(L")\n");
+				const int iRate = pPlot->getCultureRateLastTurn(ePlotOwner);
+
+				if (iRate > 0)
+				{
+					szString.append(CvWString::format(L" + %d)\n", iRate));
 				}
+				else if (iRate < 0)
+				{
+					szString.append(CvWString::format(L" - %d)\n", -iRate));
+				}
+				else szString.append(L")\n");
 			}
 			for (int iI = 0; iI < MAX_PLAYERS; iI++)
 			{
@@ -8808,6 +8808,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 							playerX.getCivilizationAdjective(), pPlot->getCulture(ePlayerX)
 						)
 					);
+					if (pPlot->isInCultureRangeOfCityByPlayer(ePlayerX)) szString.append(L"(C)");
+
 					const int iRate = pPlot->getCultureRateLastTurn(ePlayerX);
 
 					if (iRate > 0)
@@ -8863,6 +8865,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 						pOwner.getCivilizationAdjective(), pPlot->getCulture(eRevealOwner)
 					)
 				);
+				if (pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner)) szString.append(L"(C)");
+
 				const int iRate = pPlot->getCultureRateLastTurn(ePlotOwner);
 
 				if (iRate > 0)
@@ -8887,6 +8891,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 							playerX.getPlayerTextColorR(), playerX.getPlayerTextColorG(), playerX.getPlayerTextColorB(), playerX.getPlayerTextColorA(),
 							playerX.getCivilizationAdjective(), pPlot->getCulture(ePlayerX)));
 					}
+					if (pPlot->isInCultureRangeOfCityByPlayer(ePlayerX)) szString.append(L"(C)");
+
 					const int iRate = pPlot->getCultureRateLastTurn(ePlayerX);
 
 					if (iRate > 0)

--- a/Sources/CvGameTextMgr.cpp
+++ b/Sources/CvGameTextMgr.cpp
@@ -8780,10 +8780,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 						pOwner.getCivilizationAdjective(), pPlot->getCulture(ePlotOwner)
 					)
 				);
-				if (pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner)) szString.append(L"(C)");
 
 				const int iRate = pPlot->getCultureRateLastTurn(ePlotOwner);
-
 				if (iRate > 0)
 				{
 					szString.append(CvWString::format(L" + %d)\n", iRate));
@@ -8792,7 +8790,16 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 				{
 					szString.append(CvWString::format(L" - %d)\n", -iRate));
 				}
-				else szString.append(L")\n");
+				else
+				{
+					szString.append(L")\n");
+				}
+				if (!pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner))
+				{
+					szString.append(gDLL->getText("TXT_KEY_BULLET"));
+					szString.append(gDLL->getText("TXT_KEY_MISC_NO_CITY_INFLUENCE", pOwner.getCivilizationAdjective()));
+					szString.append(NEWLINE);
+				}
 			}
 			for (int iI = 0; iI < MAX_PLAYERS; iI++)
 			{
@@ -8808,10 +8815,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 							playerX.getCivilizationAdjective(), pPlot->getCulture(ePlayerX)
 						)
 					);
-					if (pPlot->isInCultureRangeOfCityByPlayer(ePlayerX)) szString.append(L"(C)");
 
 					const int iRate = pPlot->getCultureRateLastTurn(ePlayerX);
-
 					if (iRate > 0)
 					{
 						szString.append(CvWString::format(L" + %d)\n", iRate));
@@ -8820,7 +8825,16 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 					{
 						szString.append(CvWString::format(L" - %d)\n", -iRate));
 					}
-					else szString.append(L")\n");
+					else
+					{
+						szString.append(L")\n");
+					}
+					if (!pPlot->isInCultureRangeOfCityByPlayer(ePlayerX))
+					{
+						szString.append(gDLL->getText("TXT_KEY_BULLET"));
+						szString.append(gDLL->getText("TXT_KEY_MISC_NO_CITY_INFLUENCE", playerX.getCivilizationAdjective()));
+						szString.append(NEWLINE);
+					}
 				}
 			}
 		}
@@ -8865,10 +8879,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 						pOwner.getCivilizationAdjective(), pPlot->getCulture(eRevealOwner)
 					)
 				);
-				if (pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner)) szString.append(L"(C)");
 
 				const int iRate = pPlot->getCultureRateLastTurn(ePlotOwner);
-
 				if (iRate > 0)
 				{
 					szString.append(CvWString::format(L" + %d)\n", iRate));
@@ -8877,7 +8889,16 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 				{
 					szString.append(CvWString::format(L" - %d)\n", -iRate));
 				}
-				else szString.append(L")\n");
+				else
+				{
+					szString.append(L")\n");
+				}
+				if (!pPlot->isInCultureRangeOfCityByPlayer(ePlotOwner))
+				{
+					szString.append(gDLL->getText("TXT_KEY_BULLET"));
+					szString.append(gDLL->getText("TXT_KEY_MISC_NO_CITY_INFLUENCE", pOwner.getCivilizationAdjective()));
+					szString.append(NEWLINE);
+				}
 			}
 			for (int iI = 0; iI < MAX_PLAYERS; iI++)
 			{
@@ -8891,10 +8912,8 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 							playerX.getPlayerTextColorR(), playerX.getPlayerTextColorG(), playerX.getPlayerTextColorB(), playerX.getPlayerTextColorA(),
 							playerX.getCivilizationAdjective(), pPlot->getCulture(ePlayerX)));
 					}
-					if (pPlot->isInCultureRangeOfCityByPlayer(ePlayerX)) szString.append(L"(C)");
 
 					const int iRate = pPlot->getCultureRateLastTurn(ePlayerX);
-
 					if (iRate > 0)
 					{
 						szString.append(CvWString::format(L" + %d)\n", iRate));
@@ -8903,7 +8922,16 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 					{
 						szString.append(CvWString::format(L" - %d)\n", -iRate));
 					}
-					else szString.append(L")\n");
+					else
+					{
+						szString.append(L")\n");
+					}
+					if (!pPlot->isInCultureRangeOfCityByPlayer(ePlayerX))
+					{
+						szString.append(gDLL->getText("TXT_KEY_BULLET"));
+						szString.append(gDLL->getText("TXT_KEY_MISC_NO_CITY_INFLUENCE", playerX.getCivilizationAdjective()));
+						szString.append(NEWLINE);
+					}
 				}
 			}
 		}

--- a/Sources/CvGameTextMgr.cpp
+++ b/Sources/CvGameTextMgr.cpp
@@ -9062,7 +9062,7 @@ void CvGameTextMgr::setPlotHelp(CvWStringBuffer& szString, CvPlot* pPlot)
 				{
 					iMovementCost += GC.getPEAK_EXTRA_MOVEMENT();
 				}
-				else iMovementCost += 1;
+				iMovementCost += 3;
 			}
 
 			if (iMovementCost != 0)

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -4524,6 +4524,7 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 	int iConnectedForeignCities = countPotentialForeignTradeCitiesConnected();
 
 	const int iCityCount = getNumCities();
+	const int iRCSMultiplier = 1 + GC.getGame().isOption(GAMEOPTION_REALISTIC_CULTURE_SPREAD);
 
 	int iValue = 0;
 
@@ -4532,7 +4533,7 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 	// Map stuff
 	if (iCoastalCities > 0 && kTech.isExtraWaterSeeFrom())
 	{
-		iValue += 100;
+		iValue += 100 * iRCSMultiplier;
 
 		if (bCapitalAlone)
 		{
@@ -4616,7 +4617,7 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 	// Tile improvement abilities
 	if (kTech.isBridgeBuilding())
 	{
-		iValue += 400;
+		iValue += 400 * iRCSMultiplier;
 	}
 
 	if (kTech.isIrrigation())
@@ -4642,19 +4643,19 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 			if (pPlot->isAsPeak() && pPlot->getOwner() != NO_PLAYER
 			&& GET_PLAYER(pPlot->getOwner()).getID() == getID())
 			{
-				iValue += 35;
+				iValue += 35 * iRCSMultiplier;
 			}
 		}
 	}
 
 	if (kTech.isMoveFastPeaks())
 	{
-		iValue += 150;
+		iValue += 150 * iRCSMultiplier;
 	}
 
 	if (kTech.isCanFoundOnPeaks())
 	{
-		iValue += 100;
+		iValue += 100 * iRCSMultiplier;
 	}
 
 	if (gPlayerLogLevel > 2)
@@ -4766,7 +4767,7 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 
 				if (iCoastalCities > 0)
 				{
-					iValue += ((bCapitalAlone) ? 950 : 350);
+					iValue += ((bCapitalAlone) ? 950 : 350) * iRCSMultiplier;
 				}
 
 				iValue += 50;
@@ -4777,7 +4778,7 @@ int CvPlayerAI::AI_techValue(TechTypes eTech, int iPathLength, bool bIgnoreCost,
 
 	if (kTech.isRiverTrade())
 	{
-		iValue += 1000;
+		iValue += 1000 * iRCSMultiplier;
 	}
 
 	/* ------------------ Tile Improvement Value  ------------------ */

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -25794,7 +25794,7 @@ int CvPlayerAI::AI_getPlotChokeValue(const CvPlot* pPlot) const
 					}
 					if (pPlot->getImprovementType() != NO_IMPROVEMENT)
 					{
-						if (!GC.getImprovementInfo(pPlot->getImprovementType()).isActsAsCity())
+						if (!GC.getImprovementInfo(pPlot->getImprovementType()).isMilitaryStructure())
 						{
 							return 0;
 						}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -2982,7 +2982,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 				}
 			}
 			// Fail when on territory owned by non-teammate
-			// OR when outside influence of tile owner; this enables building on valid territory of teammates.
+			// OR when outside influence of tile owner; this (should?) enable building on valid territory of teammates.
 			// NOTE: This prevents workers removing forts when in territory influenced by teammate. Also does not allow
 			// 		building on a tile owned by teammate but only influenced by you (rare occurrance though for it not to be a fort tile)
 			else if (GET_PLAYER(ePlayer).getTeam() != getTeam()

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -10911,10 +10911,9 @@ void CvPlot::read(FDataStreamBase* pStream)
 			}
 		}
 		// Blaze TODO confirm working as intended
-		WRAPPER_READ_DECORATED(wrapper, "CvPlot", &iSize, "InfluencedByCityByPlayer");
+		WRAPPER_READ_DECORATED(wrapper, "CvPlot", &iSize, "InfluencedByCityByPlayerSize");
 		for (short i = 0; i < iSize; ++i)
 		{
-			int iValue = 0;
 			WRAPPER_READ_DECORATED(wrapper, "CvPlot", &iType, "InfluencedByCityByPlayer");
 
 			if (iType > -1 && iType < MAX_PLAYERS)
@@ -11307,7 +11306,7 @@ void CvPlot::write(FDataStreamBase* pStream)
 			WRAPPER_WRITE_DECORATED(wrapper, "CvPlot", (*it).second, "CultureRatesLastTurnRate");
 		}
 		// Blaze TODO confirm working as intended
-		WRAPPER_WRITE_DECORATED(wrapper, "CvPlot", (short)m_influencedByCityByPlayer.size(), "InfluencedByCityByPlayer");
+		WRAPPER_WRITE_DECORATED(wrapper, "CvPlot", (short)m_influencedByCityByPlayer.size(), "InfluencedByCityByPlayerSize");
 		for (std::vector<PlayerTypes>::iterator it = m_influencedByCityByPlayer.begin(); it != m_influencedByCityByPlayer.end(); ++it)
 		{
 			WRAPPER_WRITE_DECORATED(wrapper, "CvPlot", static_cast<short>(*it), "InfluencedByCityByPlayer");
@@ -13288,23 +13287,13 @@ int CvPlot::getCultureRateLastTurn(const PlayerTypes ePlayer) const
 
 void CvPlot::setInCultureRangeOfCityByPlayer(const PlayerTypes ePlayer)
 {
-	bool bAlreadyInfluenced = false;
-	for (std::vector<PlayerTypes>::iterator it = m_influencedByCityByPlayer.begin(); it != m_influencedByCityByPlayer.end(); ++it)
-	{
-		if (*it == ePlayer)
-		{
-			bAlreadyInfluenced = true;
-			break;
-		}
-	}
-	if (!bAlreadyInfluenced) m_influencedByCityByPlayer.push_back(ePlayer);
+    if (!isInCultureRangeOfCityByPlayer(ePlayer))
+    {
+        m_influencedByCityByPlayer.push_back(ePlayer);
+    }
 }
 
 bool CvPlot::isInCultureRangeOfCityByPlayer(const PlayerTypes ePlayer) const
 {
-	for (std::vector<PlayerTypes>::const_iterator it = m_influencedByCityByPlayer.begin(); it != m_influencedByCityByPlayer.end(); ++it)
-	{
-		if (*it == ePlayer) return true;
-	}
-	return false;
+	return find(m_influencedByCityByPlayer.begin(), m_influencedByCityByPlayer.end(), ePlayer) != m_influencedByCityByPlayer.end();
 }

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -7980,7 +7980,7 @@ void CvPlot::setCulture(PlayerTypes eIndex, int iNewValue, bool bUpdate, bool bU
 		iNewValue = 1;
 	}
 
-	// Protection from overzealous decay
+	// Protection from overzealous decay, others
 	iNewValue = std::max(0, iNewValue);
 
 	if (getCulture(eIndex) != iNewValue)
@@ -10265,19 +10265,19 @@ void CvPlot::doCulture()
 			{
 				if (GC.getGame().isOption(GAMEOPTION_EQUILIBRIUM_CULTURE))
 				{
-					// Decay 20x faster (to 60% at default speeds) if outside of city control in equilibrium, since we can't immediately set to unowned when negative
+					// Decay 15x faster (to 45% at default speeds) if outside of city control in equilibrium, since we can't immediately set to unowned when negative
 					if (isInCultureRangeOfCityByPlayer(ePlayerX))
 					{
-						setCulture(ePlayerX, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true);
+						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true));
 					}
 					else
 					{
-						setCulture(ePlayerX, getCulture(ePlayerX) * (1000 - 20 * decayPermille) / 1000, false, false, true);
+						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - 15 * decayPermille) / 1000, false, false, true));
 					}
 				}
 				else if (getCultureRateThisTurn(ePlayerX) < 1 && (!getPlotCity() || getOwner() != ePlayerX))
 				{
-					setCulture(ePlayerX, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true);
+					setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true));
 				}
 			}
 		}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -10268,16 +10268,16 @@ void CvPlot::doCulture()
 					// Decay 15x faster (to 45% at default speeds) if outside of city control in equilibrium, since we can't immediately set to unowned when negative
 					if (isInCultureRangeOfCityByPlayer(ePlayerX))
 					{
-						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true));
+						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000), false, false, true);
 					}
 					else
 					{
-						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - 15 * decayPermille) / 1000, false, false, true));
+						setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - 15 * decayPermille) / 1000), false, false, true);
 					}
 				}
 				else if (getCultureRateThisTurn(ePlayerX) < 1 && (!getPlotCity() || getOwner() != ePlayerX))
 				{
-					setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000, false, false, true));
+					setCulture(ePlayerX, std::max(0, getCulture(ePlayerX) * (1000 - decayPermille) / 1000), false, false, true);
 				}
 			}
 		}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -4092,7 +4092,7 @@ int CvPlot::movementCost(const CvUnit* pUnit, const CvPlot* pFromPlot) const
 					{
 						iRegularCost += GC.getPEAK_EXTRA_MOVEMENT();
 					}
-					else iRegularCost += 1;
+					iRegularCost += 3;
 				}
 			}
 

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -2988,7 +2988,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 				return false;
 			}
 			// Super Forts begin *AI_worker* - prevent workers from two different players from building a fort in the same plot
-			if(GC.getImprovementInfo(eImprovement).isActsAsCity())
+			if(GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 			{
 				foreach_(const CvUnit* pLoopUnit, units())
 				{
@@ -2997,7 +2997,7 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 					{
 						const ImprovementTypes eImprovementBuild = GC.getBuildInfo(pLoopUnit->getBuildType()).getImprovement();
 
-						if (eImprovementBuild != NO_IMPROVEMENT && GC.getImprovementInfo(eImprovementBuild).isActsAsCity())
+						if (eImprovementBuild != NO_IMPROVEMENT && GC.getImprovementInfo(eImprovementBuild).isMilitaryStructure())
 						{
 							return false;
 						}
@@ -6835,7 +6835,7 @@ void CvPlot::setImprovementCurrentValue()
 				iCountervalue += 10 * calculateNatureYield((YieldTypes)iK, getTeam(), (getFeatureType() == NO_FEATURE) ? true : false);
 			}
 		}
-		if (GC.getImprovementInfo(eImprovement).getCulture() > 0 || GC.getImprovementInfo(eImprovement).isActsAsCity())
+		if (GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 		{
 			int iCounterDefenseValue = GC.getImprovementInfo(eImprovement).getAirBombDefense()/10;
 			iCounterDefenseValue += GC.getImprovementInfo(eImprovement).getDefenseModifier()/10;
@@ -12388,7 +12388,7 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 	{
 		const ImprovementTypes eImprovement = GC.getBuildInfo(eBuild).getImprovement();
 
-		if (eImprovement != NO_IMPROVEMENT && GC.getImprovementInfo(eImprovement).isActsAsCity())
+		if (eImprovement != NO_IMPROVEMENT && GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 		{
 			setOwner(ePlayer, true, false);
 		}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -2890,9 +2890,12 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 
 	const ImprovementTypes eImprovement = info.getImprovement();
 
-	// Can't build if both outside of city range and not-military improvement
-	if (!isInCultureRangeOfCityByPlayer(ePlayer) && !GC.getImprovementInfo(eImprovement).isMilitaryStructure())
+	// Build impossible if: A) outside of city culture range AND B) not a (military structure OR a route)
+	if (!isInCultureRangeOfCityByPlayer(ePlayer) &&
+		!(GC.getImprovementInfo(eImprovement).isMilitaryStructure() || ((RouteTypes)(info.getRoute()) != NO_ROUTE)))
+	{
 		return false;
+	}
 
 	if (!info.getPlaceBonusTypes().empty())
 	{
@@ -12384,7 +12387,7 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, PlayerTypes ePl
 
 		if (eImprovement != NO_IMPROVEMENT && GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 		{
-			setOwner(ePlayer, true, false);
+			setOwner(ePlayer, true, true);
 		}
 	}
 	return bResult;

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -2888,6 +2888,12 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 		}
 	}
 
+	const ImprovementTypes eImprovement = info.getImprovement();
+
+	// Can't build if both outside of city range and not-military improvement
+	if (!isInCultureRangeOfCityByPlayer(ePlayer) && !GC.getImprovementInfo(eImprovement).isMilitaryStructure())
+		return false;
+
 	if (!info.getPlaceBonusTypes().empty())
 	{
 		if (getBonusType() != NO_BONUS)
@@ -2938,7 +2944,6 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 	}
 
 	bool bValid = false;
-	const ImprovementTypes eImprovement = info.getImprovement();
 
 	if (eImprovement != NO_IMPROVEMENT)
 	{
@@ -2967,16 +2972,6 @@ bool CvPlot::canBuild(BuildTypes eBuild, PlayerTypes ePlayer, bool bTestVisible,
 			{
 				return false;
 			}
-
-			/* TB Commented out to allow for units to build over current improvements with their upgrades (if the build to do so is defined.)
-			ImprovementTypes eFinalImprovementType = finalImprovementUpgrade(getImprovementType());
-
-			if (eFinalImprovementType != NO_IMPROVEMENT
-			&& eFinalImprovementType == finalImprovementUpgrade(eImprovement))
-			{
-				return false;
-			}
-			*/
 		}
 
 		if (!bTestVisible)

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -377,6 +377,9 @@ public:
 	int getCultureRateThisTurn(const PlayerTypes ePlayer) const;
 	int getCultureRateLastTurn(const PlayerTypes ePlayer) const;
 
+	void setInCultureRangeOfCityByPlayer(const PlayerTypes ePlayer);
+	bool isInCultureRangeOfCityByPlayer(const PlayerTypes ePlayer) const;
+
 protected:
 	CvGameObjectPlot m_GameObject;
 
@@ -390,6 +393,7 @@ protected:
 
 	std::vector<std::pair<PlayerTypes, int> > m_cultureRatesThisTurn;
 	std::vector<std::pair<PlayerTypes, int> > m_cultureRatesLastTurn;
+	std::vector<PlayerTypes> m_influencedByCityByPlayer;
 
 public:
 	PlayerTypes calculateCulturalOwner(bool bCountLastTurn = true) const;

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -393,6 +393,7 @@ protected:
 
 	std::vector<std::pair<PlayerTypes, int> > m_cultureRatesThisTurn;
 	std::vector<std::pair<PlayerTypes, int> > m_cultureRatesLastTurn;
+	std::vector<PlayerTypes> m_influencedByCityByPlayerLastTurn;
 	std::vector<PlayerTypes> m_influencedByCityByPlayer;
 
 public:

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -288,7 +288,7 @@ public:
 	void changeDefenseDamage(int iChange);
 
 	// Super Forts *culture*
-	void pushCultureFromFort(PlayerTypes ePlayer, int iChange, int iRange, bool bUpdate);
+	void pushCultureFromImprovement(PlayerTypes ePlayer, int iChange, int iRange, bool bUpdate);
 	void doImprovementCulture(PlayerTypes ePlayer, const CvImprovementInfo& imp);
 
 	// Super Forts *canal* *choke*

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -26474,12 +26474,8 @@ BuildTypes CvUnitAI::AI_findBestFort(const CvPlot* pPlot) const
 		if (GC.getBuildInfo(eBuild).getImprovement() != NO_IMPROVEMENT)
 		{
 			const CvImprovementInfo& kImprovement = GC.getImprovementInfo(GC.getBuildInfo(eBuild).getImprovement());
-			// Is fort or tower
-			if ((kImprovement.isActsAsCity() || kImprovement.getVisibilityChange() > 0)
-			&& canBuild(pPlot, eBuild)
-			// If not (plot in workable radius of any city and is tower line improvement); 'plot in workable radius of owned city' might be better?
-			// Toffer - The next condition seems iffy considering the above comment about it...
-			&& (!pPlot->isCityRadius() || kImprovement.isActsAsCity()))
+			// Watchtower can claim land if fort can't
+			if (kImprovement.isMilitaryStructure() && canBuild(pPlot, eBuild))
 			{
 				int iValue =
 					(

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -12354,7 +12354,7 @@ int CvUnitAI::AI_getPlotDefendersNeeded(const CvPlot* pPlot, int iExtra) const
 
 	if (pPlot->getImprovementType() != NO_IMPROVEMENT && GC.getImprovementInfo(pPlot->getImprovementType()).getCulture() > 0)
 	{
-		iNeeded = std::max(1 + (GC.getImprovementInfo(pPlot->getImprovementType()).isActsAsCity() ? 1 : 0), iNeeded);
+		iNeeded = std::max(1 + (GC.getImprovementInfo(pPlot->getImprovementType()).isMilitaryStructure() ? 1 : 0), iNeeded);
 	}
 
 	if (iNeeded == 0)
@@ -12404,7 +12404,7 @@ bool CvUnitAI::AI_guardFort(bool bSearch)
 		const ImprovementTypes eImprovement = plot()->getImprovementType();
 		if (eImprovement != NO_IMPROVEMENT)
 		{
-			if (GC.getImprovementInfo(eImprovement).isActsAsCity() || GC.getImprovementInfo(eImprovement).getCulture() > 0)
+			if (GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 			{
 				// Super Forts begin *AI_defense* - just tweaked a number here (iExtra now 1 instead of 0)
 				if (plot()->plotCount(PUF_isCityAIType, -1, -1, NULL, getOwner()) <= AI_getPlotDefendersNeeded(plot(), 1))
@@ -12439,7 +12439,7 @@ bool CvUnitAI::AI_guardFort(bool bSearch)
 				const ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
 				if (eImprovement != NO_IMPROVEMENT)
 				{
-					if (GC.getImprovementInfo(eImprovement).isActsAsCity() || GC.getImprovementInfo(eImprovement).getCulture() > 0)
+					if (GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 					{
 						// Super Forts begin *AI_defense* - just tweaked a number here (iExtra now 1 instead of 0)
 						int iValue = AI_getPlotDefendersNeeded(pLoopPlot, 1);
@@ -12502,7 +12502,7 @@ bool CvUnitAI::AI_guardFortMinDefender(bool bSearch)
 		const ImprovementTypes eImprovement = plot()->getImprovementType();
 		if (eImprovement != NO_IMPROVEMENT)
 		{
-			if (GC.getImprovementInfo(eImprovement).isActsAsCity() || GC.getImprovementInfo(eImprovement).isUpgradeRequiresFortify() || GC.getImprovementInfo(eImprovement).getCulture() > 0)
+			if (GC.getImprovementInfo(eImprovement).isMilitaryStructure() || GC.getImprovementInfo(eImprovement).isUpgradeRequiresFortify())
 			{
 				if (plot()->plotCount(PUF_isCityAIType, -1, -1, NULL, getOwner()) <= 1)
 				{
@@ -12533,7 +12533,7 @@ bool CvUnitAI::AI_guardFortMinDefender(bool bSearch)
 				const ImprovementTypes eImprovement = pLoopPlot->getImprovementType();
 				if (eImprovement != NO_IMPROVEMENT)
 				{
-					if (GC.getImprovementInfo(eImprovement).isActsAsCity() || GC.getImprovementInfo(eImprovement).isUpgradeRequiresFortify() || GC.getImprovementInfo(eImprovement).getCulture() > 0)
+					if (GC.getImprovementInfo(eImprovement).isMilitaryStructure() || GC.getImprovementInfo(eImprovement).isUpgradeRequiresFortify())
 					{
 						if (!(pLoopPlot->isVisibleEnemyUnit(this)))
 						{
@@ -21381,7 +21381,7 @@ bool CvUnitAI::AI_improveBonus(int iMinValue, CvPlot** ppBestPlot, BuildTypes* p
 											iCountervalue += 10 * pLoopPlot->calculateNatureYield((YieldTypes)iK, getTeam(), eFeature == NO_FEATURE ? true : GC.getBuildInfo(eBestTempBuild).isFeatureRemove(eFeature));
 										}
 									}
-									if (GC.getImprovementInfo(eImprovement).getCulture() > 0 || GC.getImprovementInfo(eImprovement).isActsAsCity())
+									if (GC.getImprovementInfo(eImprovement).isMilitaryStructure())
 									{
 										int iCounterDefenseValue = GC.getImprovementInfo(eImprovement).getAirBombDefense()/10;
 										iCounterDefenseValue += GC.getImprovementInfo(eImprovement).getDefenseModifier()/10;

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -20642,10 +20642,7 @@ bool CvUnitAI::AI_improveCity(CvCity* pCity)
 					{
 						iPlotMoveCost += GC.getPEAK_EXTRA_MOVEMENT();
 					}
-					else
-					{
-						iPlotMoveCost += 1;
-					}
+					iPlotMoveCost += 3;
 				}
 
 				if (iPlotMoveCost > 1)
@@ -20770,7 +20767,7 @@ bool CvUnitAI::AI_improveLocalPlot(int iRange, const CvCity* pIgnoreCity)
 				{
 					iPlotMoveCost += GC.getPEAK_EXTRA_MOVEMENT();
 				}
-				else iPlotMoveCost += 1;
+				iPlotMoveCost += 3;
 			}
 			if (iPlotMoveCost > 1)
 			{


### PR DESCRIPTION
Has an issue where other civs will display tiles as not being influenced by cities when they are in fact.

This is caused by the cache clearing between player turn and AI turn; same cause for the 'culture last turn' vs 'this turn' cache. Should be fixed before accepting; whether to only show for player's own culture or by making new cache, or changing where cache clears, not certain. Thoughts Toffer?