### PR TITLE
Updated events:

### DIFF
--- a/Assets/Python/EntryPoints/CvRandomEventInterface.py
+++ b/Assets/Python/EntryPoints/CvRandomEventInterface.py
@@ -388,12 +388,12 @@ def canTriggerBabyBoom(argsList):
 def applyBardTale3(argsList):
 	data = argsList[1]
 	player = GC.getPlayer(data.ePlayer)
-	player.changeGold(-10 * player.getNumCities())
+	player.changeGold(-50 * player.getNumCities())
 
 def canApplyBardTale3(argsList):
 	data = argsList[1]
 	player = GC.getPlayer(data.ePlayer)
-	if player.getGold() - 10 * player.getNumCities() < 0:
+	if player.getGold() - 50 * player.getNumCities() < 0:
 		return False
 	return True
 
@@ -401,7 +401,7 @@ def canApplyBardTale3(argsList):
 def getHelpBardTale3(argsList):
 	data = argsList[1]
 	player = GC.getPlayer(data.ePlayer)
-	return TRNSLTR.getText("TXT_KEY_EVENT_GOLD_LOST", (10 * player.getNumCities(), ))
+	return TRNSLTR.getText("TXT_KEY_EVENT_GOLD_LOST", (50 * player.getNumCities(), ))
 
 ######## LOOTERS ###########
 
@@ -478,6 +478,8 @@ def canTriggerBrothersInNeed(argsList):
 
   listResources = []
   listResources.append(GC.getInfoTypeForString("BONUS_COPPER_ORE"))
+  listResources.append(GC.getInfoTypeForString("BONUS_OBSIDIAN"))
+  listResources.append(GC.getInfoTypeForString("BONUS_STONE"))
   listResources.append(GC.getInfoTypeForString("BONUS_IRON_ORE"))
   listResources.append(GC.getInfoTypeForString("BONUS_HORSE"))
   listResources.append(GC.getInfoTypeForString("BONUS_ELEPHANTS"))

--- a/Assets/XML/Events/CIV4EventInfos.xml
+++ b/Assets/XML/Events/CIV4EventInfos.xml
@@ -915,12 +915,12 @@
 			<BonusType>BONUS_SPICES</BonusType>
 			<iBonusChange>1</iBonusChange>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_SPICY_2</Type>
 			<Description>TXT_KEY_EVENT_SPICY_2</Description>
-			<iGold>-20</iGold>
+			<iGold>-500</iGold>
 			<FeatureType>FEATURE_FOREST</FeatureType>
 			<iFeatureChange>-1</iFeatureChange>
 			<BonusType>BONUS_SPICES</BonusType>
@@ -930,43 +930,51 @@
 			<PythonCallback>doSpicy2</PythonCallback>
 			<PythonHelp>getHelpSpicy2</PythonHelp>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BABY_BOOM_1</Type>
 			<Description>TXT_KEY_EVENT_BABY_BOOM_1</Description>
-			<iFood>10</iFood>
+			<iFood>150</iFood>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_BABY_BOOM_2</Type>
+			<Description>TXT_KEY_EVENT_BABY_BOOM_2</Description>
+			<iGold>-1000</iGold>
+			<iFood>250</iFood>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BARDS_TALE_1</Type>
 			<Description>TXT_KEY_EVENT_BARDS_TALE_1</Description>
 			<bPickCity>1</bPickCity>
-			<iCulture>100</iCulture>
+			<iCulture>500</iCulture>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BARDS_TALE_2</Type>
 			<Description>TXT_KEY_EVENT_BARDS_TALE_2</Description>
 			<bPickCity>1</bPickCity>
-			<iGold>-25</iGold>
-			<iCulture>450</iCulture>
+			<iGold>-250</iGold>
+			<iCulture>900</iCulture>
 			<Building>BUILDING_THEATRE</Building>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BARDS_TALE_3</Type>
 			<Description>TXT_KEY_EVENT_BARDS_TALE_3</Description>
-			<iCulture>250</iCulture>
+			<iCulture>2500</iCulture>
 			<PrereqTech>TECH_RADIO</PrereqTech>
 			<PythonCallback>applyBardTale3</PythonCallback>
 			<PythonCanDo>canApplyBardTale3</PythonCanDo>
 			<PythonHelp>getHelpBardTale3</PythonHelp>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>3</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_LOOTERS_1</Type>
