### PR TITLE
Negative happiness being applied to cities while merging

### DIFF
--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -1558,7 +1558,7 @@ void CvCityAI::AI_chooseProduction()
 	{
 		if (iWorkersInArea == 0) // Not a single worker on my landmass
 		{
-			if (iNeededWorkersInArea > 0 && iProductionRank < (player.getNumCities() + 1) * 2 / 3)
+			if (iNeededWorkersInArea > 0 && iProductionRank <= (player.getNumCities() + 1) * 2 / 3)
 			{
 				if (AI_chooseUnit("no workers", UNITAI_WORKER, -1, -1, CITY_NO_WORKERS_WORKER_PRIORITY))
 				{

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -890,6 +890,8 @@ void CvUnit::reset(int iID, UnitTypes eUnit, PlayerTypes eOwner, bool bConstruct
 	// Toffer - UnitComponents
 	m_commander = NULL;
 	m_worker = NULL;
+
+	m_bInCityWhenKillDelay = false; // Not in a city by default
 }
 
 CvUnit& CvUnit::operator=(const CvUnit& other)
@@ -1590,6 +1592,7 @@ void CvUnit::killUnconditional(bool bDelay, PlayerTypes ePlayer, bool bMessaged)
 		if (bDelay)
 		{
 			m_bDeathDelay = true;
+			pPlot->getPlotCity() ? m_bInCityWhenKillDelay = true : m_bInCityWhenKillDelay = false; // check if there is a city on a plot when unit gets killed
 			return;
 		}
 		{
@@ -15736,7 +15739,7 @@ void CvUnit::setXY(int iX, int iY, bool bGroup, bool bUpdate, bool bShow, bool b
 
 		CvCity* pOldCity = pOldPlot->getPlotCity();
 
-		if (pOldCity)
+		if (pOldCity && (!isDelayedDeath() || (isDelayedDeath() && m_bInCityWhenKillDelay))) // If there is a city on old plot and death is delayed check if there was a city when death happend
 		{
 			if (isMilitaryHappiness())
 			{

--- a/Sources/CvUnit.h
+++ b/Sources/CvUnit.h
@@ -2009,6 +2009,7 @@ protected:
 	bool m_bInhibitSplit;
 	bool m_bIsBuildUp;
 	bool m_bIsReligionLocked;
+	bool m_bInCityWhenKillDelay;
 
 	PlayerTypes m_eOwner;
 	PlayerTypes m_eCapturingPlayer;


### PR DESCRIPTION
On turn 0 AI merges units that it start's with. If they build city at the starting plot in the same turn, negative happiness is applied to city, which results in starting city having at the highest difficulty -6 happiness. It is caused by kill delay.