### PR TITLE
Updated events:

### DIFF
--- a/Assets/XML/Events/CIV4EventInfos.xml
+++ b/Assets/XML/Events/CIV4EventInfos.xml
@@ -116,7 +116,7 @@
 			<PythonHelp>getHelpWildFire</PythonHelp>
 		</EventInfo>
 		<EventInfo>
-			<Type>EVENT_FOREST_NEW_2</Type>
+			<Type>EVENT_FOREST_NEW_1</Type>
 			<Description>TXT_KEY_EVENT_GENERIC_CHOICE_GOOD_NEWS</Description>
 			<FeatureType>FEATURE_FOREST_BURNT</FeatureType>
 			<iFeatureChange>-1</iFeatureChange>
@@ -129,7 +129,7 @@
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_FOREST_NEW_END</Type>
-			<FeatureType>FEATURE_FOREST</FeatureType>
+			<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
 			<iFeatureChange>1</iFeatureChange>
 		</EventInfo>
 		<EventInfo>
@@ -211,6 +211,7 @@
 					<iFlavor>1</iFlavor>
 				</TechFlavor>
 			</TechFlavors>
+			<iGold>-300</iGold>
 			<iTechPercent>15</iTechPercent>
 			<iTechCostPercent>5</iTechCostPercent>
 			<iTechMinTurnsLeft>4</iTechMinTurnsLeft>
@@ -268,15 +269,67 @@
 			<Type>EVENT_HAPPY_HUNTING_1</Type>
 			<Description>TXT_KEY_EVENT_HAPPY_HUNTING_1</Description>
 			<bPickCity>1</bPickCity>
-			<iFood>8</iFood>
+			<iFood>30</iFood>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
 			<iAIValue>1000</iAIValue>
 		</EventInfo>
 		<EventInfo>
-			<Type>EVENT_MOTHER_LODE_1</Type>
+			<Type>EVENT_HAPPY_HUNTING_2</Type>
+			<Description>TXT_KEY_EVENT_HAPPY_HUNTING_2</Description>
+			<bPickCity>1</bPickCity>
+			<iHappyTurns>1</iHappyTurns>
+			<iFood>60</iFood>
+			<iGold>-20</iGold>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>1000</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_MOTHER_LODE_GOLD_1</Type>
 			<Description>TXT_KEY_EVENT_MOTHER_LODE_1</Description>
-			<iGold>100</iGold>
-			<iRandomGold>100</iRandomGold>
+			<iGold>300</iGold>
+			<iRandomGold>500</iRandomGold>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>1000</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_MOTHER_LODE_GOLD_2</Type>
+			<Description>TXT_KEY_EVENT_MOTHER_LODE_2</Description>
+			<iGold>-200</iGold>
+			<AdditionalEvents>
+				<EventChance>
+					<Event>EVENT_MOTHER_LODE_3</Event>
+					<iEventChance>50</iEventChance>
+				</EventChance>
+			</AdditionalEvents>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>1000</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_MOTHER_LODE_SILVER_1</Type>
+			<Description>TXT_KEY_EVENT_MOTHER_LODE_1</Description>
+			<iGold>200</iGold>
+			<iRandomGold>400</iRandomGold>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>1000</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_MOTHER_LODE_SILVER_2</Type>
+			<Description>TXT_KEY_EVENT_MOTHER_LODE_2</Description>
+			<iGold>-200</iGold>
+			<AdditionalEvents>
+				<EventChance>
+					<Event>EVENT_MOTHER_LODE_3</Event>
+					<iEventChance>50</iEventChance>
+				</EventChance>
+			</AdditionalEvents>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>1000</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_MOTHER_LODE_3</Type>
+			<Description>TXT_KEY_EVENT_MOTHER_LODE</Description>
+			<iGold>500</iGold>
+			<iRandomGold>2000</iRandomGold>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
 			<iAIValue>1000</iAIValue>
 		</EventInfo>