@@ -974,29 +982,29 @@
 			<OtherPlayerPopup>TXT_KEY_EVENT_LOOTERS_OTHER_1</OtherPlayerPopup>
 			<bPickOtherPlayerCity>1</bPickOtherPlayerCity>
 			<iMinPillage>1</iMinPillage>
-			<iMaxPillage>1</iMaxPillage>
+			<iMaxPillage>2</iMaxPillage>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_LOOTERS_2</Type>
 			<Description>TXT_KEY_EVENT_LOOTERS_2</Description>
 			<OtherPlayerPopup>TXT_KEY_EVENT_LOOTERS_OTHER_2</OtherPlayerPopup>
 			<bPickOtherPlayerCity>1</bPickOtherPlayerCity>
-			<iGold>-40</iGold>
+			<iGold>-200</iGold>
 			<iMinPillage>2</iMinPillage>
 			<iMaxPillage>4</iMaxPillage>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_LOOTERS_3</Type>
 			<Description>TXT_KEY_EVENT_LOOTERS_3</Description>
 			<OtherPlayerPopup>TXT_KEY_EVENT_LOOTERS_OTHER_3</OtherPlayerPopup>
 			<bPickOtherPlayerCity>1</bPickOtherPlayerCity>
-			<iEspionagePoints>-50</iEspionagePoints>
-			<iMinPillage>3</iMinPillage>
-			<iMaxPillage>5</iMaxPillage>
+			<iEspionagePoints>-250</iEspionagePoints>
+			<iMinPillage>4</iMinPillage>
+			<iMaxPillage>6</iMaxPillage>
 			<AdditionalEvents>
 				<EventChance>
 					<Event>EVENT_LOOTERS_4</Event>
@@ -1007,7 +1015,7 @@
 			<PythonCanDo>canApplyLooters3</PythonCanDo>
 			<PythonHelp>getHelpLooters3</PythonHelp>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_LOOTERS_4</Type>
@@ -1016,7 +1024,7 @@
 			<iOurAttitudeModifier>-2</iOurAttitudeModifier>
 			<iAttitudeModifier>-2</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_1</Type>
@@ -1025,7 +1033,7 @@
 			<iAttitudeModifier>-5</iAttitudeModifier>
 			<PythonCanDo>canDoBrothersInNeed1</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_2</Type>
@@ -1035,7 +1043,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_3</Type>
@@ -1045,7 +1053,7 @@
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<iTheirEnemyAttitudeModifier>3</iTheirEnemyAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_4</Type>
@@ -1055,7 +1063,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_5</Type>
@@ -1065,7 +1073,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_6</Type>
@@ -1075,7 +1083,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_7</Type>
@@ -1085,7 +1093,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_8</Type>
@@ -1095,7 +1103,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_9</Type>
@@ -1105,7 +1113,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_10</Type>
@@ -1115,7 +1123,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_11</Type>
@@ -1125,7 +1133,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_12</Type>
@@ -1135,7 +1143,7 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BROTHERS_IN_NEED_13</Type>
@@ -1145,7 +1153,38 @@
 			<iOurAttitudeModifier>3</iOurAttitudeModifier>
 			<iAttitudeModifier>3</iAttitudeModifier>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_BROTHERS_IN_NEED_14</Type>
+			<Description>TXT_KEY_EVENT_BROTHERS_IN_NEED_14</Description>
+			<OtherPlayerPopup>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_14</OtherPlayerPopup>
+			<BonusGift>BONUS_STONE</BonusGift>
+			<iOurAttitudeModifier>3</iOurAttitudeModifier>
+			<iAttitudeModifier>3</iAttitudeModifier>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>2</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_BROTHERS_IN_NEED_15</Type>
+			<Description>TXT_KEY_EVENT_BROTHERS_IN_NEED_15</Description>
+			<OtherPlayerPopup>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_15</OtherPlayerPopup>
+			<BonusGift>BONUS_OBSIDIAN</BonusGift>
+			<iOurAttitudeModifier>3</iOurAttitudeModifier>
+			<iAttitudeModifier>3</iAttitudeModifier>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>2</iAIValue>
+		</EventInfo>
+		<EventInfo>
+			<Type>EVENT_BROTHERS_IN_NEED_16</Type>
+			<Description>TXT_KEY_EVENT_BROTHERS_IN_NEED_16</Description>
+			<OtherPlayerPopup>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_16</OtherPlayerPopup>
+			<iGold>-2000</iGold>
+			<bGoldToPlayer>1</bGoldToPlayer>
+			<iOurAttitudeModifier>3</iOurAttitudeModifier>
+			<iAttitudeModifier>3</iAttitudeModifier>
+			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_HURRICANE_1</Type>
@@ -1154,7 +1193,7 @@
 			<PythonCallback>applyHurricane1</PythonCallback>
 			<PythonCanDo>canApplyHurricane1</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_HURRICANE_2</Type>
