### PR TITLE
Fix moving units from Earth to Cislunar placing them in non-Orbit plots; Fix space unit mission rewards not moving to capital properly

### DIFF
--- a/Assets/Modules/P2K_Multimaps_Test/MM_CIV4UnitInfos.xml
+++ b/Assets/Modules/P2K_Multimaps_Test/MM_CIV4UnitInfos.xml
@@ -221,8 +221,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_LUNAR_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_LUNAR_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Launch to the Moon"
 								def getAIValue(unit, plot):
@@ -6790,8 +6790,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_LOE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									unit = gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_LOE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Place Satellite in Low-Earth Orbit."
 								def getAIValue(unit, plot):
@@ -6823,8 +6823,9 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_CISLUNAR_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_CISLUNAR_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
+
 								def getDisplay(unit,plot):
 									return u"Place Satellite in Geosynchronous Orbit"
 								def getAIValue(unit, plot):
@@ -6959,8 +6960,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS1_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS1_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):
@@ -6992,8 +6993,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS2_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS2_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):
@@ -7025,8 +7026,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS3_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS3_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):
@@ -7134,8 +7135,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INNER_SOLAR_SYSTEM_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INNER_SOLAR_SYSTEM_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore Inner Solar System"
 								def getAIValue(unit, plot):
@@ -7167,8 +7168,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_OUTER_SOLAR_SYSTEM_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_OUTER_SOLAR_SYSTEM_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore Outer Solar System"
 								def getAIValue(unit, plot):
@@ -7200,8 +7201,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_TRANSNEPTUNIAN_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_TRANSNEPTUNIAN_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore Transneptunian Space"
 								def getAIValue(unit, plot):
@@ -7235,8 +7236,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MERCURY_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MERCURY_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7270,8 +7271,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_VENUS_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_VENUS_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7305,8 +7306,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MARS_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MARS_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7340,8 +7341,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ASTEROID_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ASTEROID_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7375,8 +7376,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_JUPITER_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_JUPITER_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7410,8 +7411,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SATURN_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SATURN_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7445,8 +7446,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_EUROPA_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_EUROPA_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7480,8 +7481,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_TITAN_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_TITAN_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7515,8 +7516,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_URANUS_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_URANUS_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7550,8 +7551,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_NEPTUNE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_NEPTUNE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7585,8 +7586,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_KBO_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_KBO_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7618,8 +7619,8 @@
 									return gc.getInfoTypeForString("FEATURE_SEDNOID") == plot.getFeatureType()
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SEDNOID_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SEDNOID_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7651,8 +7652,8 @@
 									return plot.getBonusType(unit.getTeam()) in valid_bonuses
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SOLAR_SYSTEM_LIFE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SOLAR_SYSTEM_LIFE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore a nearby star"
 								def getAIValue(unit, plot):
@@ -7847,8 +7848,8 @@
 									return plot.getFeatureType() in valid_features
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_OORT_CLOUD_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_OORT_CLOUD_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore the Oort Cloud."
 								def getAIValue(unit, plot):
@@ -7880,8 +7881,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERSTELLAR_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERSTELLAR_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore a nearby star"
 								def getAIValue(unit, plot):
@@ -7915,8 +7916,8 @@
 									return plot.getFeatureType() in valid_features
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_EXOPLANET_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_EXOPLANET_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore this planet."
 								def getAIValue(unit, plot):
@@ -7948,8 +7949,8 @@
 									return plot.getBonusType(-1) in valid_bonuses
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERSTELLAR_LIFE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERSTELLAR_LIFE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore a nearby star"
 								def getAIValue(unit, plot):
@@ -8076,8 +8077,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_GALACTIC_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_GALACTIC_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore the galaxy"
 								def getAIValue(unit, plot):
@@ -8109,8 +8110,8 @@
 									return plot.getBonusType(-1) in valid_bonuses
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ANCIENT_CIVILIZATION_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ANCIENT_CIVILIZATION_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Excavate an ancient civilization"
 								def getAIValue(unit, plot):
@@ -8142,8 +8143,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_GALACTIC_CORE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_GALACTIC_CORE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore the galactic core."
 								def getAIValue(unit, plot):
