### PR TITLE
Moved wood gatherer to simple wood working

### DIFF
--- a/Assets/XML/Terrain/CIV4ImprovementInfos.xml
+++ b/Assets/XML/Terrain/CIV4ImprovementInfos.xml
@@ -7385,7 +7385,7 @@
 				<iYieldChange>0</iYieldChange>
 				<iYieldChange>1</iYieldChange>
 			</YieldChanges>
-			<PrereqTech>TECH_WOODWORKING</PrereqTech>
+			<PrereqTech>TECH_SIMPLE_WOOD_WORKING</PrereqTech>
 			<bRequiresFeature>1</bRequiresFeature>
 			<iUpgradeTime>5</iUpgradeTime>
 			<iPillageGold>5</iPillageGold>

--- a/Assets/XML/Units/CIV4BuildInfos.xml
+++ b/Assets/XML/Units/CIV4BuildInfos.xml
@@ -3263,7 +3263,7 @@
 		<BuildInfo>
 			<Type>BUILD_WOOD_GATHERER_KILL</Type>
 			<Description>TXT_KEY_BUILD_WOOD_GATHERER_KILL</Description>
-			<PrereqTech>TECH_WOODWORKING</PrereqTech>
+			<PrereqTech>TECH_SIMPLE_WOOD_WORKING</PrereqTech>
 			<ObsoleteTech>TECH_CLASSICAL_LIFESTYLE</ObsoleteTech>
 			<iTime>200</iTime>
 			<iCost>1</iCost>


### PR DESCRIPTION
the wood gatherer improvement is currently unlocked at TECH_WOODWORKING and its replacement is at carpentry that you can research as soon as you complete woodworking. This pull moves the the wood gatherer to simple wood working about 16 techs before carpentry.