### PR TITLE
Rewrite description for Azod od-Dowleh

### DIFF
--- a/Assets/XML/GameText/CIV4GameTextInfos_GreatPeople.xml
+++ b/Assets/XML/GameText/CIV4GameTextInfos_GreatPeople.xml
@@ -1631,12 +1631,12 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_GREAT_PERSON_AZOD_O_DOWLEH</Tag>
-		<English>Azod O-Dowleh</English>
+		<English>Azod od-Dowleh</English>
 		<Russian>Àçîä-î-Äîâëå</Russian>
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_GREAT_PERSON_AZOD_O_DOWLEH_PEDIA</Tag>
-		<English>[BOLD][H1]Azod O-Dowleh[\H1][\BOLD][NEWLINE][BOLD](September 24, 936 - March 26, 983)[\BOLD][NEWLINE]Was king of the Buyid dynasty. He build caravanserai's and dams. In the region of Shiraz, he built a palace with three hundred and sixty rooms with advanced wind towers for air conditioning system of residential rooms.</English>
+		<English>[BOLD][H1]Azod od-Dowleh[\H1][\BOLD][NEWLINE][BOLD](September 24, 936 - March 26, 983)[\BOLD][NEWLINE]Was king of the Buyid dynasty at its zenith. After achieving peace with the Byzantine Empire, the Buyid kingdom became prosperous under his rule; the tax income of Fārs province tripled. He built caravanserais, cisterns, dams, a large hospital, and a palace of three hundred and sixty rooms near Shiraz with elaborate wind towers and water canals.</English>
 		<French>[BOLD][H1]Azod O-Dowleh[\H1][\BOLD][NEWLINE][BOLD](24 Septembre 936 - 26 Mars 983)[\BOLD][NEWLINE]Fils aîné de Rukn ad-Dawla émir bouyide à Ray et à Hamadan. Bâtisseur, sa plus importante construction en Irak est l'hôpital à Bagdad qui est resté en fonction jusqu'après l'invasion mongole. Dans la région de Chiraz, il construit également un palais de trois cent soixante chambres avec un système perfectionné de tours à vent pour la climatisation des pièces d'habitation.</French>
 		<Polish>[BOLD][H1]Azod O-Dowleh[\H1][\BOLD][NEWLINE][BOLD](24 Wrze&#156;nia 936 - 26 Marca 983)[\BOLD][NEWLINE]Emir z dynasti Buyid&#243;w. Budowniczy carawanseraj&#243;w i tam. W regionie Shiraz wypudowa&#179; pa&#179;ac o trzystu sze&#159;dziesi&#234;ciu pokojach, posiadaj&#185;cy skomplikowane wiatraki nap&#234;dzaj&#185;ce klimatyzacje pa&#179;acu.</Polish>
 	</TEXT>


### PR DESCRIPTION
This was rather incoherent; rewrote it based largely on https://iranicaonline.org/articles/azod-al-dawla-abu-soja which appears to be the source for the equivalent mangled text on Wikipedia.