### PR TITLE
Improve support for vscode intellisense

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -16,7 +16,8 @@
         "_DEBUG",
         "_UNICODE",
         "_MSC_VER=900",
-        "FP_PROFILE_EXTRA_ENABLE"
+        "FP_PROFILE_EXTRA_ENABLE",
+        "_MOD_FRACTRADE"
       ],
       "windowsSdkVersion": "10.0.22621.0",
       "cStandard": "c99",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -12,7 +12,12 @@
         "${workspaceFolder}\\Build\\deps\\Boost-1.55.0\\include",
         "${workspaceFolder}\\Build\\deps\\Python24\\include"
       ],
-      "defines": ["_DEBUG", "_UNICODE", "_MSC_VER=900"],
+      "defines": [
+        "_DEBUG",
+        "_UNICODE",
+        "_MSC_VER=900",
+        "FP_PROFILE_EXTRA_ENABLE"
+      ],
       "windowsSdkVersion": "10.0.22621.0",
       "cStandard": "c99",
       "cppStandard": "c++03",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -12,9 +12,8 @@
         "${workspaceFolder}\\Build\\deps\\Boost-1.55.0\\include",
         "${workspaceFolder}\\Build\\deps\\Python24\\include"
       ],
-      "defines": ["_DEBUG", "UNICODE", "_UNICODE"],
+      "defines": ["_DEBUG", "_UNICODE", "_MSC_VER=900"],
       "windowsSdkVersion": "10.0.22621.0",
-      "compilerPath": "${workspaceFolder}\\Build\\deps\\Microsoft Visual C++ Toolkit 2003\\bin\\cl.exe",
       "cStandard": "c99",
       "cppStandard": "c++03",
       "intelliSenseMode": "windows-msvc-x86"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-vscode.cpptools"]
+}

--- a/Sources/.vscode/c_cpp_properties.json
+++ b/Sources/.vscode/c_cpp_properties.json
@@ -16,7 +16,8 @@
         "_DEBUG",
         "_UNICODE",
         "_MSC_VER=900",
-        "FP_PROFILE_EXTRA_ENABLE"
+        "FP_PROFILE_EXTRA_ENABLE",
+        "_MOD_FRACTRADE"
       ],
       "windowsSdkVersion": "10.0.22621.0",
       "compilerPath": "cl.exe",

--- a/Sources/.vscode/c_cpp_properties.json
+++ b/Sources/.vscode/c_cpp_properties.json
@@ -12,7 +12,12 @@
         "${workspaceFolder}\\..\\Build\\deps\\Boost-1.55.0\\include",
         "${workspaceFolder}\\..\\Build\\deps\\Python24\\include"
       ],
-      "defines": [],
+      "defines": [
+        "_DEBUG",
+        "_UNICODE",
+        "_MSC_VER=900",
+        "FP_PROFILE_EXTRA_ENABLE"
+      ],
       "windowsSdkVersion": "10.0.22621.0",
       "compilerPath": "cl.exe",
       "cStandard": "c99",

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -7321,6 +7321,7 @@ int CvCityAI::AI_getGoodTileCount() const
 				{
 					// This check is necessary to stop oscillation which can result
 					// when best build changes food situation for city, changing the best build.
+					// this signature is erroring out in vscode, but it does compile and work as intended, so we ignore the error
 					eBuild = scoring::min_score(
 						pLoopPlot->units() | filtered(CvUnit::fn::getBuildType() != NO_BUILD)
 						| transformed(CvUnit::fn::getBuildType()),

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -26223,11 +26223,11 @@ void CvPlayerAI::AI_setPushReligiousVictory()
 	}
 
 	bool bStateReligionBest = true;
-	for (iI = 0; iI < GC.getNumReligionInfos(); iI++)
+	for (int iJ = 0; iJ < GC.getNumReligionInfos(); iJ++)
 	{
-		if (eStateReligion != (ReligionTypes)iI)
+		if (eStateReligion != (ReligionTypes)iJ)
 		{
-			if (GC.getGame().calculateReligionPercent((ReligionTypes)iI) > iStateReligionInfluence)
+			if (GC.getGame().calculateReligionPercent((ReligionTypes)iJ) > iStateReligionInfluence)
 			{
 				bStateReligionBest = false;
 				break;

--- a/Sources/CvTalkingHeadMessage.cpp
+++ b/Sources/CvTalkingHeadMessage.cpp
@@ -210,7 +210,7 @@ int CvTalkingHeadMessage::getExpireTurn() const
 	case MESSAGE_TYPE_CHAT:
 		iExpireTurn += 20;
 		break;
-    case MESSAGE_TYPE_COMBAT_MESSAGE:
+	case MESSAGE_TYPE_COMBAT_MESSAGE:
 		iExpireTurn += 20;
 		break;
 	case MESSAGE_TYPE_MINOR_EVENT:


### PR DESCRIPTION
this PR does some tweaks to improve the support of vscode intellisense.

important, as of current, you need to use version  `1.19.4`

`1.19.5` and onwards currently breaks intellisense in this project read: 
https://github.com/microsoft/vscode-cpptools/issues/12451