@@ -1163,7 +1202,7 @@
 			<iPopulationChange>-1</iPopulationChange>
 			<PythonCanDo>canApplyHurricane2</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_CYCLONE_1</Type>
@@ -1172,7 +1211,7 @@
 			<PythonCallback>applyHurricane1</PythonCallback>
 			<PythonCanDo>canApplyHurricane1</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_CYCLONE_2</Type>
@@ -1181,7 +1220,7 @@
 			<iPopulationChange>-1</iPopulationChange>
 			<PythonCanDo>canApplyHurricane2</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_TSUNAMI_1</Type>
@@ -1190,7 +1229,7 @@
 			<PythonCallback>applyTsunami1</PythonCallback>
 			<PythonCanDo>canApplyTsunami1</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_TSUNAMI_2</Type>
@@ -1201,7 +1240,7 @@
 			<PythonCanDo>canApplyTsunami2</PythonCanDo>
 			<PythonHelp>getHelpTsunami2</PythonHelp>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_MONSOON_1</Type>
@@ -1210,7 +1249,7 @@
 			<PythonCallback>applyHurricane1</PythonCallback>
 			<PythonCanDo>canApplyHurricane1</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_MONSOON_2</Type>
@@ -1219,7 +1258,7 @@
 			<iPopulationChange>-1</iPopulationChange>
 			<PythonCanDo>canApplyHurricane2</PythonCanDo>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BLIZZARD_1</Type>
@@ -1227,20 +1266,20 @@
 			<iImprovementChange>-1</iImprovementChange>
 			<iRouteChange>-1</iRouteChange>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_BLIZZARD_2</Type>
 			<Description>TXT_KEY_EVENT_BLIZZARD_2</Description>
-			<iGold>-5</iGold>
+			<iGold>-50</iGold>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_DUSTBOWL_1</Type>
 			<Description>TXT_KEY_EVENT_DUSTBOWL_1</Description>
 			<bPickCity>1</bPickCity>
-			<iGold>-40</iGold>
+			<iGold>-300</iGold>
 			<iImprovementChange>-1</iImprovementChange>
 			<ClearEvents>
 				<EventChance>
@@ -1249,7 +1288,7 @@
 				</EventChance>
 			</ClearEvents>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>2</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_DUSTBOWL_2</Type>
@@ -1259,12 +1298,12 @@
 			<ClearEvents>
 				<EventChance>
 					<Event>EVENT_DUSTBOWL_2</Event>
-					<iEventChance>25</iEventChance>
+					<iEventChance>40</iEventChance>
 				</EventChance>
 			</ClearEvents>
 			<PythonHelp>getHelpDustBowl2</PythonHelp>
 			<Button>,Art/Interface/Buttons/Process/Blank.dds,Art/Interface/Buttons/Beyond_the_Sword_Atlas.dds,8,5</Button>
-			<iAIValue>1000</iAIValue>
+			<iAIValue>1</iAIValue>
 		</EventInfo>
 		<EventInfo>
 			<Type>EVENT_PARROTS_1</Type>

--- a/Assets/XML/Events/CIV4EventTriggerInfos.xml
+++ b/Assets/XML/Events/CIV4EventTriggerInfos.xml
@@ -1325,17 +1325,22 @@
 		<EventTriggerInfo>
 			<Type>EVENTTRIGGER_SPICY</Type>
 			<WorldNewsTexts>
-				<Text>TXT_KEY_EVENTTRIGGER_SPICY</Text>
+				<Text>TXT_KEY_EVENTTRIGGER_SPICY_1</Text>
+				<Text>TXT_KEY_EVENTTRIGGER_SPICY_2</Text>
 			</WorldNewsTexts>
 			<TriggerTexts>
 				<TriggerText>
 					<Text>TXT_KEY_EVENT_TRIGGER_SPICY_1</Text>
 					<Era>NONE</Era>
 				</TriggerText>
