### PR TITLE
Recon unit parity fix

### DIFF
--- a/Assets/Modules/Cultures/Cultures_Cultural_CIV4UnitInfos.xml
+++ b/Assets/Modules/Cultures/Cultures_Cultural_CIV4UnitInfos.xml
@@ -28646,8 +28646,10 @@
 			<Description>TXT_KEY_UNIT_WAPITI</Description>
 			<Civilopedia>TXT_KEY_UNIT_WAPITI_PEDIA</Civilopedia>
 			<Advisor>ADVISOR_GROWTH</Advisor>
+			<bBarbCoExist>1</bBarbCoExist>
 			<bNoBadGoodies>1</bNoBadGoodies>
-			<bOnlyDefensive>1</bOnlyDefensive>
+			<bPassage>1</bPassage>
+			<bUpgradeAnywhere>1</bUpgradeAnywhere>
 			<bMilitarySupport>1</bMilitarySupport>
 			<bMilitaryProduction>1</bMilitaryProduction>
 			<bPillage>1</bPillage>
@@ -28674,7 +28676,8 @@
 					<UnitAIType>UNITAI_HUNTER</UnitAIType>
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
-			</NotUnitAIs>
+			</NotUnitAIs>			
+			<SeeInvisible>INVISIBLE_CAMOUFLAGE</SeeInvisible>
 			<PrereqTech>TECH_ROAD_BUILDING</PrereqTech>
 			<BonusType>BONUS_PILAGA</BonusType>
 			<iCost>190</iCost>
@@ -48122,8 +48125,10 @@
 			<Description>TXT_KEY_UNIT_TIGURINI_SCOUTS</Description>
 			<Civilopedia>TXT_KEY_UNIT_TIGURINI_SCOUTS_PEDIA</Civilopedia>
 			<Advisor>ADVISOR_GROWTH</Advisor>
+			<bBarbCoExist>1</bBarbCoExist>
 			<bNoBadGoodies>1</bNoBadGoodies>
-			<bOnlyDefensive>1</bOnlyDefensive>
+			<bPassage>1</bPassage>
+			<bUpgradeAnywhere>1</bUpgradeAnywhere>
 			<bMilitarySupport>1</bMilitarySupport>
 			<bMilitaryProduction>1</bMilitaryProduction>
 			<bPillage>1</bPillage>
@@ -48151,6 +48156,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</NotUnitAIs>
+			<SeeInvisible>INVISIBLE_CAMOUFLAGE</SeeInvisible>
 			<PrereqTech>TECH_ROAD_BUILDING</PrereqTech>
 			<BonusType>BONUS_HELVETIAN</BonusType>
 			<iCost>190</iCost>

--- a/Assets/XML/Units/U_Land_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/U_Land_CIV4UnitInfos.xml
@@ -43411,7 +43411,10 @@
 			<Description>TXT_KEY_UNIT_UNMANNED_TRIKE</Description>
 			<Civilopedia>TXT_KEY_UNIT_UNMANNED_TRIKE_PEDIA</Civilopedia>
 			<Advisor>ADVISOR_GROWTH</Advisor>
-			<bOnlyDefensive>1</bOnlyDefensive>
+			<bBarbCoExist>1</bBarbCoExist>
+			<bNoBadGoodies>1</bNoBadGoodies>
+			<bNoDefensiveBonus>1</bNoDefensiveBonus>
+			<bPassage>1</bPassage>
 			<bMilitarySupport>1</bMilitarySupport>
 			<bMilitaryProduction>1</bMilitaryProduction>
 			<bIgnoreTerrainCost>1</bIgnoreTerrainCost>
@@ -43425,6 +43428,7 @@
 					<bUnitAI>1</bUnitAI>
 				</UnitAI>
 			</UnitAIs>
+			<SeeInvisible>INVISIBLE_CAMOUFLAGE</SeeInvisible>
 			<PrereqTech>TECH_MILITARY_ROBOTICS</PrereqTech>
 			<BonusType>BONUS_TIRES</BonusType>
 			<PrereqBonuses>


### PR DESCRIPTION
Parity changes for Tigurini Scouts and Wapiti, giving them the same abilities as the explorer, and for Unmanned trike, giving it the same abilities as the motorcycle. No stat changes.