--- a/Assets/XML/Events/CIV4EventTriggerInfos.xml
+++ b/Assets/XML/Events/CIV4EventTriggerInfos.xml
@@ -62,21 +62,24 @@
 			<bRecurring>1</bRecurring>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
-			<Type>EVENTTRIGGER_FOREST_NEW_2</Type>
+			<Type>EVENTTRIGGER_FOREST_NEW_1</Type>
+			<WorldNewsTexts>
+				<Text>TXT_KEY_EVENTTRIGGER_FOREST_NEW_1</Text>
+			</WorldNewsTexts>
 			<TriggerTexts>
 				<TriggerText>
-					<Text>TXT_KEY_EVENT_FOREST_NEW_2</Text>
+					<Text>TXT_KEY_EVENT_FOREST_NEW_1</Text>
 					<Era>NONE</Era>
 				</TriggerText>
 			</TriggerTexts>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>1</iWeight>
+			<iWeight>5</iWeight>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
 			<FeaturesRequired>
 				<FeatureType>FEATURE_FOREST_BURNT</FeatureType>
 			</FeaturesRequired>
 			<Events>
-				<Event>EVENT_FOREST_NEW_2</Event>
+				<Event>EVENT_FOREST_NEW_1</Event>
 			</Events>
 			<bOwnPlot>1</bOwnPlot>
 			<bRecurring>1</bRecurring>
@@ -114,9 +117,10 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/CityRuinsEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>500</iWeight>
+			<iWeight>4</iWeight>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
 			<bOwnPlot>1</bOwnPlot>
+			<bRecurring>1</bRecurring>
 			<ImprovementsRequired>
 				<ImprovementType>IMPROVEMENT_CITY_RUINS</ImprovementType>
 			</ImprovementsRequired>
@@ -150,7 +154,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/HappyHuntingEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>200</iWeight>
+			<iWeight>50</iWeight>
 			<iAngry>-1</iAngry>
 			<iUnhealthy>-1</iUnhealthy>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
@@ -160,6 +164,7 @@
 			</FeaturesRequired>
 			<Events>
 				<Event>EVENT_HAPPY_HUNTING_1</Event>
+				<Event>EVENT_HAPPY_HUNTING_2</Event>
 			</Events>
 			<OrPreReqs>
 				<PrereqTech>TECH_PERSISTENCE_HUNTING</PrereqTech>
@@ -170,19 +175,19 @@
 			<bRecurring>1</bRecurring>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
-			<Type>EVENTTRIGGER_MOTHER_LODE</Type>
+			<Type>EVENTTRIGGER_MOTHER_LODE_GOLD</Type>
 			<WorldNewsTexts>
-				<Text>TXT_KEY_EVENTTRIGGER_MOTHER_LODE</Text>
+				<Text>TXT_KEY_EVENTTRIGGER_MOTHER_LODE_GOLD</Text>
 			</WorldNewsTexts>
 			<TriggerTexts>
 				<TriggerText>
-					<Text>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_1</Text>
+					<Text>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_GOLD_1</Text>
 					<Era>NONE</Era>
 				</TriggerText>
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/MotherlodeEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>200</iWeight>
+			<iWeight>3</iWeight>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
 			<bOwnPlot>1</bOwnPlot>
 			<ImprovementsRequired>
@@ -204,11 +209,56 @@
 				<RouteType>ROUTE_JUMPLANE</RouteType>
 			</RoutesRequired>
 			<Events>
-				<Event>EVENT_MOTHER_LODE_1</Event>
+				<Event>EVENT_MOTHER_LODE_GOLD_1</Event>
+				<Event>EVENT_MOTHER_LODE_GOLD_2</Event>
 			</Events>
 			<OrPreReqs>
 				<PrereqTech>TECH_HYDRAULIC_MINING</PrereqTech>
 			</OrPreReqs>