@@ -8287,8 +8288,8 @@
 									return plot.getFeatureType() in valid_features
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERGALACTIC_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_INTERGALACTIC_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore a distant galaxy"
 								def getAIValue(unit, plot):
@@ -8320,8 +8321,8 @@
 									return plot.getBonusType(-1) in valid_bonuses
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ANCIENT_CIVILIZATION_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_ANCIENT_CIVILIZATION_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Excavate an ancient civilization"
 								def getAIValue(unit, plot):
@@ -8513,8 +8514,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_DISTANT_COSMOS_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_DISTANT_COSMOS_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore the far universe"
 								def getAIValue(unit, plot):
@@ -8626,8 +8627,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_HYPERSPACE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_HYPERSPACE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore hyperspace"
 								def getAIValue(unit, plot):
@@ -8659,8 +8660,8 @@
 									return plot.getTerrainType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MULTIVERSE_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_MULTIVERSE_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Explore multiverse"
 								def getAIValue(unit, plot):
@@ -8789,8 +8790,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS1_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS1_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):
@@ -8822,8 +8823,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS2_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS2_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):
@@ -8855,8 +8856,8 @@
 									return plot.getImprovementType() in valid_terrains
 								def doOutcome(unit,plot,eDefPlayer, eDefUnitType):
 									gc = CyGlobalContext()
-									capital = gc.getPlayer(unit.getOwner()).getCapitalCity()
-									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS3_REWARD'),capital.getX(),capital.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getPlayer(unit.getOwner()).initUnit(gc.getInfoTypeForString('UNIT_SS3_REWARD'),plot.getX(),plot.getY(),UnitAITypes.NO_UNITAI,DirectionTypes.DIRECTION_SOUTH)
+									gc.getMapByIndex(MapTypes.MAP_EARTH).moveUnitToMap(unit, 1, true)
 								def getDisplay(unit,plot):
 									return u"Conduct Scientific Mission"
 								def getAIValue(unit, plot):

--- a/Sources/CvMap.h
+++ b/Sources/CvMap.h
@@ -69,7 +69,7 @@ public:
 	void afterSwitch();
 
 	void updateIncomingUnits();
-	void moveUnitToMap(CvUnit& unit, int numTravelTurns);
+	void moveUnitToMap(CvUnit& unit, int numTravelTurns, bool tpToCapital = false);
 	void deleteOffMapUnits();
 
 	//void deleteViewport(int iIndex);

--- a/Sources/CyMap.cpp
+++ b/Sources/CyMap.cpp
@@ -447,10 +447,9 @@ CyPlot* CyMap::getLastPathPlotByIndex(int index) const
 	return NULL;
 }
 
-
-void CyMap::moveUnitToMap(const CyUnit* unit, int numTravelTurns)
+void CyMap::moveUnitToMap(const CyUnit* unit, int numTravelTurns, bool tpToCapital)
 {
-	m_pMap->moveUnitToMap(*unit->getUnit(), numTravelTurns);
+	m_pMap->moveUnitToMap(*unit->getUnit(), numTravelTurns, tpToCapital);
 }
 
 void CyMap::setClimateZone(const int y, const ClimateZoneTypes eClimate)

--- a/Sources/CyMap.h
+++ b/Sources/CyMap.h
@@ -106,7 +106,7 @@ public:
 	int getLastPathStepNum() const;
 	CyPlot* getLastPathPlotByIndex(int index) const;
 
-	void moveUnitToMap(const CyUnit* unit, int numTravelTurns);
+	void moveUnitToMap(const CyUnit* unit, int numTravelTurns, bool tpToCapital = false);
 
 	void setClimateZone(const int y, const ClimateZoneTypes eClimate);
 


### PR DESCRIPTION
Not sure how easy it is to be able to instantly TP a unit between multimaps, as trying to do a `switchMap` during `doOutcome` (regardless of if the switch was in the XML/Python or in actual C++) would crash the game. However to properly create a unit on Earth or get the capital's coords, the current map does need to be Earth... too much random stuff everywhere just assumes to use GC.getMap instead of being passed a map to operate on