+				<TriggerText>
+					<Text>TXT_KEY_EVENT_TRIGGER_SPICY_2</Text>
+					<Era>NONE</Era>
+				</TriggerText>
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/SpicyEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>5</iWeight>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
 			<bOwnPlot>1</bOwnPlot>
 			<ImprovementsRequired>
@@ -1351,7 +1356,7 @@
 			<OrPreReqs>
 				<PrereqTech>TECH_CALENDAR</PrereqTech>
 			</OrPreReqs>
-			<bGlobal>1</bGlobal>
+			<bRecurring>1</bRecurring>
 			<PythonCanDo>canTriggerSpicy</PythonCanDo>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
@@ -1368,10 +1373,11 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/BabyBoomEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>500</iWeight>
+			<iWeight>30</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_BABY_BOOM_1</Event>
+				<Event>EVENT_BABY_BOOM_</Event>
 			</Events>
 			<AndPreReqs>
 				<PrereqTech>TECH_WARFARE</PrereqTech>
@@ -1394,7 +1400,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/BardsTaleEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>200</iWeight>
+			<iWeight>12</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_BARDS_TALE_1</Event>
@@ -1404,6 +1410,7 @@
 			<OrPreReqs>
 				<PrereqTech>TECH_MUSICAL_NOTATION</PrereqTech>
 			</OrPreReqs>
+			<bRecurring>1</bRecurring>
 			<bPickCity>1</bPickCity>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
@@ -1467,7 +1474,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/LootersEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>25</iWeight>
 			<iAngry>1</iAngry>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
@@ -1493,7 +1500,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/BrothersInNeedEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>1000</iWeight>
+			<iWeight>30</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<bPickReligion>1</bPickReligion>
 			<bStateReligion>1</bStateReligion>
@@ -1511,6 +1518,9 @@
 				<Event>EVENT_BROTHERS_IN_NEED_11</Event>
 				<Event>EVENT_BROTHERS_IN_NEED_12</Event>
 				<Event>EVENT_BROTHERS_IN_NEED_13</Event>
+				<Event>EVENT_BROTHERS_IN_NEED_14</Event>
+				<Event>EVENT_BROTHERS_IN_NEED_15</Event>
+				<Event>EVENT_BROTHERS_IN_NEED_16</Event>
 			</Events>
 			<bRecurring>1</bRecurring>
 			<bPickPlayer>1</bPickPlayer>
@@ -1531,7 +1541,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/HurricaneEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>4</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_HURRICANE_1</Event>
@@ -1542,6 +1552,7 @@
 				<PrereqTech>TECH_PREHISTORIC_MUSIC</PrereqTech>
 				<PrereqTech>TECH_HERBALISM</PrereqTech>
 			</OrPreReqs>
+			<bRecurring>1</bRecurring>
 			<bPickCity>1</bPickCity>
 			<PythonCanDoCity>canTriggerHurricaneCity</PythonCanDoCity>
 		</EventTriggerInfo>
@@ -1558,7 +1569,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/CycloneEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>4</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_CYCLONE_1</Event>
@@ -1570,6 +1581,7 @@
 				<PrereqTech>TECH_HERBALISM</PrereqTech>
 			</OrPreReqs>
 			<bPickCity>1</bPickCity>
+			<bRecurring>1</bRecurring>
 			<PythonCanDoCity>canTriggerCycloneCity</PythonCanDoCity>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
@@ -1585,18 +1597,13 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/TsunamiEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>25</iWeight>
+			<iWeight>1</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_TSUNAMI_1</Event>
 				<Event>EVENT_TSUNAMI_2</Event>
 			</Events>
-			<OrPreReqs>
-				<PrereqTech>TECH_LITERATURE</PrereqTech>
-				<PrereqTech>TECH_CODE_OF_LAWS</PrereqTech>
-				<PrereqTech>TECH_MACHINERY</PrereqTech>
-			</OrPreReqs>
-			<bGlobal>1</bGlobal>
+			<bRecurring>1</bRecurring>
 			<bPickCity>1</bPickCity>
 			<PythonCanDoCity>canTriggerTsunamiCity</PythonCanDoCity>
 		</EventTriggerInfo>