+			<bRecurring>1</bRecurring>
+		</EventTriggerInfo>
+		<EventTriggerInfo>
+			<Type>EVENTTRIGGER_MOTHER_LODE_SILVER</Type>
+			<WorldNewsTexts>
+				<Text>TXT_KEY_EVENTTRIGGER_MOTHER_LODE_SILVER</Text>
+			</WorldNewsTexts>
+			<TriggerTexts>
+				<TriggerText>
+					<Text>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_SILVER_1</Text>
+					<Era>NONE</Era>
+				</TriggerText>
+			</TriggerTexts>
+			<EventArt>Art/Event_Images/SilverOreEvent.dds</EventArt>
+			<iPercentGamesActive>100</iPercentGamesActive>
+			<iWeight>3</iWeight>
+			<iNumPlotsRequired>1</iNumPlotsRequired>
+			<bOwnPlot>1</bOwnPlot>
+			<ImprovementsRequired>
+				<ImprovementType>IMPROVEMENT_MINE</ImprovementType>
+				<ImprovementType>IMPROVEMENT_SHAFT_MINE</ImprovementType>
+				<ImprovementType>IMPROVEMENT_MODERN_MINE</ImprovementType>
+			</ImprovementsRequired>
+			<BonusesRequired>
+				<BonusType>BONUS_SILVER_ORE</BonusType>
+			</BonusesRequired>
+			<RoutesRequired>
+				<RouteType>ROUTE_PATH</RouteType>
+				<RouteType>ROUTE_ROAD</RouteType>
+				<RouteType>ROUTE_PAVED_ROAD</RouteType>
+				<RouteType>ROUTE_HIGHWAY</RouteType>
+				<RouteType>ROUTE_RAILROAD</RouteType>
+				<RouteType>ROUTE_ELECTRIC_RAILROAD</RouteType>
+				<RouteType>ROUTE_MAGLEV</RouteType>
+				<RouteType>ROUTE_JUMPLANE</RouteType>
+			</RoutesRequired>
+			<Events>
+				<Event>EVENT_MOTHER_LODE_SILVER_1</Event>
+				<Event>EVENT_MOTHER_LODE_SILVER_2</Event>
+			</Events>
+			<OrPreReqs>
+				<PrereqTech>TECH_HYDRAULIC_MINING</PrereqTech>
+			</OrPreReqs>
+			<bRecurring>1</bRecurring>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
 			<Type>EVENTTRIGGER_WASHED_OUT</Type>

--- a/Assets/XML/GameText/Events_CIV4GameText.xml
+++ b/Assets/XML/GameText/Events_CIV4GameText.xml
@@ -865,6 +865,10 @@
         <Tag>TXT_KEY_EVENTTRIGGER_MASSIVE_FOREST_WILDFIRE</Tag>
         <English>Due to recent droughts a massive wildfire has started near the %s1_civ_adjective city of %s2_city.</English>
     </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENTTRIGGER_FOREST_NEW_1</Tag>
+        <English>Forest has started growing again near the %s1_civ_adjective city of %s2_city.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENTTRIGGER_FOREST_FIRE</Tag>
 		<English>Fire has raged through a forest near the %s1_civ_adjective city of %s2_city.</English>
@@ -1727,13 +1731,17 @@
 		<Spanish>Los aluviones del monzón, más fuerte de lo habitual en %s2_city, han llevado el desastre al pueblo %s1_civ_adjective que habita ahí.</Spanish>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_EVENTTRIGGER_MOTHER_LODE</Tag>
+		<Tag>TXT_KEY_EVENTTRIGGER_MOTHER_LODE_GOLD</Tag>
 		<English>Gold miners near the %s1_civ_adjective city of %s2_city have struck the mother lode.</English>
 		<French>Des mineurs près de la ville %s1:2_civ_adjective de %s2_city ont trouvé une importante veine d'or.</French>
 		<German>Die Goldgräber sind nahe der %s1:2_civ_adjective Stadt %s2_city auf die Hauptader gestoßen.</German>
 		<Italian>I minatori d'oro della città %s1:2_civ_adjective di %s2_city hanno scoperto il filone principale.</Italian>
 		<Spanish>Los mineros de la ciudad %s1:2_civ_adjective de %s2_city han dado con el filón principal de oro.</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENTTRIGGER_MOTHER_LODE_SILVER</Tag>
