### PR TITLE
Paddle Steamer Movement Fix

### DIFF
--- a/Assets/XML/Units/U_Sea_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/U_Sea_CIV4UnitInfos.xml
@@ -729,6 +729,7 @@
 			<bMilitaryProduction>1</bMilitaryProduction>
 			<bPillage>1</bPillage>
 			<bIgnoreBuildingDefense>1</bIgnoreBuildingDefense>
+			<bIgnoreTerrainCost>1</bIgnoreTerrainCost>
 			<bMechanized>1</bMechanized>
 			<bRenderBelowWater>1</bRenderBelowWater>
 			<UnitUpgrades>


### PR DESCRIPTION
The Paddle Steamer is a steam-powered ship. Let it ignore Terrain movement costs. Otherwise it's slower than any wooden ship with the Maneuvering 1 promotion.