@@ -1613,17 +1620,14 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/MonsoonEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>4</iWeight>
 			<bOwnPlot>1</bOwnPlot>
 			<Events>
 				<Event>EVENT_MONSOON_1</Event>
 				<Event>EVENT_MONSOON_2</Event>
 			</Events>
-			<OrPreReqs>
-				<PrereqTech>TECH_WRITING</PrereqTech>
-				<PrereqTech>TECH_ANIMAL_RIDING</PrereqTech>
-			</OrPreReqs>
 			<bPickCity>1</bPickCity>
+			<bRecurring>1</bRecurring>
 			<PythonCanDoCity>canTriggerMonsoonCity</PythonCanDoCity>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
@@ -1644,7 +1648,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/BlizzardEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>10</iWeight>
 			<iNumPlotsRequired>1</iNumPlotsRequired>
 			<bOwnPlot>1</bOwnPlot>
 			<TerrainsRequired>
@@ -1731,7 +1735,7 @@
 			</TriggerTexts>
 			<EventArt>Art/Event_Images/DustbowlEvent.dds</EventArt>
 			<iPercentGamesActive>100</iPercentGamesActive>
-			<iWeight>100</iWeight>
+			<iWeight>7</iWeight>
 			<iNumPlotsRequired>4</iNumPlotsRequired>
 			<bOwnPlot>1</bOwnPlot>
 			<TerrainsRequired>
@@ -1744,10 +1748,7 @@
 				<Event>EVENT_DUSTBOWL_1</Event>
 				<Event>EVENT_DUSTBOWL_2</Event>
 			</Events>
-			<OrPreReqs>
-				<PrereqTech>TECH_CIVIL_SERVICE</PrereqTech>
-			</OrPreReqs>
-			<bGlobal>1</bGlobal>
+			<bRecurring>1</bRecurring>
 		</EventTriggerInfo>
 		<EventTriggerInfo>
 			<Type>EVENTTRIGGER_DUSTBOWL_CONT</Type>
@@ -1773,7 +1774,7 @@
 				<Event>EVENT_DUSTBOWL_2</Event>
 			</PrereqEvents>
 			<bPrereqEventPlot>1</bPrereqEventPlot>
-			<bGlobal>1</bGlobal>
+			<bRecurring>1</bRecurring>
 			<PythonCanDo>canTriggerDustbowlCont</PythonCanDo>
 		</EventTriggerInfo>
 		<EventTriggerInfo>

--- a/Assets/XML/GameText/Events_CIV4GameText.xml
+++ b/Assets/XML/GameText/Events_CIV4GameText.xml
@@ -2352,13 +2352,17 @@
 		<Spanish>Los mercaderes %s1:3_civ_adjective están ofreciendo descuentos por la compra al por mayor de crudo ácido, que está lleno de impurezas.</Spanish>
 	</TEXT>
 	<TEXT>
-		<Tag>TXT_KEY_EVENTTRIGGER_SPICY</Tag>
+		<Tag>TXT_KEY_EVENTTRIGGER_SPICY_1</Tag>
 		<English>A %s1_civ_adjective chef has identified a new and valuable type of spice.</English>
 		<French>Un dirigeant %s1:1_civ_adjective a identifié une nouvelle sorte d'épice de grande valeur.</French>
 		<German>Ein Koch des %s1:2_civ_adjective Volkes hat eine neue, wertvolle Gewürzsorte entdeckt.</German>
 		<Italian>Uno chef %s1_civ_adjective ha scoperto un nuovo e prezioso tipo di spezia.</Italian>
 		<Spanish>Un cocinero %s1:1_civ_adjective ha identificado un tipo de especia nuevo y valioso.</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENTTRIGGER_SPICY_2</Tag>
+        <English>%s1_civ_adjective farmers have discovered a new herb that makes food more delicious.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENTTRIGGER_SPOILED_GRAIN</Tag>
 		<English>Vermin got in to the granary in %s2_city. All the food stored there was ruined.</English>
@@ -3217,6 +3221,10 @@
 		<Italian>La nostra popolazione sta prosperando in tempo di pace.</Italian>
 		<Spanish>Nuestro pueblo progresa en tiempos de paz.</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BABY_BOOM_2</Tag>
+        <English>Let's help our people even more. Offer subsidies to every family that has more then three children</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_BANANA_BLIGHT</Tag>
 		<English>The tastiest banana sub-species has been wiped out by the dreaded banana blight.</English>