+        <English>Silver miners near the %s1_civ_adjective city of %s2_city have struck the mother lode.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENTTRIGGER_MOTOR_OIL</Tag>
 		<English>%s1_civ_adjective chemists have developed an advanced refinement process for motor oil.</English>
@@ -5728,7 +5736,7 @@
 		<Spanish>Estamos demasiado apurados como para prestarles ayuda.</Spanish>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_EVENT_FOREST_NEW_2</Tag>
+		<Tag>TXT_KEY_EVENT_FOREST_NEW_1</Tag>
 		<English>Life is returning to this once burnt forest.</English>
 		<French>La vie revient dans cette forêt autrefois brûlée.</French>
 		<Italian>La vita ritorna nella foresta un tempo andata a fuoco.</Italian>
@@ -6451,6 +6459,10 @@
 		<Italian>Invia le congratulazioni agli abitanti.</Italian>
 		<Spanish>Que se felicite a los ciudadanos.</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_HAPPY_HUNTING_2</Tag>
+        <English>Organise a great hunt, we must use this time of plenty to stock up on food.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_HAPPY_TO_PLAYER</Tag>
 		<English>[ICON_BULLET]%D1[ICON_UNHAPPY] in all cities. %s3_playerName gets %D2[ICON_HAPPY]</English>
@@ -8163,6 +8175,14 @@
 		<Italian>Incassa il premio del nostro successo!</Italian>
 		<Spanish>¡Que se guarde este triunfo en nuestro tesoro!</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_MOTHER_LODE_2</Tag>
+        <English>Try to dig as deep as you can.</English>
+    </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_MOTHER_LODE</Tag>
+        <English>We found even more than before, mine it all out.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_MOTOR_OIL_1</Tag>
 		<English>Authorize the selling of the improved motor oil on the open market.</English>
@@ -12109,13 +12129,17 @@
 		<Russian>Казначейство сообщает, что период профицита нашего бюджета подошел к концу, и что резервы в твердой валюте упали до опасно низкого уровня. Мы можем напечатать больше валюты и снова снизить процентные ставки, но инфляция почти наверняка пойдет еще выше.</Russian>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_1</Tag>
+		<Tag>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_GOLD_1</Tag>
 		<English>Our gold miners near %s2_city have struck the mother lode! We are rich, rich, rich!</English>
 		<French>Nos mineurs près de %s2_city ont trouvé une importante veine d'or ! Nous sommes riches, riches, riches !</French>
 		<German>Unsere Goldgräber sind in der Nähe von %s2_city auf die Hauptader gestoßen! Wir sind reich, reich, reich!</German>
 		<Italian>I nostri minatori vicino a %s2_city hanno scoperto il filone principale! Siamo ricchi, ricchi, ricchi!</Italian>
 		<Spanish>¡Los mineros han dado con el filón principal de oro cerca de %s2_city! ¡Somos ricos, ricos, ricos!</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_TRIGGER_MOTHER_LODE_SILVER_1</Tag>
+        <English>Our silver miners near %s2_city have struck the mother lode! We are rich, rich, rich!</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_TRIGGER_MOTOR_OIL_1</Tag>
 		<English>Our chemists have developed an improved motor oil that lasts longer and lubricates engines better.</English>


### PR DESCRIPTION
- Renamed new forest event and instead of forest now we get young forest, increased odds of the event happening
- Added missing gold cost for ruin searching expedition event and made the event recurring instead of one-off, reduced the chance of the event happening
- Hunting event updated, reduced the chance of it happening added additional choice and increased the hunting event rewards
- Mother-lode event split into gold and silver versions, events rebalanced to give more gold, added additional choice to the events, also made to be recurring with low odds of repeating often
- Added additional needed translations and added image(SilverOreEvent.dds) for the new silver event.