@@ -3749,6 +3757,18 @@
 		<Spanish>Sus unidades mecánicas son débiles. ¡Envíales algunos de nuestros androides!</Spanish>
 		<Polish>Ich jednostki mechaniczne s&#185; s&#179;abe. Wy&#156;lij im kilka naszych android&#243;w!</Polish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_14</Tag>
+        <English>We can send them stone, to build mighty walls.</English>
+    </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_15</Tag>
+        <English>Send them obsidian to build durable weapons.</English>
+    </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_16</Tag>
+        <English>We dont have much but we can always send them gold.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_2</Tag>
 		<English>Offer to send them a large supply of Copper for weapon making.</English>
@@ -3853,6 +3873,18 @@
 		<Polish>Nasi %s1_civ_adjective bracia w wierze podarowali nam [COLOR_HIGHLIGHT_TEXT]Androidy[COLOR_REVERT] by pom&#243;c nam w naszej w wojnie z niewiernymi.</Polish>
 		<Spanish>¡Nuestros hermanos %s1:3_civ_adjective nos han obsequiado con [COLOR_HIGHLIGHT_TEXT]Androides[COLOR_REVERT] para ayudarnos en la guerra!</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_14</Tag>
+        <English>Our %s1_civ_adjective religious brothers have gifted us with [COLOR_HIGHLIGHT_TEXT]Stone[COLOR_REVERT] to aid us in our war effort!</English>
+    </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_15</Tag>
+        <English>Our %s1_civ_adjective religious brothers have gifted us with [COLOR_HIGHLIGHT_TEXT]Obsidian[COLOR_REVERT] to aid us in our war effort!</English>
+    </TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_16</Tag>
+        <English>Our %s1_civ_adjective religious brothers have gifted us with [COLOR_HIGHLIGHT_TEXT]Gold[COLOR_REVERT] to aid us in our war effort!</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_BROTHERS_IN_NEED_OTHER_2</Tag>
 		<English>Our %s1_civ_adjective religious brothers have gifted us with [COLOR_HIGHLIGHT_TEXT]Copper[COLOR_REVERT] to aid us in our war effort!</English>
@@ -12651,6 +12683,10 @@
 		<Italian>Un inventivo chef ha scoperto un nuovo tipo di spezia, che cresce solo in una foresta vicino a %s2_city.</Italian>
 		<Spanish>Un cocinero muy innovador ha descubierto un nuevo tipo de especia que solo crece en un bosque cerca de %s2_city.</Spanish>
 	</TEXT>
+    <TEXT>
+        <Tag>TXT_KEY_EVENT_TRIGGER_SPICY_2</Tag>
+        <English>A worker was farming near the city of %s2_city when he discovered an herb that makes food more delicious.</English>
+    </TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_EVENT_TRIGGER_SPOILED_GRAIN_1</Tag>
 		<English>Vermin have gotten in to the granary in %s2_city. All the food stored there is spoiled.</English>


### PR DESCRIPTION
-Event trigger spicy gives spice resource, decreased chance of event happening, event can happen more than 1 time, added bonus text, increased event choice gold cost, adjusted AI-weight decision values
 -Event baby boom gives food, decreased chance of event happening, event has one more option to chose now(gold for food), event gives more food, adjusted AI-weight decision values
 -Event bard tales gives culture, decreased chance of event happening, event can happen more than 1 time, increased cost and rewards from the event, adjusted AI-weight decision values
 -Event looters where if enemy city has unrest there is an option to destroy improvements, decreased chance of event happening, made every event do more damage, event choice cost more
 -Event brothers in need where you give a nation of same religion a strategic resource, decreased chance of event happening , has 3 more options for (obsidian, stone, gold), now triggers with stone and obsidian, adjusted AI-weight decision values 
-Events hurricane and cyclone that destroy one building or pop, decreased chance of events happening, events can happen more then 1 time, adjusted AI-weight decision values 
-Events monsoon(destroys 1 pop or building) and tsunami(destroys 6 pop or city), decreased chance of events happening, events can happen more then 1 time, adjusted AI-weight decision values, removed prerequisite technologies 
-Event blizzard destroys improvement, decreased chance of event happening, event choices cost more, adjusted AI-weight decision values 
-Event dust bowl destroys farms, decreased chance of event happening, event can happen more then 1 time, increased gold cost of choices, made worse punishment of bad event, adjusted AI-weight decision values, removed prerequisite tech