### PR TITLE
Hunting rewards update

### DIFF
--- a/Assets/XML/GameText/BuildingHelp_CIV4GameText.xml
+++ b/Assets/XML/GameText/BuildingHelp_CIV4GameText.xml
@@ -204,7 +204,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_BUILDINGHELP_COASTAL_TRADE_ROUTES</Tag>
-		<English>[ICON_BULLET]Торговых путей во всех прибрежных городах: %D1_Change</English>
+		<English>[ICON_BULLET]%D1_Change Trade Routes in All Coastal Cities</English>
 		<French>[ICON_BULLET]%D1_Change Routes commerciales dans toutes les villes côtières</French>
 		<German>[ICON_BULLET]%D1_Change Handelswege in allen Küstenstädten</German>
 		<Italian>[ICON_BULLET]%D1_Change rotte commerciali in tutte le città costiere</Italian>

--- a/Assets/XML/Units/CIV4SpawnInfos.xml
+++ b/Assets/XML/Units/CIV4SpawnInfos.xml
@@ -18,7 +18,7 @@ Valid NPC players for spawns:
 	Plots that are not of the same area as the spawn plot is not counted.
  <iMinAreaPlotsPerPlayerUnit> Minimum number of area plots per unit owned by spawning player within the area before spawn is disabled.
 	A value of 20 means that the player must have less than 1 unit per 20 plots in that map area to spawn this unit there.
-	If it's value is bigger than the total maount of plots in an area, then 1 unit will always be allowed to spawn.
+	If it's value is bigger than the total amount of plots in an area, then 1 unit will always be allowed to spawn.
 	This value is ignored for areas with less than 50 plots in total.
  <iMinAreaPlotsPerUnitType> Minimum number of area plots per unit type within the area before spawn is disabled.
 	The unit type is counted regardless of which player owns it.
@@ -40,75 +40,141 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_ANIMAL_JAGUAR_NATIVE</Type>
 			<UnitType>UNIT_ANIMAL_JAGUAR</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>600</iTurns>
+			<iTurns>540</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_MANGROVE</FeatureType>
+				<FeatureType>FEATURE_CAVES</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BISON_NATIVE</Type>
+			<Type>SPAWN_BISON_BONUS</Type>
 			<UnitType>UNIT_BISON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>100</iTurns>
+			<iTurns>90</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_BISON_TERRAIN</Type>
+			<UnitType>UNIT_BISON</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>3</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_BISON_HERD</Type>
+			<UnitType>UNIT_BISON</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<iTurns>810</iTurns>
+			<iStartDate>-200000</iStartDate>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>4</iMaxLocalDensity>
+			<ObsoleteTech>TECH_MEDIEVAL_LIFESTYLE</ObsoleteTech>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-25</iMaxLongitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_BISON</BonusType>
+			</BonusTypes>
+			<SpawnGroup>
+				<UnitType>UNIT_BISON</UnitType>
+				<UnitType>UNIT_BISON</UnitType>
+				<UnitType>UNIT_BISON</UnitType>
+			</SpawnGroup>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_BENGALTIGER_NATIVE</Type>
 			<UnitType>UNIT_BENGALTIGER</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>600</iTurns>
+			<iTurns>540</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_MANGROVE</FeatureType>
+				<FeatureType>FEATURE_CAVES</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_BROWN_BEAR_FOREST</Type>
 			<UnitType>UNIT_BEAR</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
-				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -116,108 +182,198 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_BLACKBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>23</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>23</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_CAMEL_NATIVE</Type>
+			<Type>SPAWN_CAMEL_BONUS</Type>
 			<UnitType>UNIT_CAMEL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>90</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_CAMEL</BonusType>
+			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_CAMEL_TERRAIN</Type>
+			<UnitType>UNIT_CAMEL</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>5</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+				<TerrainType>TERRAIN_DUNES</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_CAVEBEAR_BONUS</Type>
+			<UnitType>UNIT_CAVEBEAR</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>3</iMaxLocalDensity>
+			<ObsoleteTech>TECH_CHIEFDOM</ObsoleteTech>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--            <bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--            <iMinLatitude>25</iMinLatitude>-->
+			<!--            <iMaxLatitude>80</iMaxLatitude>-->
+			<!--            <iMinLongitude>-60</iMinLongitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_DEER</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_CAVEBEAR_NATIVE</Type>
 			<UnitType>UNIT_CAVEBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iTurns>810</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>15</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>30</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<ObsoleteTech>TECH_CHIEFDOM</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>25</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_KANGAROO</BonusType>
-				<BonusType>BONUS_BISON</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
-			</BonusTypes>
+			<!--            <bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--            <iMinLatitude>25</iMinLatitude>-->
+			<!--            <iMaxLatitude>80</iMaxLatitude>-->
+			<!--            <iMinLongitude>-60</iMinLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_CAVES</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_CAVE_LION_NATIVE</Type>
+			<Type>SPAWN_CAVE_LION_BONUS</Type>
 			<UnitType>UNIT_CAVE_LION</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>250</iTurns>
+			<iTurns>225</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>25</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>25</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_DEER</BonusType>
 				<BonusType>BONUS_HORSE</BonusType>
 				<BonusType>BONUS_COW</BonusType>
 				<BonusType>BONUS_DONKEY</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_CHEETAH_NATIVE</Type>
+			<Type>SPAWN_CAVE_LION_TERRAIN</Type>
+			<UnitType>UNIT_CAVE_LION</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>675</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>25</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_CHEETAH_BONUS</Type>
 			<UnitType>UNIT_CHEETAH</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_RABBIT</BonusType>
 				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_HORSE</BonusType>
-				<BonusType>BONUS_COW</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_COW_NATIVE</Type>
+			<Type>SPAWN_CHEETAH_TERRAIN</Type>
+			<UnitType>UNIT_CHEETAH</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>540</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SAVANNA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_COW_BONUS</Type>
 			<UnitType>UNIT_COW</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
@@ -228,29 +384,70 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_DEER_NATIVE</Type>
+			<Type>SPAWN_COW_TERRAIN</Type>
+			<UnitType>UNIT_COW</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>4</iMaxLocalDensity>
+			<ObsoleteTech>TECH_RENAISSANCE_LIFESTYLE</ObsoleteTech>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SAVANNA</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_DEER_BONUS</Type>
 			<UnitType>UNIT_STAG_DEER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_DONKEY_NATIVE</Type>
+			<Type>SPAWN_DEER_TERRAIN</Type>
+			<UnitType>UNIT_STAG_DEER</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>5</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_DONKEY_BONUS</Type>
 			<UnitType>UNIT_DONKEY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
@@ -261,132 +458,229 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_DONKEY_NATIVE2</Type>
+			<Type>SPAWN_DONKEY_TERRAIN</Type>
 			<UnitType>UNIT_DONKEY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<BonusTypes>
-				<BonusType>BONUS_HORSE</BonusType>
-			</BonusTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_ELEPHANT_NATIVE</Type>
+			<Type>SPAWN_ELEPHANT_BONUS</Type>
 			<UnitType>UNIT_ELEPHANT_ASIAN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>150</iTurns>
+			<iTurns>135</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_ELEPHANTS</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_ELEPHANT_TERRAIN</Type>
+			<UnitType>UNIT_ELEPHANT_ASIAN</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>405</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SAVANNA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_FLAMINGO_NATIVE</Type>
 			<UnitType>UNIT_FLAMINGO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>100</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMaxLongitude>100</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_MANGROVE</FeatureType>
+				<FeatureType>FEATURE_SWAMP</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GORILLA_NATIVE</Type>
 			<UnitType>UNIT_GORILLA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-15</iMinLatitude>-->
+			<!--			<iMaxLatitude>15</iMaxLatitude>-->
+			<!--			<iMinLongitude>-40</iMinLongitude>-->
+			<!--			<iMaxLongitude>40</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GRIZZLY_NATIVE</Type>
 			<UnitType>UNIT_GRIZZLY</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>23</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>23</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</FeatureTerrainTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_HORSE_NATIVE</Type>
+			<Type>SPAWN_HORSE_BONUS</Type>
 			<UnitType>UNIT_HORSE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--            <bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--            <iMinLatitude>-60</iMinLatitude>-->
+			<!--            <iMaxLatitude>60</iMaxLatitude>-->
+			<!--            <iMinLongitude>-180</iMinLongitude>-->
+			<!--            <iMaxLongitude>180</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_HORSE</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_HORSE_TERRAIN</Type>
+			<UnitType>UNIT_HORSE</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>270</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>4</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--            <bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--            <iMinLatitude>-60</iMinLatitude>-->
+			<!--            <iMaxLatitude>60</iMaxLatitude>-->
+			<!--            <iMinLongitude>-180</iMinLongitude>-->
+			<!--            <iMaxLongitude>180</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_HYENA_NATIVE</Type>
 			<UnitType>UNIT_HYENA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_HYENA_BONUS</Type>
+			<UnitType>UNIT_HYENA</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<iTurns>170</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_CAMEL</BonusType>
 				<BonusType>BONUS_RABBIT</BonusType>
@@ -400,22 +694,49 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_LION_NATIVE</Type>
 			<UnitType>UNIT_LION</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-20</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-20</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
-				<BonusType>BONUS_COW</BonusType>
 				<BonusType>BONUS_DEER</BonusType>
 				<BonusType>BONUS_HORSE</BonusType>
-				<BonusType>BONUS_DONKEY</BonusType>
+			</BonusTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_LION_BONUS</Type>
+			<UnitType>UNIT_LION</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>170</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-20</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-20</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_DEER</BonusType>
+				<BonusType>BONUS_HORSE</BonusType>
+				<BonusType>BONUS_CAMEL</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -423,44 +744,79 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_ORANGUTAN</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-25</iMinLatitude>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-25</iMinLatitude>-->
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
-			<FeatureTerrainTypes>
-				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
-			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_PANDA_BEAR_NATIVE</Type>
 			<UnitType>UNIT_PANDA_BEAR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_BAMBOO</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_PANTHER_BONUS</Type>
+			<UnitType>UNIT_PANTHER</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>320</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>70</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<BonusTypes>
+				<BonusType>BONUS_COW</BonusType>
+				<BonusType>BONUS_DEER</BonusType>
+				<BonusType>BONUS_RABBIT</BonusType>
+			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_PANTHER_TERRAIN</Type>
+			<UnitType>UNIT_PANTHER</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>960</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>70</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
@@ -468,95 +824,80 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
-				<TerrainType>TERRAIN_BARREN</TerrainType>
-				<TerrainType>TERRAIN_ROCKY</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 			</FeatureTerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_PANTHER_NATIVE</Type>
-			<UnitType>UNIT_PANTHER</UnitType>
-			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>600</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>70</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<iMinLongitude>60</iMinLongitude>
-			<iMaxLongitude>-60</iMaxLongitude>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<BonusTypes>
-				<BonusType>BONUS_COW</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
-			</BonusTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_PANTHER_RANDOM</Type>
-			<UnitType>UNIT_PANTHER</UnitType>
-			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>600</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>70</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<iMinLongitude>60</iMinLongitude>
-			<iMaxLongitude>-60</iMaxLongitude>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<BonusTypes>
-				<BonusType>BONUS_ELEPHANTS</BonusType>
-				<BonusType>BONUS_DONKEY</BonusType>
-			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_PENGUIN_NATIVE</Type>
 			<UnitType>UNIT_PENGUIN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>-40</iMaxLatitude>
-			<BonusTypes>
-				<BonusType>BONUS_SEA_LION_AND_SEAL</BonusType>
-				<BonusType>BONUS_POULTRY</BonusType>
-			</BonusTypes>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>-40</iMaxLatitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_ICE</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_POLARBEAR_NATIVE</Type>
+			<Type>SPAWN_POLARBEAR_BONUS</Type>
 			<UnitType>UNIT_POLARBEAR</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>100</iTurns>
+			<iTurns>250</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_WALRUS</BonusType>
 				<BonusType>BONUS_SEA_LION_AND_SEAL</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_POLARBEAR_TERRAIN</Type>
+			<UnitType>UNIT_POLARBEAR</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>600</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>3</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_ICE</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_PUFFADDER_NATIVE</Type>
 			<UnitType>UNIT_PUFFADDER</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
@@ -569,95 +910,144 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_RACCOON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>23</iMinLatitude>
-			<iMaxLatitude>75</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>23</iMinLatitude>-->
+			<!--			<iMaxLatitude>75</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_REDPANDA_NATIVE</Type>
 			<UnitType>UNIT_REDPANDA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>50</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_BAMBOO</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_SIBERIANTIGER_NATIVE</Type>
+			<Type>SPAWN_SIBERIANTIGER_BONUS</Type>
 			<UnitType>UNIT_SIBERIANTIGER</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>600</iTurns>
+			<iTurns>400</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_HORSE</BonusType>
-				<BonusType>BONUS_DONKEY</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_WARTHOG_NATIVE</Type>
+			<Type>SPAWN_SIBERIANTIGER_TERRAIN</Type>
+			<UnitType>UNIT_SIBERIANTIGER</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>1200</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_WARTHOG_BONUS</Type>
 			<UnitType>UNIT_WARTHOG</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_PIG</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_WARTHOG_TERRAIN</Type>
+			<UnitType>UNIT_WARTHOG</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>360</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>8</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<FeatureTerrainTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_AARDVARK_NATIVE</Type>
 			<UnitType>UNIT_AARDVARK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>-10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>15</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
@@ -673,73 +1063,107 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_BADGER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>20</iMinLatitude>
-			<iMaxLatitude>60</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_BALLPYTHON_NATIVE</Type>
 			<UnitType>UNIT_BALLPYTHON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
-				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BEAVER_NATIVE</Type>
+			<Type>SPAWN_BEAVER_BONUS</Type>
 			<UnitType>UNIT_BEAVER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>-180</iMinLongitude>-->
+			<!--			<iMaxLongitude>180</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BEAVERS</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_BEAVER_TERRAIN</Type>
+			<UnitType>UNIT_BEAVER</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>240</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>10</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>-180</iMinLongitude>-->
+			<!--			<iMaxLongitude>180</iMaxLongitude>-->
+			<bFreshWaterOnly>1</bFreshWaterOnly>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_BONGO_NATIVE</Type>
 			<UnitType>UNIT_BONGO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-30</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>15</iMaxLatitude>-->
+			<!--			<iMinLongitude>-20</iMinLongitude>-->
+			<!--			<iMaxLongitude>45</iMaxLongitude>-->
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
@@ -747,7 +1171,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BUFFALO_CAPE_1</Type>
+			<Type>SPAWN_BUFFALO_CAPE_BONUS</Type>
 			<UnitType>UNIT_BUFFALO_CAPE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<iTurns>80</iTurns>
@@ -756,84 +1180,135 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BUFFALO_CAPE_2</Type>
+			<Type>SPAWN_BUFFALO_CAPE_TERRAIN</Type>
 			<UnitType>UNIT_BUFFALO_CAPE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>160</iTurns>
+			<iTurns>240</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_BISON</BonusType>
-			</BonusTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
+<!--		<SpawnInfo>-->
+<!--			<Type>SPAWN_BUFFALO_CAPE_1</Type>-->
+<!--			<UnitType>UNIT_BUFFALO_CAPE</UnitType>-->
+<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+<!--			<iTurns>80</iTurns>-->
+<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+<!--			<iMaxLocalDensity>4</iMaxLocalDensity>-->
+<!--			<iStartDate>-200000</iStartDate>-->
+<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+<!--			&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMinLatitude>-35</iMinLatitude>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMaxLatitude>15</iMaxLatitude>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMinLongitude>-20</iMinLongitude>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMaxLongitude>50</iMaxLongitude>&ndash;&gt;-->
+<!--			<BonusTypes>-->
+<!--				<BonusType>BONUS_BISON</BonusType>-->
+<!--			</BonusTypes>-->
+<!--			<FeatureTypes>-->
+<!--				<FeatureType>FEATURE_SAVANNA</FeatureType>-->
+<!--				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>-->
+<!--			</FeatureTypes>-->
+<!--			<TerrainTypes>-->
+<!--				<TerrainType>TERRAIN_GRASSLAND</TerrainType>-->
+<!--				<TerrainType>TERRAIN_PLAINS</TerrainType>-->
+<!--			</TerrainTypes>-->
+<!--		</SpawnInfo>-->
+<!--		<SpawnInfo>-->
+<!--			<Type>SPAWN_BUFFALO_CAPE_2</Type>-->
+<!--			<UnitType>UNIT_BUFFALO_CAPE</UnitType>-->
+<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+<!--			<iTurns>160</iTurns>-->
+<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+<!--			<iMaxLocalDensity>4</iMaxLocalDensity>-->
+<!--			<iStartDate>-200000</iStartDate>-->
+<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+<!--			&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMinLatitude>0</iMinLatitude>&ndash;&gt;-->
+<!--			&lt;!&ndash;			<iMinLongitude>60</iMinLongitude>&ndash;&gt;-->
+<!--			<BonusTypes>-->
+<!--				<BonusType>BONUS_BISON</BonusType>-->
+<!--			</BonusTypes>-->
+<!--			<FeatureTypes>-->
+<!--				<FeatureType>FEATURE_SAVANNA</FeatureType>-->
+<!--				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>-->
+<!--			</FeatureTypes>-->
+<!--			<TerrainTypes>-->
+<!--				<TerrainType>TERRAIN_GRASSLAND</TerrainType>-->
+<!--				<TerrainType>TERRAIN_PLAINS</TerrainType>-->
+<!--			</TerrainTypes>-->
+<!--		</SpawnInfo>-->
 		<SpawnInfo>
-			<Type>SPAWN_CARIBOU_NATIVE</Type>
+			<Type>SPAWN_CARIBOU_BONUS</Type>
 			<UnitType>UNIT_CARIBOU</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_DEER</BonusType>
+			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_CARIBOU_TERRAIN</Type>
+			<UnitType>UNIT_CARIBOU</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>540</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>4</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
-				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</FeatureTerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_CARIBOU_NATIVE2</Type>
-			<UnitType>UNIT_CARIBOU</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
-			<BonusTypes>
-				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
-			</BonusTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_CASSOWARY_NATIVE</Type>
 			<UnitType>UNIT_CASSOWARY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>5</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>160</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -841,32 +1316,40 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_PLAINS</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_COBRA_NATIVE</Type>
 			<UnitType>UNIT_COBRA</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMinLongitude>-30</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_DUCK_NATIVE</Type>
 			<UnitType>UNIT_DUCK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>600</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
@@ -875,14 +1358,22 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
+				<FeatureType>FEATURE_OASIS</FeatureType>
+				<FeatureType>FEATURE_MANGROVE</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_DUCK_NATIVE2</Type>
+			<Type>SPAWN_DUCK_BONUS</Type>
 			<UnitType>UNIT_DUCK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
@@ -897,51 +1388,69 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_EAGLE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>60</iMaxLatitude>
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_SWAMP</FeatureType>
+				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_EAGLE_BALD_NATIVE</Type>
 			<UnitType>UNIT_EAGLE_BALD</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>25</iMinLatitude>
-			<iMaxLatitude>60</iMaxLatitude>
-			<iMinLongitude>-65</iMinLongitude>
-			<iMaxLongitude>-125</iMaxLongitude>
+			<!--			<iMinLatitude>25</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
+			<!--			<iMinLongitude>-65</iMinLongitude>-->
+			<!--			<iMaxLongitude>-125</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SWAMP </FeatureType>
+				<FeatureType>FEATURE_FLOOD_PLAINS </FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_EMU_NATIVE</Type>
 			<UnitType>UNIT_EMU</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
@@ -952,39 +1461,41 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GEMSBOK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_BARREN</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_HAAST_EAGLE_NATIVE</Type>
 			<UnitType>UNIT_HAAST_EAGLE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<ObsoleteTech>TECH_RENAISSANCE_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>-40</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>-40</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -992,78 +1503,89 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_HAWK</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>60</iMaxLatitude>
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
 				<TerrainType>TERRAIN_BADLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_HIPPO_NATIVE</Type>
 			<UnitType>UNIT_HIPPO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
+				<FeatureType>FEATURE_OASIS</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_HORNEDOWL_NATIVE</Type>
 			<UnitType>UNIT_HORNEDOWL</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>30</iMinLatitude>
-			<iMaxLatitude>50</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_IBEX_NATIVE</Type>
 			<UnitType>UNIT_IBEX</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_BARREN</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
 				<TerrainType>TERRAIN_BADLAND</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1071,48 +1593,56 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_IGUANA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SWAMP</FeatureType>
+				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_KANGAROO_RED_NATIVE</Type>
 			<UnitType>UNIT_KANGAROO_RED</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_KANGAROO_RED_NATIVE2</Type>
+			<Type>SPAWN_KANGAROO_RED_BONUS</Type>
 			<UnitType>UNIT_KANGAROO_RED</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>150</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>4</iMaxLocalDensity>
+			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
@@ -1124,38 +1654,41 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_KANGAROO_GREY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_KANGAROO_GREY_NATIVE2</Type>
 			<UnitType>UNIT_KANGAROO_GREY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>150</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>6</iMaxLocalDensity>
+			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>70</iMinLongitude>
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>70</iMinLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_KANGAROO</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1163,15 +1696,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_KOALA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-45</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-45</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
@@ -1182,35 +1715,39 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_KOMODO_NATIVE</Type>
 			<UnitType>UNIT_KOMODO_DRAGON</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>35</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_MANDRILL_NATIVE</Type>
 			<UnitType>UNIT_MANDRILL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1218,35 +1755,38 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MOA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>70</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<ObsoleteTech>TECH_RENAISSANCE_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>-30</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>-30</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_MOOSE_NATIVE</Type>
 			<UnitType>UNIT_MOOSE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>40</iMinLatitude>
-			<iMaxLatitude>60</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
@@ -1255,6 +1795,8 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1262,42 +1804,47 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MONITOR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-35</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_MOUFLON_NATIVE</Type>
 			<UnitType>UNIT_MOUFLON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>20</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>45</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_BARREN</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1305,17 +1852,21 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MUSKOX</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>40</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1323,19 +1874,19 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_OKAPI</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
-				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1343,19 +1894,23 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_OSTRICH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>15</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1363,33 +1918,40 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_PHEASANT</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMinAreaPlotsPerUnitType>15</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>30</iMinLatitude>
-			<iMaxLatitude>50</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT </FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_RHEA_NATIVE</Type>
 			<UnitType>UNIT_RHEA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-50</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
@@ -1397,6 +1959,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1404,19 +1967,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_ROCKHOPPER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>550</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>-40</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>-40</iMaxLatitude>-->
 			<TerrainTypes>
-				<TerrainType>TERRAIN_ICE</TerrainType>
-				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
-				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_JAGGED</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
@@ -1424,73 +1984,91 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_SLOTHBEAR_NATIVE</Type>
 			<UnitType>UNIT_SLOTHBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>360</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>95</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_SPECTACLEDBEAR_NATIVE</Type>
 			<UnitType>UNIT_SPECTACLEDBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>15</iMaxLatitude>-->
+			<!--			<iMinLongitude>-80</iMinLongitude>-->
+			<!--			<iMaxLongitude>-50</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_SUNBEAR_NATIVE</Type>
 			<UnitType>UNIT_SUNBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
+			<!--			<iMinLongitude>80</iMinLongitude>-->
+			<!--			<iMaxLongitude>120</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_TASMANIANDEVIL_NATIVE</Type>
 			<UnitType>UNIT_TASMANIANDEVIL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
@@ -1501,12 +2079,12 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_DESERT_TORTOISE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
@@ -1518,13 +2096,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GALAPAGOS_TORTOISE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
@@ -1537,31 +2115,35 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_TURKEY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>30</iMinLatitude>
-			<iMaxLatitude>50</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_VIPER_NATIVE</Type>
 			<UnitType>UNIT_VIPER</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>66</iMaxLatitude>
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>66</iMaxLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -1570,28 +2152,34 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_VIPER_CHAIN_NATIVE</Type>
 			<UnitType>UNIT_VIPER_CHAIN</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>800</iTurns>
+			<iTurns>720</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMinLatitude>-30</iMinLatitude>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMinLongitude>65</iMinLongitude>
-			<iMaxLongitude>105</iMaxLongitude>
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
+			<!--			<iMinLongitude>65</iMinLongitude>-->
+			<!--			<iMaxLongitude>105</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_BAMBOO</FeatureType>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1599,7 +2187,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_VULTURE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>9</iMaxLocalDensity>
@@ -1622,19 +2210,20 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WALLABY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1642,18 +2231,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WALLABY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>150</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>-45</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_KANGAROO</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1661,15 +2249,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WALLAROO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
@@ -1690,12 +2278,11 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>-45</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_KANGAROO</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1703,15 +2290,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GUANACO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-55</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-55</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
@@ -1726,19 +2313,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GUANACO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>150</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_LLAMA</BonusType>
-				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1746,16 +2331,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WILDEBEEST</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
@@ -1769,19 +2354,18 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WILDEBEEST</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
-				<BonusType>BONUS_BISON</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
+				<BonusType>BONUS_ELEPHANT</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1789,19 +2373,20 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_KOOKABURRA</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1809,18 +2394,19 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MACAW</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-30</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1828,15 +2414,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_CAPYBARA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>450</iTurns>
+			<iTurns>400</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>9</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-35</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-35</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-70</iMaxLongitude>-->
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
@@ -1849,22 +2436,24 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GAZELLE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_DESERT</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1872,39 +2461,46 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_RATEL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_BADLAND</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_SKUNK_NATIVE</Type>
 			<UnitType>UNIT_SKUNK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>50</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -1912,88 +2508,121 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WALRUS</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WALRUS</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_WALRUS_NATIVE2</Type>
+			<UnitType>UNIT_WALRUS</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>350</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_ICE</TerrainType>
+				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_WOLVERINE_NATIVE</Type>
 			<UnitType>UNIT_WOLVERINE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_ICE</TerrainType>
 				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_OXPECKER_NATIVE</Type>
 			<UnitType>UNIT_OXPECKER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-50</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_ELEPHANT</BonusType>
+			</BonusTypes>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_TERN_NATIVE</Type>
 			<UnitType>UNIT_TERN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<iMinLatitude>70</iMinLatitude>
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SWAMP</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_CROW_NATIVE</Type>
 			<UnitType>UNIT_CROW</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<iMaxLatitude>70</iMaxLatitude>
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_CORN</BonusType>
 				<BonusType>BONUS_RICE</BonusType>
@@ -2006,14 +2635,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GULL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<iMaxLatitude>80</iMaxLatitude>
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_SEA_LION_AND_SEAL</BonusType>
 				<BonusType>BONUS_FISH</BonusType>
@@ -2022,35 +2650,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BISON_HERD</Type>
-			<UnitType>UNIT_BISON</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>4</iMaxLocalDensity>
-			<ObsoleteTech>TECH_MEDIEVAL_LIFESTYLE</ObsoleteTech>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMaxLongitude>-25</iMaxLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_BISON</BonusType>
-			</BonusTypes>
-			<SpawnGroup>
-				<UnitType>UNIT_BISON</UnitType>
-				<UnitType>UNIT_BISON</UnitType>
-				<UnitType>UNIT_BISON</UnitType>
-			</SpawnGroup>
-		</SpawnInfo>
-		<SpawnInfo>
 			<Type>SPAWN_BOAR_NATIVE</Type>
 			<UnitType>UNIT_BOAR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
@@ -2058,11 +2668,37 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_BOAR_NATIVE</Type>
+			<UnitType>UNIT_BOAR</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>360</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>5</iMaxLocalDensity>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_PIG_NEW_NATIVE</Type>
 			<UnitType>UNIT_PIG_NEW</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>150</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
@@ -2077,13 +2713,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_LOCUST_SMALL_SWARM</UnitType>
 			<PlayerType>INSECT_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<PrereqTech>TECH_AGRICULTURE</PrereqTech>
-			<iMinLongitude>-40</iMinLongitude>
-			<iMaxLongitude>40</iMaxLongitude>
+			<!--			<iMinLongitude>-40</iMinLongitude>-->
+			<!--			<iMaxLongitude>40</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
@@ -2091,6 +2727,11 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_BARREN</TerrainType>
 			</TerrainTypes>
+			<BonusTypes>
+				<BonusType>BONUS_WHEAT</BonusType>
+				<BonusType>BONUS_RICE</BonusType>
+				<BonusType>BONUS_CORN</BonusType>
+			</BonusTypes>
 		</SpawnInfo>
 		<!-- Bigger variants are removed from game because "unfun". Available in three forms in the Bad_Karma modules -->
 		<SpawnInfo>
@@ -2098,41 +2739,62 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_ANTEATER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_LEMUR_NATIVE</Type>
+			<Type>SPAWN_LEMUR_BONUS</Type>
 			<UnitType>UNIT_LEMUR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-26</iMinLatitude>
-			<iMaxLatitude>-12</iMaxLatitude>
-			<iMinLongitude>43</iMinLongitude>
-			<iMaxLongitude>51</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-26</iMinLatitude>-->
+			<!--			<iMaxLatitude>-12</iMaxLatitude>-->
+			<!--			<iMinLongitude>43</iMinLongitude>-->
+			<!--			<iMaxLongitude>51</iMaxLongitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_BANANA</BonusType>
+			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_LEMUR_TERRAIN</Type>
+			<UnitType>UNIT_LEMUR</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>540</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>12</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-26</iMinLatitude>-->
+			<!--			<iMaxLatitude>-12</iMaxLatitude>-->
+			<!--			<iMinLongitude>43</iMinLongitude>-->
+			<!--			<iMaxLongitude>51</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
@@ -2142,16 +2804,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_LOON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
@@ -2162,30 +2823,34 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_PEACOCK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>300</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>6</iMinLatitude>
-			<iMaxLatitude>35</iMaxLatitude>
-			<iMinLongitude>68</iMinLongitude>
-			<iMaxLongitude>97</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>6</iMinLatitude>-->
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMinLongitude>68</iMinLongitude>-->
+			<!--			<iMaxLongitude>97</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_BAMBOO</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_PIGEON_NATIVE</Type>
 			<UnitType>UNIT_PIGEON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
@@ -2197,118 +2862,116 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 			</TerrainTypes>
+			<BonusTypes>
+				<BonusType>BONUS_CORN</BonusType>
+				<BonusType>BONUS_RICE</BonusType>
+			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GERENUK_NATIVE</Type>
 			<UnitType>UNIT_GERENUK</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>270</iTurns>
+			<iTurns>250</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_IMPALA_NATIVE</Type>
 			<UnitType>UNIT_IMPALA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-25</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_IMPALA_NATIVE2</Type>
-			<UnitType>UNIT_IMPALA</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>6</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_DEER</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
-			</BonusTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SCRUB</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_SAIGA_NATIVE</Type>
 			<UnitType>UNIT_SAIGA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 			</TerrainTypes>
+			<BonusTypes>
+				<BonusType>BONUS_SALT</BonusType>
+			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_ASIANBEAR_NATIVE</Type>
 			<UnitType>UNIT_ASIANBEAR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>40</iMinLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_BAMBOO</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_CHIMPANZEE_NATIVE</Type>
 			<UnitType>UNIT_CHIMPANZEE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -2316,7 +2979,6 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
@@ -2326,32 +2988,39 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_PLATYPUS</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>600</iTurns>
+			<iTurns>540</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_TOUCAN_NATIVE</Type>
 			<UnitType>UNIT_TOUCAN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>35</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -2362,22 +3031,22 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_CAPUCHIN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-40</iMinLatitude>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_SEALION_LAND_NATIVE</Type>
+			<Type>SPAWN_SEALION_LAND_NATIVE_BONUS</Type>
 			<UnitType>UNIT_SEALION_LAND</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
@@ -2392,21 +3061,39 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_SEALION_LAND_NATIVE</Type>
+			<UnitType>UNIT_SEALION_LAND</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>350</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_ICE</TerrainType>
+				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_LYNX_NATIVE</Type>
 			<UnitType>UNIT_LYNX</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>10</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>10</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -2414,17 +3101,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_SNOWLEOPARD</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>85</iMaxLatitude>
-			<iMinLongitude>100</iMinLongitude>
-			<iMaxLongitude>160</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>85</iMaxLatitude>-->
+			<!--			<iMinLongitude>100</iMinLongitude>-->
+			<!--			<iMaxLongitude>160</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_ICE</TerrainType>
 				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
@@ -2438,17 +3125,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_BARBARYAPE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-10</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-10</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
@@ -2462,17 +3149,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GELADA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-30</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-30</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
@@ -2485,15 +3172,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_PROCOPTODON</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<ObsoleteTech>TECH_CHIEFDOM</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
@@ -2505,15 +3192,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_QUOLL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>800</iTurns>
+			<iTurns>720</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>5</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>5</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
@@ -2532,16 +3219,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_GIRAFFE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
@@ -2549,25 +3236,28 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 			</FeatureTerrainTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_DARTFROG_NATIVE</Type>
 			<UnitType>UNIT_DARTFROG</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>20</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-50</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>-110</iMinLongitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
@@ -2577,13 +3267,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_ARCTICFOX</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>80</iMinLatitude>
+			<!--			<iMinLatitude>70</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_ICE</TerrainType>
 				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
@@ -2596,16 +3286,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_DHOLE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>310</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
-			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>110</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
@@ -2620,64 +3310,92 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_DINGO</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-10000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-80</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-80</iMinLatitude>-->
+			<!--			<iMinLongitude>110</iMinLongitude>-->
+			<!--			<iMaxLongitude>160</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
 			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
+				<FeatureType>FEATURE_FEATURE_VERY_TALL_GRASS</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_DIREWOLF_NATIVE</Type>
 			<UnitType>UNIT_DIREWOLF</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_COW</BonusType>
 				<BonusType>BONUS_DEER</BonusType>
 				<BonusType>BONUS_HORSE</BonusType>
 				<BonusType>BONUS_DONKEY</BonusType>
-				<BonusType>BONUS_KANGAROO</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_DIREWOLF_TERRAIN</Type>
+			<UnitType>UNIT_DIREWOLF</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_EWOLF_NATIVE</Type>
 			<UnitType>UNIT_EWOLF</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>250</iTurns>
+			<iTurns>220</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>60</iMaxLatitude>-->
+			<!--			<iMinLongitude>0</iMinLongitude>-->
+			<!--			<iMaxLongitude>100</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_FOREST</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -2685,16 +3403,17 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_FENNECFOX</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>5</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMinLongitude>-20</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_DUNES</TerrainType>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
@@ -2708,36 +3427,45 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MANEDWOLF</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-40</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-75</iMinLongitude>-->
+			<!--			<iMaxLongitude>-35</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 				<FeatureType>FEATURE_VERY_TALL_GRASS</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_REDFOX_NATIVE</Type>
 			<UnitType>UNIT_REDFOX</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>80</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMinLongitude>-160</iMinLongitude>-->
+			<!--			<iMaxLongitude>160</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
 			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
@@ -2751,15 +3479,21 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_THYLACINE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>1000</iTurns>
+			<iTurns>900</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>7</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-55</iMinLatitude>-->
+			<!--			<iMaxLatitude>-25</iMaxLatitude>-->
+			<!--			<iMinLongitude>110</iMinLongitude>-->
+			<!--			<iMaxLongitude>160</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
@@ -2779,8 +3513,9 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_COW</BonusType>
@@ -2791,17 +3526,37 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_WOLF_NATIVE_TERRAIN</Type>
+			<UnitType>UNIT_WOLF</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>400</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>15</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>30</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>3</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_FOREST</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_WOLF_PACK</Type>
 			<UnitType>UNIT_WOLF</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>4000</iTurns>
+			<iTurns>3600</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>20</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_COW</BonusType>
@@ -2820,41 +3575,25 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_RIVERCROC_LARGE_TERRAIN</Type>
 			<UnitType>UNIT_RIVER_CROC_LARGE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-23</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>150</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_ROCKY</TerrainType>
-				<TerrainType>TERRAIN_BARREN</TerrainType>
 			</TerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_RIVERCROC_LARGE_FEATURE</Type>
-			<UnitType>UNIT_RIVER_CROC_LARGE</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>2</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
@@ -2863,44 +3602,28 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_RIVERCROC_SMALL_TERRAIN</Type>
+			<Type>SPAWN_RIVERCROC_SMALL_NATIVE</Type>
 			<UnitType>UNIT_RIVER_CROC_SMALL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-23</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>150</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_ROCKY</TerrainType>
-				<TerrainType>TERRAIN_BARREN</TerrainType>
 			</TerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_RIVERCROC_SMALL_FEATURE</Type>
-			<UnitType>UNIT_RIVER_CROC_SMALL</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>6</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
@@ -2909,94 +3632,52 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_CAIMAN_BLACK_1</Type>
+			<Type>SPAWN_CAIMAN_BLACK_NATIVE</Type>
 			<UnitType>UNIT_CAIMAN_BLACK</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMinLatitude>-25</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-85</iMinLongitude>-->
+			<!--			<iMaxLongitude>-45</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-			</TerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_CAIMAN_BLACK_2</Type>
-			<UnitType>UNIT_CAIMAN_BLACK</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>4</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
-			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</TerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_CAIMAN_BLACK_3</Type>
-			<UnitType>UNIT_CAIMAN_BLACK</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>4</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_GHARIAL_TERRAIN</Type>
+			<Type>SPAWN_GHARIAL_NATIVE</Type>
 			<UnitType>UNIT_GHARIAL</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<bFreshWaterOnly>1</bFreshWaterOnly>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>25</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_ROCKY</TerrainType>
-				<TerrainType>TERRAIN_BARREN</TerrainType>
 			</TerrainTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_GHARIAL_FEATURE</Type>
-			<UnitType>UNIT_GHARIAL</UnitType>
-			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>6</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>25</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
@@ -3006,149 +3687,204 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_GATOR_NATIVE</Type>
 			<UnitType>UNIT_GATOR</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>35</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GATOR_ASIAN_NATIVE</Type>
 			<UnitType>UNIT_GATOR_ASIAN</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>3</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>35</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>35</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_NILECROC_NATIVE</Type>
 			<UnitType>UNIT_NILECROC</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
+			<bFreshWaterOnly>1</bFreshWaterOnly>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>30</iMaxLatitude>
-			<iMinLongitude>-15</iMinLongitude>
-			<iMaxLongitude>45</iMaxLongitude>
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
+			<!--			<iMinLongitude>-15</iMinLongitude>-->
+			<!--			<iMaxLongitude>45</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FLOOD_PLAINS</FeatureType>
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_OASIS</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_TAPIR_NATIVE</Type>
 			<UnitType>UNIT_TAPIR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_BRAZILIAN_TAPIR_NATIVE</Type>
 			<UnitType>UNIT_BRAZILIAN_TAPIR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_MALAYAN_TAPIR_NATIVE</Type>
 			<UnitType>UNIT_MALAYAN_TAPIR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_MOUNTAIN_TAPIR_NATIVE</Type>
 			<UnitType>UNIT_MOUNTAIN_TAPIR</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_ROCKY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_AFRICANGREY_NATIVE</Type>
 			<UnitType>UNIT_AFRICANGREY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>380</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_PARROTS</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_AFRICANELEPHANT_NATIVE</Type>
+			<Type>SPAWN_AFRICANGREY_NATIVE1</Type>
+			<UnitType>UNIT_AFRICANGREY</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>900</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>12</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_AFRICANELEPHANT_BONUS</Type>
 			<UnitType>UNIT_ELEPHANT_AFRICAN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
@@ -3158,108 +3894,157 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<iMaxLocalDensity>2</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
 			<BonusTypes>
 				<BonusType>BONUS_ELEPHANTS</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_AFRICANELEPHANT_TERRAIN</Type>
+			<UnitType>UNIT_ELEPHANT_AFRICAN</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SCRUB</FeatureType>
+			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_ARMADILLO_NATIVE</Type>
 			<UnitType>UNIT_ARMADILLO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_ARMADILLO_NATIVE_EDGE</Type>
+			<UnitType>UNIT_ARMADILLO</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>700</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_BABIRUSA_NATIVE</Type>
 			<UnitType>UNIT_BABIRUSA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_CUSCUS_NATIVE</Type>
 			<UnitType>UNIT_CUSCUS</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-23</iMinLatitude>-->
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GLYPTO_NATIVE</Type>
 			<UnitType>UNIT_GLYPTO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_GROUNDSLOTH_NATIVE</Type>
 			<UnitType>UNIT_GROUNDSLOTH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<ObsoleteTech>TECH_CLASSICAL_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>80</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>80</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -3267,13 +4052,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_LIZARD</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>600</iTurns>
+			<iTurns>540</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>50</iMaxLatitude>
+			<!--			<iMaxLatitude>50</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
@@ -3293,15 +4078,19 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_NUMBAT</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_ROCKY</TerrainType>
@@ -3313,16 +4102,16 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_OPOSSUM</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
@@ -3339,101 +4128,129 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_PARROT</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_PARROTS</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_PARROT_NATIVE_ASIA</Type>
+			<Type>SPAWN_PARROT_NATIVE_AFRICA_TERRAIN</Type>
 			<UnitType>UNIT_PARROT</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>750</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_PARROTS</BonusType>
-			</BonusTypes>
+			<FeatureTypes>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_PARROT_NATIVE_OCEANIA</Type>
-			<UnitType>UNIT_PARROT</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>10</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>-20</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<BonusTypes>
-				<BonusType>BONUS_PARROTS</BonusType>
-			</BonusTypes>
-		</SpawnInfo>
+		<!--		<SpawnInfo>-->
+		<!--			<Type>SPAWN_PARROT_NATIVE_ASIA</Type>-->
+		<!--			<UnitType>UNIT_PARROT</UnitType>-->
+		<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+		<!--			<bNeutralOnly>0</bNeutralOnly>-->
+		<!--			<iTurns>350</iTurns>-->
+		<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+		<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+		<!--			<iMaxLocalDensity>10</iMaxLocalDensity>-->
+		<!--			<iStartDate>-200000</iStartDate>-->
+		<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+		<!--&lt;!&ndash;			<iMaxLatitude>23</iMaxLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLongitude>60</iMinLongitude>&ndash;&gt;-->
+		<!--			<BonusTypes>-->
+		<!--				<BonusType>BONUS_PARROTS</BonusType>-->
+		<!--			</BonusTypes>-->
+		<!--		</SpawnInfo>-->
+		<!--		<SpawnInfo>-->
+		<!--			<Type>SPAWN_PARROT_NATIVE_OCEANIA</Type>-->
+		<!--			<UnitType>UNIT_PARROT</UnitType>-->
+		<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+		<!--			<bNeutralOnly>0</bNeutralOnly>-->
+		<!--			<iTurns>350</iTurns>-->
+		<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+		<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+		<!--			<iMaxLocalDensity>10</iMaxLocalDensity>-->
+		<!--			<iStartDate>-200000</iStartDate>-->
+		<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+		<!--&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLatitude>-70</iMinLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMaxLatitude>-20</iMaxLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLongitude>60</iMinLongitude>&ndash;&gt;-->
+		<!--			<BonusTypes>-->
+		<!--				<BonusType>BONUS_PARROTS</BonusType>-->
+		<!--			</BonusTypes>-->
+		<!--		</SpawnInfo>-->
 		<SpawnInfo>
 			<Type>SPAWN_POSSUM_NATIVE</Type>
 			<UnitType>UNIT_POSSUM</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_PYGMYHIPPO_NATIVE</Type>
 			<UnitType>UNIT_PYGMYHIPPO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_RAVEN_NATIVE</Type>
+			<Type>SPAWN_RAVEN_BONUS</Type>
 			<UnitType>UNIT_RAVEN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>250</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
@@ -3452,20 +4269,41 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_RAVEN_NATIVE</Type>
+			<UnitType>UNIT_RAVEN</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>10</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_TAIGA</FeatureType>
+			</FeatureTypes>
+			<FeatureTerrainTypes>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_BARREN</TerrainType>
+			</FeatureTerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_SECRETARYBIRD_NATIVE</Type>
 			<UnitType>UNIT_SECRETARYBIRD</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>8</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
@@ -3480,18 +4318,20 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_TREESLOTH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-70</iMinLatitude>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-70</iMinLatitude>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -3499,38 +4339,47 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WOMBAT</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMaxLatitude>0</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMaxLatitude>0</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
 				<FeatureType>FEATURE_FOREST</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BOOBY_NATIVE</Type>
+			<Type>SPAWN_BOOBY_NATIVE_BONUS</Type>
 			<UnitType>UNIT_BOOBY</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>12</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_BOOBY_NATIVE_TERRAIN</Type>
+			<UnitType>UNIT_BOOBY</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>750</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>12</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -3545,18 +4394,19 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_BARREDOWL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -3564,19 +4414,35 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_SEAEAGLE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_SEAEAGLE_NATIVE1</Type>
+			<UnitType>UNIT_SEAEAGLE</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>600</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>5</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -3591,13 +4457,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_JUNGLE_TARANTULA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>300</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>20</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
@@ -3607,113 +4473,157 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_DESERT_TARANTULA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>500</iTurns>
+			<iTurns>300</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>20</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_DESERT</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_DUNES</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_BARNOWL_AMERICA_EUROPE</Type>
+			<Type>SPAWN_BARNOWL_NATIVE</Type>
 			<UnitType>UNIT_BARNOWL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_FOREST</FeatureType>
+				<FeatureType>FEATURE_FOREST_YOUNG</FeatureType>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_BARNOWL_AMERICA_ASIA</Type>
-			<UnitType>UNIT_BARNOWL</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>5</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<FeatureTypes>
-				<FeatureType>FEATURE_FOREST</FeatureType>
-			</FeatureTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_BARNOWL_OCEANIA</Type>
-			<UnitType>UNIT_BARNOWL</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>5</iMaxLocalDensity>
-			<iStartDate>-200000</iStartDate>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>-20</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<FeatureTypes>
-				<FeatureType>FEATURE_FOREST</FeatureType>
-			</FeatureTypes>
-		</SpawnInfo>
+		<!--		<SpawnInfo>-->
+		<!--			<Type>SPAWN_BARNOWL_AMERICA_EUROPE</Type>-->
+		<!--			<UnitType>UNIT_BARNOWL</UnitType>-->
+		<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+		<!--			<bNeutralOnly>0</bNeutralOnly>-->
+		<!--			<iTurns>350</iTurns>-->
+		<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+		<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+		<!--			<iMaxLocalDensity>5</iMaxLocalDensity>-->
+		<!--			<iStartDate>-200000</iStartDate>-->
+		<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+		<!--&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLatitude>-60</iMinLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMaxLatitude>40</iMaxLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMaxLongitude>60</iMaxLongitude>&ndash;&gt;-->
+		<!--			<FeatureTypes>-->
+		<!--				<FeatureType>FEATURE_FOREST</FeatureType>-->
+		<!--			</FeatureTypes>-->
+		<!--		</SpawnInfo>-->
+		<!--		<SpawnInfo>-->
+		<!--			<Type>SPAWN_BARNOWL_AMERICA_ASIA</Type>-->
+		<!--			<UnitType>UNIT_BARNOWL</UnitType>-->
+		<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+		<!--			<bNeutralOnly>0</bNeutralOnly>-->
+		<!--			<iTurns>360</iTurns>-->
+		<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+		<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+		<!--			<iMaxLocalDensity>5</iMaxLocalDensity>-->
+		<!--			<iStartDate>-200000</iStartDate>-->
+		<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+		<!--&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLatitude>0</iMinLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMaxLatitude>40</iMaxLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLongitude>60</iMinLongitude>&ndash;&gt;-->
+		<!--			<FeatureTypes>-->
+		<!--				<FeatureType>FEATURE_FOREST</FeatureType>-->
+		<!--			</FeatureTypes>-->
+		<!--		</SpawnInfo>-->
+		<!--		<SpawnInfo>-->
+		<!--			<Type>SPAWN_BARNOWL_OCEANIA</Type>-->
+		<!--			<UnitType>UNIT_BARNOWL</UnitType>-->
+		<!--			<PlayerType>PREY_PLAYER</PlayerType>-->
+		<!--			<bNeutralOnly>0</bNeutralOnly>-->
+		<!--			<iTurns>360</iTurns>-->
+		<!--			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>-->
+		<!--			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>-->
+		<!--			<iMaxLocalDensity>5</iMaxLocalDensity>-->
+		<!--			<iStartDate>-200000</iStartDate>-->
+		<!--			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>-->
+		<!--&lt;!&ndash;			<bLatitudeAbs>0</bLatitudeAbs>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLatitude>-60</iMinLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMaxLatitude>-20</iMaxLatitude>&ndash;&gt;-->
+		<!--&lt;!&ndash;			<iMinLongitude>60</iMinLongitude>&ndash;&gt;-->
+		<!--			<FeatureTypes>-->
+		<!--				<FeatureType>FEATURE_FOREST</FeatureType>-->
+		<!--			</FeatureTypes>-->
+		<!--		</SpawnInfo>-->
 		<SpawnInfo>
 			<Type>SPAWN_HARPYEAGLE_NATIVE</Type>
 			<UnitType>UNIT_HARPYEAGLE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>5</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
+				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_AFRICAN_PENGUIN_NATIVE</Type>
+			<Type>SPAWN_AFRICAN_PENGUIN_BONUS</Type>
 			<UnitType>UNIT_AFRICAN_PENGUIN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-80</iMinLatitude>
-			<iMaxLatitude>-40</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-80</iMinLatitude>-->
+			<!--			<iMaxLatitude>-40</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_AFRICAN_PENGUIN_TERRAIN</Type>
+			<UnitType>UNIT_AFRICAN_PENGUIN</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>800</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>10</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-80</iMinLatitude>-->
+			<!--			<iMaxLatitude>-40</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -3724,21 +4634,35 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_GALAPAGOS_PENGUIN_NATIVE</Type>
+			<Type>SPAWN_GALAPAGOS_PENGUIN_BONUS</Type>
 			<UnitType>UNIT_GALAPAGOS_PENGUIN</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_GALAPAGOS_PENGUIN_TERRAIN</Type>
+			<UnitType>UNIT_GALAPAGOS_PENGUIN</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>800</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>10</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -3749,36 +4673,59 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_RAZORBILL_NATIVE</Type>
+			<Type>SPAWN_RAZORBILL_BONUS</Type>
 			<UnitType>UNIT_RAZORBILL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>350</iTurns>
+			<iTurns>320</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>10</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>30</iMinLatitude>
-			<iMaxLatitude>70</iMaxLatitude>
-			<iMinLongitude>-70</iMinLongitude>
-			<iMaxLongitude>30</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>-70</iMinLongitude>-->
+			<!--			<iMaxLongitude>30</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_SABRETOOTH_NATIVE</Type>
+			<Type>SPAWN_RAZORBILL_TERRAIN</Type>
+			<UnitType>UNIT_RAZORBILL</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>20</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>10</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>30</iMinLatitude>-->
+			<!--			<iMaxLatitude>70</iMaxLatitude>-->
+			<!--			<iMinLongitude>-70</iMinLongitude>-->
+			<!--			<iMaxLongitude>30</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_COAST</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
+				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP_POLAR</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_SABRETOOTH_BONUS</Type>
 			<UnitType>UNIT_SABRETOOTH</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>500</iTurns>
+			<iTurns>600</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLongitude>-60</iMaxLongitude>
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_ELEPHANTS</BonusType>
@@ -3790,79 +4737,99 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_SABRETOOTH_TERRAIN</Type>
+			<UnitType>UNIT_SABRETOOTH</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<iTurns>1500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLongitude>-60</iMaxLongitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_GRASS</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_BLACK_RHINO_NATIVE</Type>
 			<UnitType>UNIT_BLACK_RHINO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-50</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_INDIAN_RHINO_NATIVE</Type>
 			<UnitType>UNIT_INDIAN_RHINO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<iMaxLongitude>120</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>120</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+				<TerrainType>TERRAIN_NARSH</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_JAVA_RHINO_NATIVE</Type>
 			<UnitType>UNIT_JAVA_RHINO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>20</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
-			<iMaxLongitude>120</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>20</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
+			<!--			<iMaxLongitude>120</iMaxLongitude>-->
 			<FeatureTypes>
-				<FeatureType>FEATURE_SAVANNA</FeatureType>
+				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
 				<TerrainType>TERRAIN_LUSH</TerrainType>
-				<TerrainType>TERRAIN_PLAINS</TerrainType>
 				<TerrainType>TERRAIN_MUDDY</TerrainType>
 				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
@@ -3872,78 +4839,99 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_WHITE_RHINO</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-50</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-50</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 			</FeatureTypes>
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
 			</FeatureTerrainTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_LUSH</TerrainType>
+				<TerrainType>TERRAIN_MUDDY</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_ELASMOTHERIUM_NATIVE</Type>
 			<UnitType>UNIT_ELASMOTHERIUM</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
-			<iTurns>60</iTurns>
+			<iTurns>460</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
 			<ObsoleteTech>TECH_TRIBALISM</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<FeatureTypes>
-				<FeatureType>FEATURE_SAVANNA</FeatureType>
-			</FeatureTypes>
-			<FeatureTerrainTypes>
-				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
-				<TerrainType>TERRAIN_LUSH</TerrainType>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<TerrainTypes>
 				<TerrainType>TERRAIN_PLAINS</TerrainType>
-				<TerrainType>TERRAIN_MUDDY</TerrainType>
-				<TerrainType>TERRAIN_MARSH</TerrainType>
-			</FeatureTerrainTypes>
+				<TerrainType>TERRAIN_TAIGA</TerrainType>
+				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PERMAFROST</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_ZEBRA_NATIVE</Type>
+			<Type>SPAWN_ZEBRA_BONUS</Type>
 			<UnitType>UNIT_ZEBRA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>50</iTurns>
+			<iTurns>125</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>40</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>6</iMaxLocalDensity>
 			<iStartDate>-200000</iStartDate>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-60</iMinLatitude>
-			<iMaxLatitude>10</iMaxLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_HORSE</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_ZEBRA_TERRAIN</Type>
+			<UnitType>UNIT_ZEBRA</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>450</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>40</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>6</iMaxLocalDensity>
+			<iStartDate>-200000</iStartDate>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-60</iMinLatitude>-->
+			<!--			<iMaxLatitude>10</iMaxLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
+			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<FeatureTypes>
+				<FeatureType>FEATURE_SAVANNA</FeatureType>
+			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_GRASSLAND</TerrainType>
+				<TerrainType>TERRAIN_PLAINS</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_MAMMOTH_BONUS1</Type>
 			<UnitType>UNIT_MAMMOTH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iGlobalTurns>800</iGlobalTurns>
+			<iTurns>600</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>4</iMaxLocalDensity>
@@ -3958,7 +4946,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_MAMMOTH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iGlobalTurns>2400</iGlobalTurns>
+			<iTurns>1200</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>2</iMaxLocalDensity>
@@ -3970,30 +4958,14 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_MAMMOTH_BONUS3</Type>
-			<UnitType>UNIT_MAMMOTH</UnitType>
-			<PlayerType>PREY_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>3</iMaxLocalDensity>
-			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
-			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<BonusTypes>
-				<BonusType>BONUS_MAMMOTH</BonusType>
-			</BonusTypes>
-		</SpawnInfo>
-		<SpawnInfo>
 			<Type>SPAWN_MAMMOTH_TERRAIN</Type>
 			<UnitType>UNIT_MAMMOTH</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iGlobalTurns>5000</iGlobalTurns>
+			<iTurns>1800</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>10</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_TRIBALISM</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
@@ -4010,31 +4982,32 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_BELUGA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>60</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>60</iMinLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_ICE</FeatureType>
 			</FeatureTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_COD_BONUS</Type>
 			<UnitType>UNIT_COD</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>40</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
@@ -4044,14 +5017,13 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_COD</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>3000</iTurns>
+			<iTurns>700</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>40</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>40</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4072,11 +5044,10 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_CRAB</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_CRAB</BonusType>
@@ -4087,46 +5058,57 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_CRAB</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>1000</iTurns>
+			<iTurns>700</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP_POLAR</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_DOLPHIN_NATIVE</Type>
+			<Type>SPAWN_DOLPHIN_BONUS</Type>
 			<UnitType>UNIT_DOLPHIN</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>50</iTurns>
+			<iTurns>125</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WHALE</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_DOLPHIN_TERRAIN</Type>
+			<UnitType>UNIT_DOLPHIN</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>900</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>2</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_COAST</TerrainType>
+				<TerrainType>TERRAIN_SEA</TerrainType>
+				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_DUGONG_NATIVE</Type>
 			<UnitType>UNIT_DUGONG</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>600</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_SEA_GRASS</FeatureType>
@@ -4134,42 +5116,71 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<FeatureTerrainTypes>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
-				<TerrainType>TERRAIN_COAST</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_GIANT_SQUID_BASE</Type>
+			<Type>SPAWN_GIANT_SQUID_BONUS</Type>
 			<UnitType>UNIT_GIANT_SQUID</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>250</iTurns>
+			<iTurns>300</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>400</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WHALE</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_GREATWHITE_NATIVE</Type>
+			<Type>SPAWN_GIANT_SQUID_TERRAIN</Type>
+			<UnitType>UNIT_GIANT_SQUID</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>400</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
+				<TerrainType>TERRAIN_TRENCH</TerrainType>
+				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP_POLAR</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_GREATWHITE_BONUS</Type>
 			<UnitType>UNIT_GREATWHITE</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>200</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>23</iMinLatitude>
-			<iMaxLatitude>67</iMaxLatitude>
+			<!--			<iMinLatitude>23</iMinLatitude>-->
+			<!--			<iMaxLatitude>67</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 				<BonusType>BONUS_WHALE</BonusType>
 				<BonusType>BONUS_SHRIMP</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_GREATWHITE_TERRAIN</Type>
+			<UnitType>UNIT_GREATWHITE</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1200</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>200</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMinLatitude>23</iMinLatitude>-->
+			<!--			<iMaxLatitude>67</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4182,21 +5193,31 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_HAMMERHEAD_NATIVE</Type>
+			<Type>SPAWN_HAMMERHEAD_BONUS</Type>
 			<UnitType>UNIT_HAMMERHEAD</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 				<BonusType>BONUS_WHALE</BonusType>
 				<BonusType>BONUS_SHRIMP</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_HAMMERHEAD_TERRAIN</Type>
+			<UnitType>UNIT_HAMMERHEAD</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>900</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4207,15 +5228,14 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_HUMPBACK_WHALE_NATIVE</Type>
+			<Type>SPAWN_HUMPBACK_WHALE_BONUS</Type>
 			<UnitType>UNIT_HUMPBACK_WHALE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>225</iTurns>
+			<iTurns>500</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WHALE</BonusType>
@@ -4223,7 +5243,26 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_MACKEREL_NATIVE</Type>
+			<Type>SPAWN_HUMPBACK_WHALE_TERRAIN</Type>
+			<UnitType>UNIT_HUMPBACK_WHALE</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1900</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SEA</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
+				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_MACKEREL_BONUS</Type>
 			<UnitType>UNIT_MACKEREL</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
@@ -4231,55 +5270,65 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>0</iMinLatitude>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>0</iMinLatitude>-->
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_MARLIN_NATIVE</Type>
-			<UnitType>UNIT_MARLIN</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
+			<Type>SPAWN_MACKEREL_TERRAIN</Type>
+			<UnitType>UNIT_MACKEREL</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>600</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
-			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>40</iMaxLatitude>
-			<BonusTypes>
-				<BonusType>BONUS_FISH</BonusType>
-			</BonusTypes>
-		</SpawnInfo>
-		<SpawnInfo>
-			<Type>SPAWN_MARLIN_NATIVE2</Type>
-			<UnitType>UNIT_MARLIN</UnitType>
-			<PlayerType>BEAST_PLAYER</PlayerType>
-			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>3000</iTurns>
-			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
-			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
-			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
-				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP_POLAR</TerrainType>
 				<TerrainType>TERRAIN_SEA</TerrainType>
 				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
-				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
-				<TerrainType>TERRAIN_SEA_DEEP_POLAR</TerrainType>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_MARLIN_BONUS</Type>
+			<UnitType>UNIT_MARLIN</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>80</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<BonusTypes>
+				<BonusType>BONUS_FISH</BonusType>
+			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_MARLIN_TERRAIN</Type>
+			<UnitType>UNIT_MARLIN</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>2700</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<TerrainTypes>
+				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_OCEAN</TerrainType>
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
-				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
-				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -4287,28 +5336,26 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_NARWHAL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>250</iTurns>
+			<iTurns>210</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_ICE</FeatureType>
 			</FeatureTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_ORCA_NATIVE</Type>
+			<Type>SPAWN_ORCA_BONUS</Type>
 			<UnitType>UNIT_ORCA</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>200</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WHALE</BonusType>
@@ -4316,17 +5363,35 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
+			<Type>SPAWN_ORCA_TERRAIN</Type>
+			<UnitType>UNIT_ORCA</UnitType>
+			<PlayerType>PREDATOR_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1100</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>200</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_COAST</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
+				<TerrainType>TERRAIN_SEA</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+				<TerrainType>TERRAIN_TRENCH</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
 			<Type>SPAWN_RAY_EAGLE_NATIVE</Type>
 			<UnitType>UNIT_RAY_EAGLE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>450</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>30</iMaxLatitude>
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_CORAL_REEF</FeatureType>
 			</FeatureTypes>
@@ -4338,20 +5403,34 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_RAY_MANTA_NATIVE</Type>
+			<Type>SPAWN_RAY_MANTA_BONUS</Type>
 			<UnitType>UNIT_RAY_MANTA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>260</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>40</iMaxLatitude>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_RAY_MANTA_TERRAIN</Type>
+			<UnitType>UNIT_RAY_MANTA</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>600</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>40</iMaxLatitude>-->
+			<FeatureTypes>
+				<FeatureType>FEATURE_CORAL_REEF</FeatureType>
+			</FeatureTypes>
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4362,9 +5441,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_OCEAN</TerrainType>
-				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_OCEAN_TROPICAL</TerrainType>
-				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
@@ -4372,11 +5449,10 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_REEF_SHARK</UnitType>
 			<PlayerType>PREDATOR_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<FeatureTypes>
 				<FeatureType>FEATURE_CORAL_REEF</FeatureType>
@@ -4391,16 +5467,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_SALTCROC_LARGE_NATIVE</Type>
 			<UnitType>UNIT_SALTWATER_CROC_LARGE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>400</iTurns>
+			<iTurns>360</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-23</iMinLatitude>-->
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
@@ -4410,16 +5485,15 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<Type>SPAWN_SALTCROC_SMALL_NATIVE</Type>
 			<UnitType>UNIT_SALTWATER_CROC_SMALL</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
-			<iTurns>300</iTurns>
+			<iTurns>270</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>-23</iMinLatitude>
-			<iMaxLatitude>23</iMaxLatitude>
-			<iMinLongitude>60</iMinLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>-23</iMinLatitude>-->
+			<!--			<iMaxLatitude>23</iMaxLatitude>-->
+			<!--			<iMinLongitude>60</iMinLongitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
@@ -4430,31 +5504,32 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_SEALION_SEA</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>200</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<BonusTypes>
-				<BonusType>BONUS_SEA_LION_AND_SEAL</BonusType>
-			</BonusTypes>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_COAST</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
+				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
+				<TerrainType>TERRAIN_COAST_DEEP_POLAR</TerrainType>
+			</TerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
 			<Type>SPAWN_SEAOTTER_NATIVE</Type>
 			<UnitType>UNIT_SEAOTTER</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>225</iTurns>
+			<iTurns>200</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<bLatitudeAbs>0</bLatitudeAbs>
-			<iMinLatitude>50</iMinLatitude>
-			<iMinLongitude>-60</iMinLongitude>
-			<iMaxLongitude>60</iMaxLongitude>
+			<!--			<bLatitudeAbs>0</bLatitudeAbs>-->
+			<!--			<iMinLatitude>50</iMinLatitude>-->
+			<!--			<iMinLongitude>-60</iMinLongitude>-->
+			<!--			<iMaxLongitude>60</iMaxLongitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_KELP</FeatureType>
 			</FeatureTypes>
@@ -4472,13 +5547,12 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<UnitType>UNIT_SEATURTLE</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>200</iTurns>
+			<iTurns>180</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>30</iMaxLatitude>
+<!--			<iMaxLatitude>30</iMaxLatitude>-->
 			<FeatureTypes>
 				<FeatureType>FEATURE_CORAL_REEF</FeatureType>
 			</FeatureTypes>
@@ -4487,36 +5561,53 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP_TROPICAL</TerrainType>
-				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
-				<TerrainType>TERRAIN_COAST_DEEP_POLAR</TerrainType>
 			</FeatureTerrainTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_TUNA_NATIVE</Type>
+			<Type>SPAWN_TUNA_BONUS</Type>
 			<UnitType>UNIT_TUNA</UnitType>
 			<PlayerType>PREY_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>100</iTurns>
+			<iTurns>80</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>30</iMaxLatitude>
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_FISH</BonusType>
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_WHALE_MINKIE_NATIVE</Type>
+			<Type>SPAWN_TUNA_TERRAIN</Type>
+			<UnitType>UNIT_TUNA</UnitType>
+			<PlayerType>PREY_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>320</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>40</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>80</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SEA</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+				<TerrainType>TERRAIN_TRENCH</TerrainType>
+				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP_POLAR</TerrainType>
+				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
+				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_WHALE_MINKIE_BONUS</Type>
 			<UnitType>UNIT_MINKIE_WHALE</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>400</iTurns>
+			<iTurns>460</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
 			<BonusTypes>
 				<BonusType>BONUS_WHALE</BonusType>
@@ -4524,20 +5615,52 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			</BonusTypes>
 		</SpawnInfo>
 		<SpawnInfo>
-			<Type>SPAWN_WHALESHARK_NATIVE</Type>
+			<Type>SPAWN_WHALE_MINKIE_TERRAIN</Type>
+			<UnitType>UNIT_MINKIE_WHALE</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1200</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>50</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<TerrainTypes>
+				<TerrainType>TERRAIN_SEA</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP</TerrainType>
+				<TerrainType>TERRAIN_OCEAN</TerrainType>
+				<TerrainType>TERRAIN_TRENCH</TerrainType>
+				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
+				<TerrainType>TERRAIN_SEA_DEEP_POLAR</TerrainType>
+				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
+				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
+			</TerrainTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_WHALESHARK_BONUS</Type>
 			<UnitType>UNIT_WHALESHARK</UnitType>
 			<PlayerType>BEAST_PLAYER</PlayerType>
 			<bNeutralOnly>0</bNeutralOnly>
-			<iTurns>150</iTurns>
+			<iTurns>350</iTurns>
 			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
 			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
 			<iMaxLocalDensity>1</iMaxLocalDensity>
-			<PrereqTech>TECH_FISHING</PrereqTech>
 			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMaxLatitude>30</iMaxLatitude>
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_SHRIMP</BonusType>
 			</BonusTypes>
+		</SpawnInfo>
+		<SpawnInfo>
+			<Type>SPAWN_WHALESHARK_TERRAIN</Type>
+			<UnitType>UNIT_WHALESHARK</UnitType>
+			<PlayerType>BEAST_PLAYER</PlayerType>
+			<bNeutralOnly>0</bNeutralOnly>
+			<iTurns>1500</iTurns>
+			<iMinAreaPlotsPerPlayerUnit>30</iMinAreaPlotsPerPlayerUnit>
+			<iMinAreaPlotsPerUnitType>100</iMinAreaPlotsPerUnitType>
+			<iMaxLocalDensity>1</iMaxLocalDensity>
+			<rateOverrideDefineName>SEA_ANIMAL_SPAWN_MODIFIER</rateOverrideDefineName>
+			<!--			<iMaxLatitude>30</iMaxLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4549,7 +5672,9 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 			</TerrainTypes>
 		</SpawnInfo>
+		<!--		!!!!!!!!!!!!!!!!!!!!-->
 		<!-- Neanderthals -->
+		<!--		!!!!!!!!!!!!!!!!!!!-->
 		<SpawnInfo>
 			<Type>SPAWN_NEANDERTHAL_BASE</Type>
 			<UnitType>UNIT_NEANDERTHAL_BRUTE</UnitType>
@@ -4647,7 +5772,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_HARD_HAMMER_PERCUSSION</PrereqTech>
 			<ObsoleteTech>TECH_SHARPENING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>40</iMinLatitude>
+			<!--			<iMinLatitude>40</iMinLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_BISON</BonusType>
 				<BonusType>BONUS_DEER</BonusType>
@@ -4680,7 +5805,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_SHARPENING</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -4702,7 +5827,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_RAFT_BUILDING</PrereqTech>
 			<ObsoleteTech>TECH_BOAT_BUILDING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4723,7 +5848,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_HARPOON_MAKING</PrereqTech>
 			<ObsoleteTech>TECH_NAVAL_WARFARE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4744,7 +5869,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_BOAT_BUILDING</PrereqTech>
 			<ObsoleteTech>TECH_SAILING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_COAST</TerrainType>
 				<TerrainType>TERRAIN_COAST_DEEP</TerrainType>
@@ -4765,7 +5890,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_ELEPHANT_DOMESTICATION</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<BonusTypes>
 				<BonusType>BONUS_ELEPHANTS</BonusType>
 			</BonusTypes>
@@ -4783,7 +5908,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_OBSIDIAN_WEAPONS</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -4808,7 +5933,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_OBSIDIAN_WEAPONS</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -4833,7 +5958,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_SPEAR_MAKING</PrereqTech>
 			<ObsoleteTech>TECH_OBSIDIAN_WEAPONS</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
@@ -4859,7 +5984,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_AXE_MAKING</PrereqTech>
 			<ObsoleteTech>TECH_OBSIDIAN_WEAPONS</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
@@ -4885,7 +6010,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_SIMPLE_WOOD_WORKING</PrereqTech>
 			<ObsoleteTech>TECH_SPEAR_MAKING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
@@ -4908,7 +6033,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_OBSIDIAN_WEAPONS</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -4933,7 +6058,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_OBSIDIAN_WEAPONS</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -4958,7 +6083,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_COMPOSITE_TOOLS</PrereqTech>
 			<ObsoleteTech>TECH_OBSIDIAN_WEAPONS</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
@@ -4984,7 +6109,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_HUNTING</PrereqTech>
 			<ObsoleteTech>TECH_SEDENTARY_LIFESTYLE</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainTypes>
@@ -5006,7 +6131,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_TRACKING</PrereqTech>
 			<ObsoleteTech>TECH_HUNTING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
@@ -5029,7 +6154,7 @@ Using both <iGlobalTurns> and <iTurns> will not yield predictable results:
 			<PrereqTech>TECH_PERSISTENCE_HUNTING</PrereqTech>
 			<ObsoleteTech>TECH_TRACKING</ObsoleteTech>
 			<rateOverrideDefineName>NEANDERTHAL_SPAWN_MODIFIER</rateOverrideDefineName>
-			<iMinLatitude>50</iMinLatitude>
+			<!--			<iMinLatitude>50</iMinLatitude>-->
 			<TerrainTypes>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>

--- a/Assets/XML/Units/U_Animals_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/U_Animals_CIV4UnitInfos.xml
@@ -74,8 +74,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -91,7 +91,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_AARDVARK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -100,16 +100,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -200,8 +232,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -219,7 +251,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_AFRICANGREY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -229,15 +261,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -328,8 +362,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -347,7 +381,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_AFRICAN_PENGUIN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -356,13 +390,17 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>2</iYield>
+						<iYield>0</iYield>
 						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>2</iYield>
+						<iYield>0</iYield>
 						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
@@ -457,11 +495,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>9</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iEarlyWithdraw>30</iEarlyWithdraw>
 			<FeatureAttacks>
@@ -491,7 +529,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>0</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_JAGUAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -500,16 +538,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>100</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -601,8 +671,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -618,7 +688,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ANTEATER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -627,16 +697,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -760,8 +862,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -777,7 +879,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ARCTICFOX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -786,16 +888,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -886,8 +1010,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -903,7 +1027,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ARMADILLO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -912,16 +1036,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1019,7 +1175,7 @@
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -1044,16 +1200,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>21</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>21</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1183,11 +1371,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iEarlyWithdraw>20</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -1208,13 +1396,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_PIG</BonusType>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_BABIRUSA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1223,16 +1427,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1300,11 +1536,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -1320,7 +1556,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BADGER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1329,16 +1565,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1411,11 +1679,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -1431,7 +1699,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BALLPYTHON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1442,14 +1710,26 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1540,11 +1820,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -1561,7 +1841,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BARBARYAPE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1570,16 +1850,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1640,8 +1942,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
@@ -1660,7 +1962,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BARNOWL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1668,12 +1970,19 @@
 							<ID>TECH_SEDENTARY_LIFESTYLE</ID>
 						</Has>
 					</bUnitToCity>
+					<Yields>
+						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
+					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1751,8 +2060,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>55</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
@@ -1784,7 +2093,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BARREDOWL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -1792,12 +2101,19 @@
 							<ID>TECH_SEDENTARY_LIFESTYLE</ID>
 						</Has>
 					</bUnitToCity>
+					<Yields>
+						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
+					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -1889,11 +2205,11 @@
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iPursuit>10</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -1921,11 +2237,22 @@
 					<Yields>
 						<iYield>
 							<Plus>
-								<Constant>1</Constant>
-								<Random>2</Random>
+								<Constant>45</Constant>
+								<Random>135</Random>
 							</Plus>
 						</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>26</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -1934,11 +2261,22 @@
 					<Yields>
 						<iYield>
 							<Plus>
-								<Constant>1</Constant>
-								<Random>2</Random>
+								<Constant>45</Constant>
+								<Random>135</Random>
 							</Plus>
 						</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>26</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2015,8 +2353,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -2037,13 +2375,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_BEAVERS</BonusType>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_BEAVER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -2052,16 +2406,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2161,8 +2547,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -2179,34 +2565,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_BELUGA</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>10</iYield>
-						<iYield>5</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>35</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BELUGA</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>8</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>35</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>10</iYield>
-						<iYield>5</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>35</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2297,11 +2731,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>8</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>14</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iPursuit>15</iPursuit>
 			<UnitMeshGroups>
@@ -2328,16 +2762,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>85</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>125</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>85</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>125</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2431,11 +2897,11 @@
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -2454,10 +2920,30 @@
 					<OutcomeType>OUTCOME_BONUS_SPAWNED</OutcomeType>
 					<iChance>2</iChance>
 					<BonusType>BONUS_BISON</BonusType>
+					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>270</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>33</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_BISON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -2466,16 +2952,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>270</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>33</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>270</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>33</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2563,11 +3081,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -2592,16 +3110,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>105</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>105</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2712,11 +3262,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -2737,13 +3287,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_PIG</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_BOAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -2752,16 +3318,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2861,8 +3459,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -2880,7 +3478,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BONGO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -2889,16 +3487,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>75</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>75</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -2984,8 +3614,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3003,7 +3633,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BOOBY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3012,13 +3642,17 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>1</iYield>
+						<iYield>0</iYield>
 						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>1</iYield>
+						<iYield>0</iYield>
 						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
@@ -3128,11 +3762,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -3148,7 +3782,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BUFFALO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3157,16 +3791,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>250</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>250</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -3273,11 +3939,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -3293,7 +3959,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>0</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CAIMAN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3302,16 +3968,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>110</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>100</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>110</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -3395,11 +4093,11 @@
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3420,13 +4118,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_CAMEL</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_CAMEL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3435,16 +4149,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -3525,8 +4271,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3544,7 +4290,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CAPUCHIN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3554,14 +4300,16 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
 						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
 						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
@@ -3664,8 +4412,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3683,7 +4431,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CAPYBARA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3692,16 +4440,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -3803,8 +4583,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3825,13 +4605,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_DEER</BonusType>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_CARIBOU</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3840,16 +4636,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -3935,11 +4763,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>1</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>5</iWithdrawalProb>
 			<iEarlyWithdraw>30</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -3957,7 +4785,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CASSOWARY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -3966,16 +4794,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4047,11 +4907,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>5</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -4076,16 +4936,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4186,11 +5078,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>7</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>35</iPursuit>
 			<UnitMeshGroups>
@@ -4221,16 +5113,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>125</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>56</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>125</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>56</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4318,11 +5242,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
 			<iEarlyWithdraw>40</iEarlyWithdraw>
@@ -4350,16 +5274,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>26</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>64</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>26</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>64</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4463,11 +5419,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -4485,7 +5441,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CHIMPANZEE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -4494,16 +5450,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>10</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>10</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4562,11 +5540,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>70</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -4584,7 +5562,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_COBRA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -4593,16 +5571,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4686,8 +5676,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -4706,7 +5696,9 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_FISH</BonusType>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>5</iYield>
+						<iYield>0</iYield>
+						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -4717,25 +5709,31 @@
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>5</iYield>
+						<iYield>0</iYield>
+						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_SMALL</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_COD</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>5</iYield>
+						<iYield>0</iYield>
+						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>5</iYield>
+						<iYield>0</iYield>
+						<iYield>2</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4822,11 +5820,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -4845,13 +5843,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_COW</BonusType>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>27</Constant>
+								<Random>27</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>13</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_COW</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -4860,16 +5874,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>27</Constant>
+								<Random>27</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>13</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>27</Constant>
+								<Random>27</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>13</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -4947,8 +5993,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -4967,6 +6013,8 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_CRAB</BonusType>
 					<Yields>
+						<iYield>2</iYield>
+						<iYield>0</iYield>
 						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
@@ -4979,6 +6027,8 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>2</iYield>
+						<iYield>0</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -4990,13 +6040,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>2</iYield>
+						<iYield>0</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>82</iChance>
 					<Yields>
 						<iYield>2</iYield>
+						<iYield>0</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5073,8 +6127,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>10</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -5092,7 +6146,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CROW</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5102,13 +6156,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5176,8 +6234,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -5195,7 +6253,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_CUSCUS</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5204,14 +6262,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5305,8 +6387,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -5322,7 +6404,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DARTFROG</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5332,17 +6414,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>0</iYield>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>0</iYield>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5400,8 +6482,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -5417,7 +6499,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DESERT_TORTOISE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5426,16 +6508,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5543,11 +6647,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -5563,7 +6667,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DHOLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5572,16 +6676,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5660,11 +6786,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -5680,7 +6806,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DINGO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -5689,16 +6815,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5788,11 +6936,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>6</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iPursuit>25</iPursuit>
 			<UnitMeshGroups>
@@ -5819,16 +6967,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -5909,8 +7089,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iPursuit>20</iPursuit>
 			<UnitMeshGroups>
@@ -5928,34 +7108,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_DOLPHIN</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DOLPHIN</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6031,8 +7259,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -6053,13 +7281,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_DONKEY</BonusType>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>195</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_DONKEY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6068,16 +7312,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>195</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>195</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6152,8 +7428,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>70</iWithdrawalProb>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -6174,12 +7450,19 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_POULTRY</BonusType>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_DUCK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6188,14 +7471,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6272,8 +7569,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -6289,34 +7586,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_DUGONG</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DUGONG</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6392,8 +7737,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iPursuit>35</iPursuit>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
@@ -6412,7 +7757,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_EAGLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6423,14 +7768,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6504,8 +7851,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iPursuit>35</iPursuit>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
@@ -6524,7 +7871,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_EAGLE_BALD</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6535,14 +7882,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6634,11 +7983,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>5</iCombat>
+			<iCombat>7</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -6656,14 +8005,30 @@
 					<OutcomeType>OUTCOME_BONUS_SPAWNED</OutcomeType>
 					<iChance>2</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 					<BonusType>BONUS_ELEPHANTS</BonusType>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_AFRICANELEPHANT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6672,16 +8037,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6758,11 +8155,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>5</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>11</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -6781,13 +8178,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_ELEPHANTS</BonusType>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>150</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_ELEPHANT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6796,16 +8209,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>150</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>150</Constant>
+								<Random>350</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>82</Constant>
+								<Random>55</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -6888,8 +8333,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -6907,7 +8352,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_EMU</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -6916,16 +8361,42 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7013,11 +8484,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iPursuit>20</iPursuit>
 			<UnitMeshGroups>
@@ -7035,7 +8506,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_EWOLF</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7044,16 +8515,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>5</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>5</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7131,8 +8614,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -7148,7 +8631,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_FENNECFOX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7159,14 +8642,26 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7260,8 +8755,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>85</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -7279,7 +8774,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_FLAMINGO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7288,16 +8783,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7386,8 +8893,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>95</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -7405,7 +8912,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GALAPAGOS_PENGUIN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7414,14 +8921,14 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7471,11 +8978,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -7491,7 +8998,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GALAPAGOS_TORTOISE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7500,16 +9007,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7599,11 +9138,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -7628,16 +9167,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>32</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>32</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7710,11 +9281,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -7730,7 +9301,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GATOR_ASIAN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7739,16 +9310,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7830,8 +9433,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>55</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -7849,7 +9452,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GAZELLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7858,16 +9461,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -7948,11 +9583,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -7970,7 +9605,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GELADA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -7979,16 +9614,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8073,8 +9740,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -8092,7 +9759,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GEMSBOK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -8101,16 +9768,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8193,8 +9892,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>95</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -8212,7 +9911,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GERENUK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -8221,16 +9920,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8326,11 +10057,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -8346,7 +10077,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GHARIAL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -8355,16 +10086,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>14</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>14</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8421,11 +10184,11 @@
 				<TerrainType>TERRAIN_COAST_POLAR</TerrainType>
 				<TerrainType>TERRAIN_COAST_TROPICAL</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2</fMaxSpeed>
@@ -8441,34 +10204,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_GIANT_SQUID</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GIANT_SQUID</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8548,8 +10359,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -8565,7 +10376,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GIRAFFE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -8574,16 +10385,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8656,11 +10499,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -8676,7 +10519,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GLYPTO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -8685,16 +10528,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>250</Constant>
+								<Random>250</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>250</Constant>
+								<Random>250</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>22</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8783,11 +10658,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>4</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iPursuit>25</iPursuit>
 			<UnitMeshGroups>
@@ -8814,16 +10689,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8884,8 +10791,8 @@
 			<iCombat>4</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iPursuit>60</iPursuit>
 			<UnitMeshGroups>
@@ -8903,34 +10810,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_GREATWHITE</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>58</Constant>
+								<Random>42</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GREATWHITE</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>58</Constant>
+								<Random>42</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>58</Constant>
+								<Random>42</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -8984,11 +10939,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<iPursuit>20</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -9014,16 +10969,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>14</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>14</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9105,10 +11092,10 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>5</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
+			<iXPValueAttack>11</iXPValueAttack>
 			<iXPValueDefense>9</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -9134,16 +11121,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>12</iYield>
-						<iYield>6</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>18</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>12</iYield>
-						<iYield>6</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>18</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9236,8 +11255,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -9258,13 +11277,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_LLAMA</BonusType>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_LLAMA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9273,16 +11308,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9354,8 +11421,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -9373,7 +11440,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_GULL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9383,13 +11450,27 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9463,8 +11544,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>30</iEarlyWithdraw>
@@ -9483,7 +11564,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HAAST_EAGLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9492,16 +11573,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9571,8 +11674,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>25</iPursuit>
 			<UnitMeshGroups>
@@ -9590,34 +11693,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_HAMMERHEAD</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HAMMERHEAD</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9707,8 +11858,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
@@ -9727,7 +11878,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HARPYEAGLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9736,16 +11887,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9818,8 +11991,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iPursuit>45</iPursuit>
 			<iEarlyWithdraw>45</iEarlyWithdraw>
@@ -9838,7 +12011,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HAWK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9848,13 +12021,27 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -9957,10 +12144,10 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>5</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
+			<iXPValueAttack>13</iXPValueAttack>
 			<iXPValueDefense>9</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -9977,7 +12164,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HIPPO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -9986,16 +12173,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>1300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>160</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>1300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>160</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10080,11 +12299,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -10100,7 +12319,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PYGMYHIPPO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10109,16 +12328,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10213,8 +12464,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
@@ -10243,6 +12494,8 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -10250,6 +12503,8 @@
 					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10340,8 +12595,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -10362,13 +12617,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_HORSE</BonusType>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_HORSE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10377,16 +12648,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>120</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10440,11 +12743,11 @@
 			<bRenderBelowWater>1</bRenderBelowWater>
 			<iCost>-1</iCost>
 			<iMoves>3</iMoves>
-			<iCombat>6</iCombat>
+			<iCombat>8</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>15</iXPValueAttack>
+			<iXPValueDefense>10</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -10463,8 +12766,24 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_WHALE</BonusType>
 					<Yields>
-						<iYield>8</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>5000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>220</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -10475,28 +12794,76 @@
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>8</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>5000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>220</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HUMPBACK_WHALE</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>5000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>220</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>8</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>5000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>220</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10570,8 +12937,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>25</iPursuit>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
@@ -10590,7 +12957,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_HYENA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10599,16 +12966,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10685,8 +13084,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -10704,7 +13103,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_IBEX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10713,16 +13112,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10778,8 +13209,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -10795,7 +13226,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_IGUANA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10804,16 +13235,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -10892,8 +13345,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>55</iWithdrawalProb>
 			<iEarlyWithdraw>85</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -10911,7 +13364,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_IMPALA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -10920,16 +13373,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11005,8 +13490,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>45</iWithdrawalProb>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -11027,13 +13512,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_KANGAROO</BonusType>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_KANGAROO_GREY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11042,16 +13543,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11127,8 +13660,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -11149,13 +13682,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_KANGAROO</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_KANGAROO_RED</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11164,16 +13713,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11231,8 +13812,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -11250,7 +13831,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_KOALA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11259,16 +13840,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11379,11 +13992,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -11408,16 +14021,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11509,8 +14154,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -11528,7 +14173,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_KOOKABURRA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11538,13 +14183,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11621,8 +14270,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>35</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -11640,7 +14289,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_LEMUR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11650,15 +14299,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11761,11 +14412,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>6</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>6</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<UnitMeshGroups>
@@ -11792,16 +14443,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>56</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>56</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11853,8 +14536,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -11870,7 +14553,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_LIZARD</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -11879,16 +14562,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -11951,8 +14666,8 @@
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>4</iCombat>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -12024,8 +14739,8 @@
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>17</iCombat>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -12097,8 +14812,8 @@
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>9</iCombat>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>12</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -12170,8 +14885,8 @@
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>3</iCombat>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -12240,8 +14955,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>70</iWithdrawalProb>
 			<iEarlyWithdraw>85</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -12263,11 +14978,13 @@
 					<BonusType>BONUS_POULTRY</BonusType>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_LOON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12277,13 +14994,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12369,11 +15090,11 @@
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iPursuit>40</iPursuit>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
@@ -12392,7 +15113,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_LYNX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12401,16 +15122,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>22</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>22</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12481,8 +15234,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>55</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -12500,7 +15253,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MACAW</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12511,14 +15264,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12596,8 +15351,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -12616,7 +15371,7 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_FISH</BonusType>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -12627,25 +15382,25 @@
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_SMALL</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MACKEREL</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>3</iYield>
+						<iYield>1</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12704,11 +15459,11 @@
 				<TerrainType>TERRAIN_DUNES</TerrainType>
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>7</iCombat>
+			<iCombat>8</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>14</iXPValueAttack>
+			<iXPValueDefense>10</iXPValueDefense>
 			<iCollateralDamage>100</iCollateralDamage>
 			<iCollateralDamageLimit>75</iCollateralDamageLimit>
 			<iCollateralDamageMaxUnits>4</iCollateralDamageMaxUnits>
@@ -12726,8 +15481,33 @@
 			<FormationType>FORMATION_TYPE_ANIMAL</FormationType>
 			<KillOutcomes>
 				<Outcome>
+					<OutcomeType>OUTCOME_BONUS_SPAWNED</OutcomeType>
+					<iChance>2</iChance>
+					<BonusType>BONUS_MAMMOTH</BonusType>
+					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>118</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+					</Yields>
+				</Outcome>
+				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_MAMMOTH</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12736,16 +15516,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>7</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>118</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>7</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>1000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>118</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12811,11 +15623,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
 			<UnitMeshGroups>
@@ -12833,7 +15645,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MANEDWOLF</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12842,16 +15654,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -12965,11 +15809,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>10</iPursuit>
 			<iEarlyWithdraw>20</iEarlyWithdraw>
@@ -12988,7 +15832,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MANDRILL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -12997,16 +15841,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13053,8 +15929,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -13070,31 +15946,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_RAY_MANTA</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RAY_MANTA</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13159,8 +16086,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -13179,7 +16106,24 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_FISH</BonusType>
 					<Yields>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -13190,25 +16134,76 @@
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MARLIN</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>45</Constant>
+								<Random>180</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13268,11 +16263,11 @@
 			<bRenderBelowWater>1</bRenderBelowWater>
 			<iCost>-1</iCost>
 			<iMoves>3</iMoves>
-			<iCombat>6</iCombat>
+			<iCombat>7</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -13288,34 +16283,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_MINKIE_WHALE</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MINKIE_WHALE</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>6</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13394,8 +16437,8 @@
 			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iPursuit>20</iPursuit>
 			<iEarlyWithdraw>20</iEarlyWithdraw>
@@ -13414,7 +16457,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MOA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -13423,16 +16466,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>24</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13524,11 +16599,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -13544,7 +16619,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MONITOR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -13553,16 +16628,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13628,8 +16735,8 @@
 			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>20</iPursuit>
 			<UnitMeshGroups>
@@ -13647,7 +16754,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MOOSE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -13656,16 +16763,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>160</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>180</Constant>
+								<Random>160</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13730,8 +16869,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>40</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -13752,13 +16891,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_SHEEP</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_MOUFLON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -13767,16 +16922,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13849,11 +17036,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -13869,7 +17056,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MUSKOX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -13878,16 +17065,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -13969,8 +17188,8 @@
 			<iCombat>5</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -13988,34 +17207,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_NARWHAL</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_NARWHAL</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>400</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14125,11 +17392,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -14145,7 +17412,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_NILECROC</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14154,16 +17421,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>17</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>17</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>13</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14225,8 +17524,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -14244,7 +17543,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_NUMBAT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14258,7 +17557,7 @@
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 					</Yields>
@@ -14317,8 +17616,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -14336,7 +17635,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_OKAPI</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14345,16 +17644,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>75</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14407,8 +17738,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
@@ -14427,7 +17758,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_OPOSSUM</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14437,13 +17768,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14495,11 +17830,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -14516,7 +17851,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ORANGUTAN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14525,16 +17860,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14600,11 +17967,11 @@
 			<bNoDefensiveBonus>1</bNoDefensiveBonus>
 			<iCost>-1</iCost>
 			<iMoves>3</iMoves>
-			<iCombat>6</iCombat>
+			<iCombat>7</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>11</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<iPursuit>35</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -14621,34 +17988,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_ORCA</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ORCA</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2000</Constant>
+								<Random>2000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>300</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14731,8 +18146,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>25</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -14750,7 +18165,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_OSTRICH</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14759,16 +18174,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14848,8 +18295,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>95</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -14867,7 +18314,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_OXPECKER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14877,13 +18324,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -14953,8 +18404,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -14970,7 +18421,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PANDA_BEAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -14979,16 +18430,42 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15043,11 +18520,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iPursuit>40</iPursuit>
 			<iEarlyWithdraw>25</iEarlyWithdraw>
@@ -15079,16 +18556,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>46</Constant>
+								<Random>64</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>46</Constant>
+								<Random>64</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15145,8 +18654,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>55</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15169,11 +18678,17 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_PARROT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15184,14 +18699,26 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15261,8 +18788,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iEarlyWithdraw>40</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15283,13 +18810,19 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_POULTRY</BonusType>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_PEACOCK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15298,16 +18831,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15405,8 +18950,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15424,7 +18969,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PENGUIN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15433,16 +18978,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15513,8 +19090,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15532,7 +19109,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PHEASANT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15542,13 +19119,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>6</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15622,8 +19203,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15645,11 +19226,13 @@
 					<BonusType>BONUS_POULTRY</BonusType>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_PIGEON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15659,13 +19242,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15735,11 +19322,11 @@
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15760,13 +19347,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_PIG</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>230</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_PIG_NEW</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15775,16 +19378,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>230</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>230</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15861,8 +19496,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>85</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -15880,7 +19515,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PLATYPUS</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -15889,16 +19524,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -15983,11 +19640,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>5</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>12</iXPValueAttack>
+			<iXPValueDefense>10</iXPValueDefense>
 			<iPursuit>30</iPursuit>
 			<TerrainAttacks>
 				<TerrainAttack>
@@ -16057,16 +19714,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>35</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>35</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16118,8 +19807,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -16137,7 +19826,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_POSSUM</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16146,14 +19835,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16238,8 +19941,8 @@
 			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>7</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>20</iPursuit>
 			<iEarlyWithdraw>25</iEarlyWithdraw>
@@ -16258,7 +19961,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PROCOPTODON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16267,16 +19970,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16369,11 +20104,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -16391,7 +20126,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_PUFFADDER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16400,16 +20135,18 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16465,8 +20202,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
@@ -16485,7 +20222,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_QUOLL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16495,15 +20232,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>0</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16575,8 +20314,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -16593,7 +20332,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RACCOON</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16602,16 +20341,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16688,11 +20449,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -16709,7 +20470,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>0</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RATEL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16718,16 +20479,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>100</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16803,8 +20576,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -16822,7 +20595,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RAVEN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -16832,13 +20605,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -16887,8 +20664,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -16904,31 +20681,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_RAY_EAGLE</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_SMALL</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RAY_EAGLE</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17013,8 +20841,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>70</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -17032,7 +20860,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RAZORBILL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17042,13 +20870,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17141,8 +20973,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iPursuit>40</iPursuit>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
@@ -17161,7 +20993,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_REDFOX</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17170,16 +21002,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17247,8 +21101,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -17266,7 +21120,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_REDPANDA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17275,16 +21129,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17363,8 +21239,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -17382,7 +21258,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RHEA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17391,16 +21267,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17466,10 +21374,10 @@
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>5</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
+			<iXPValueAttack>11</iXPValueAttack>
 			<iXPValueDefense>9</iXPValueDefense>
 			<iCollateralDamage>100</iCollateralDamage>
 			<iCollateralDamageLimit>75</iCollateralDamageLimit>
@@ -17489,7 +21397,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ELASMOTHERIUM</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17498,16 +21406,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>32</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>4</iYield>
+						<iYield>
+							<Plus>
+								<Constant>500</Constant>
+								<Random>500</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>32</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17574,11 +21514,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -17594,7 +21534,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BLACK_RHINO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17603,16 +21543,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>9</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17680,11 +21652,11 @@
 				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -17700,7 +21672,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_INDIAN_RHINO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17709,16 +21681,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>120</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>120</Constant>
+								<Random>90</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17784,11 +21788,11 @@
 				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -17804,7 +21808,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_JAVA_RHINO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17813,16 +21817,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>300</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -17898,11 +21934,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -17918,7 +21954,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WHITE_RHINO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -17927,16 +21963,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>140</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>3</iYield>
+						<iYield>
+							<Plus>
+								<Constant>400</Constant>
+								<Random>200</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>140</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>16</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18046,11 +22114,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -18066,7 +22134,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RIVER_CROC_LARGE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -18075,16 +22143,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>14</Constant>
+								<Random>28</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18196,11 +22296,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>5</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -18216,7 +22316,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_RIVER_CROC_SMALL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -18225,16 +22325,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18331,8 +22463,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -18349,7 +22481,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ROCKHOPPER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -18358,16 +22490,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>0</iYield>
+						<iYield>
+							<Plus>
+								<Constant>0</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18437,11 +22591,11 @@
 			</UnitCombatTargets>
 			<iCost>-1</iCost>
 			<iMoves>1</iMoves>
-			<iCombat>4</iCombat>
+			<iCombat>6</iCombat>
 			<iAggression>10</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>14</iXPValueAttack>
+			<iXPValueDefense>12</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<UnitMeshGroups>
@@ -18468,16 +22622,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>64</Constant>
+								<Random>128</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
 					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>64</Constant>
+								<Random>128</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18572,8 +22758,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>35</iWithdrawalProb>
 			<iEarlyWithdraw>85</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -18591,7 +22777,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SAIGA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -18600,16 +22786,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18664,10 +22882,10 @@
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>7</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
+			<iXPValueAttack>12</iXPValueAttack>
 			<iXPValueDefense>9</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -18684,34 +22902,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_SALTWATER_CROCL</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>26</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>0</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SALTWATER_CROCL</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>26</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>100</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>26</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18774,11 +23040,11 @@
 				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>7</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -18794,14 +23060,30 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_SALTWATER_CROCS</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -18812,16 +23094,48 @@
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>95</iChance>
+					<iChance>85</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>50</Constant>
+								<Random>150</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -18896,11 +23210,11 @@
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
@@ -18919,7 +23233,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SEAEAGLE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -18928,16 +23242,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19026,11 +23362,11 @@
 					<PassableTech>NONE</PassableTech>
 				</FeaturePassableTech>
 			</FeaturePassableTechs>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -19049,10 +23385,30 @@
 					<OutcomeType>OUTCOME_BONUS_SPAWNED</OutcomeType>
 					<iChance>2</iChance>
 					<BonusType>BONUS_SEA_LION_AND_SEAL</BonusType>
+					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_SEALION_LAND</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -19061,16 +23417,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19145,11 +23533,11 @@
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -19167,34 +23555,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_SEALION_SEA</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SEALION_SEA</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19279,8 +23715,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>60</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -19298,22 +23734,54 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SEAOTTER</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>9</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19388,11 +23856,11 @@
 				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>1</iCombat>
+			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -19408,34 +23876,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_SEATURTLE</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>185</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_SMALL</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SEATURTLE</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>185</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>15</Constant>
+								<Random>185</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>18</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19528,8 +24044,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -19545,7 +24061,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SECRETARYBIRD</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -19556,14 +24072,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19650,8 +24168,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iPursuit>40</iPursuit>
 			<UnitMeshGroups>
@@ -19669,34 +24187,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_REEF_SHARK</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_REEF_SHARK</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19771,10 +24337,10 @@
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>4</iCombat>
+			<iCombat>7</iCombat>
 			<iAggression>5</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
+			<iXPValueAttack>12</iXPValueAttack>
 			<iXPValueDefense>9</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
@@ -19794,7 +24360,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SIBERIANTIGER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -19803,16 +24369,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>74</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>70</Constant>
+								<Random>50</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>74</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19879,8 +24477,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>20</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -19898,7 +24496,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SKUNK</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -19907,16 +24505,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -19975,11 +24595,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>6</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
 			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueDefense>7</iXPValueDefense>
 			<iPursuit>20</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -19996,7 +24616,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SLOTHBEAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20005,16 +24625,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>16</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20098,11 +24750,11 @@
 				<FeatureType>FEATURE_SAVANNA</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>8</iXPValueAttack>
+			<iXPValueDefense>6</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
@@ -20165,7 +24817,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SNOWLEOPARD</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20174,16 +24826,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>24</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>24</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20268,11 +24952,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>4</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iPursuit>25</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -20289,7 +24973,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SPECTACLEDBEAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20298,16 +24982,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>20</Constant>
+								<Random>20</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20377,11 +25093,11 @@
 				<TerrainType>TERRAIN_JAGGED</TerrainType>
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>35</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -20402,13 +25118,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_DEER</BonusType>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_STAG_DEER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20417,16 +25149,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>80</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20496,8 +25260,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iPursuit>30</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -20514,7 +25278,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_SUNBEAR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20523,16 +25287,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>4</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20622,8 +25418,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -20641,7 +25437,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TAPIR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20650,16 +25446,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>25</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20736,8 +25564,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -20755,7 +25583,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_BRAZILIAN_TAPIR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20764,16 +25592,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>17</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>40</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>17</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20851,8 +25711,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -20870,7 +25730,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MALAYAN_TAPIR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20879,16 +25739,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>19</Constant>
+								<Random>23</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>60</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>19</Constant>
+								<Random>23</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -20963,8 +25855,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>70</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -20982,7 +25874,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_MOUNTAIN_TAPIR</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -20991,16 +25883,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>30</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>7</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21064,8 +25988,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -21081,7 +26005,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_JUNGLE_TARANTULA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21095,7 +26019,7 @@
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 					</Yields>
@@ -21158,8 +26082,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -21175,7 +26099,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_DESERT_TARANTULA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21189,7 +26113,7 @@
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 					</Yields>
@@ -21286,8 +26210,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>30</iEarlyWithdraw>
@@ -21306,7 +26230,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TASMANIANDEVIL</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21315,16 +26239,36 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21404,8 +26348,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>95</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -21423,7 +26367,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TERN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21433,13 +26377,17 @@
 					</bUnitToCity>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21534,8 +26482,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>20</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
@@ -21554,7 +26502,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_THYLACINE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21563,16 +26511,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21646,8 +26626,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>35</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -21665,7 +26645,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TOUCAN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21676,14 +26656,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21739,8 +26721,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -21757,7 +26739,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TREESLOTH</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -21766,16 +26748,18 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>4</iYield>
 						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>4</iYield>
 						<iYield>1</iYield>
+						<iYield>3</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21845,8 +26829,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>15</iWithdrawalProb>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -21867,7 +26851,12 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_FISH</BonusType>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>235</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
@@ -21878,25 +26867,40 @@
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>235</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_SMALL</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_TUNA</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>235</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>235</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -21972,8 +26976,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iEarlyWithdraw>100</iEarlyWithdraw>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -21993,13 +26997,19 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_POULTRY</BonusType>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_TURKEY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22008,16 +27018,28 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22079,8 +27101,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>65</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -22098,7 +27120,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_VIPER</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22109,14 +27131,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22186,8 +27210,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>5</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>65</iWithdrawalProb>
 			<iEarlyWithdraw>65</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -22205,7 +27229,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_VIPER_CHAIN</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22216,14 +27240,16 @@
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
 						<iYield>1</iYield>
 						<iYield>1</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22305,11 +27331,11 @@
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>1</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>40</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -22327,7 +27353,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_VULTURE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22336,16 +27362,18 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>0</iYield>
 						<iYield>1</iYield>
+						<iYield>1</iYield>
+						<iYield>4</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22478,8 +27506,8 @@
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>3</iXPValueAttack>
+			<iXPValueDefense>2</iXPValueDefense>
 			<iWithdrawalProb>35</iWithdrawalProb>
 			<iEarlyWithdraw>90</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -22497,7 +27525,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WALLABY</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22506,16 +27534,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22569,8 +27629,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>40</iWithdrawalProb>
 			<iEarlyWithdraw>80</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -22588,7 +27648,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WALLAROO</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22597,16 +27657,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>5</Constant>
+								<Random>15</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>2</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>3</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22694,8 +27786,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>5</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>1.75</fMaxSpeed>
@@ -22714,13 +27806,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_WALRUS</BonusType>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>625</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_WALRUS</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22729,16 +27837,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>625</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>5</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>200</Constant>
+								<Random>625</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>40</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>12</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22830,8 +27970,8 @@
 			<iCombat>2</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>4</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>30</iPursuit>
 			<UnitMeshGroups>
@@ -22852,13 +27992,29 @@
 					<iChance>2</iChance>
 					<BonusType>BONUS_PIG</BonusType>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>8</iChance>
+					<iChance>3</iChance>
 					<UnitType>UNIT_SUBDUED_WARTHOG</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -22867,16 +28023,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>3</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>25</Constant>
+								<Random>80</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>2</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -22922,11 +28110,11 @@
 				<TerrainType>TERRAIN_OCEAN_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 			</TerrainImpassableTypes>
-			<iCombat>3</iCombat>
+			<iCombat>5</iCombat>
 			<iAggression>0</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>10</iXPValueAttack>
+			<iXPValueDefense>8</iXPValueDefense>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>2.25</fMaxSpeed>
@@ -22942,34 +28130,82 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_TALES_SEA</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_TALESOF_WHALESHARK</UnitType>
 					<bUnitToCity>
 						<Constant>1</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>7000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1000</Constant>
+								<Random>700</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE_SEA_LARGE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WHALESHARK</UnitType>
 					<bUnitToCity>
 						<Constant>DONT_ESCORT_SUBDUED_SEA_ANIMAL</Constant>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>7000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>80</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>10000</Constant>
+								<Random>7000</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>100</Constant>
+								<Random>70</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>30</Constant>
+								<Random>10</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -23058,8 +28294,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>2</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iEarlyWithdraw>50</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -23077,7 +28313,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WILDEBEEST</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -23086,16 +28322,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>4</iYield>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>60</Constant>
+								<Random>100</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>11</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>8</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -23166,11 +28434,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>3</iCombat>
 			<iAggression>4</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>3</iXPValueDefense>
 			<iWithdrawalProb>30</iWithdrawalProb>
 			<iPursuit>50</iPursuit>
 			<UnitMeshGroups>
@@ -23188,7 +28456,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WOLF</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -23197,16 +28465,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>28</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>12</Constant>
+								<Random>28</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>6</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>8</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -23312,8 +28612,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iPursuit>30</iPursuit>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
@@ -23330,7 +28630,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WOLVERINE</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -23339,16 +28639,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>2</iYield>
+						<iYield>
+							<Plus>
+								<Constant>3</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>4</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -23405,11 +28727,11 @@
 				<FeatureType>FEATURE_MANGROVE</FeatureType>
 				<FeatureType>FEATURE_SWAMP</FeatureType>
 			</FeatureImpassableTypes>
-			<iCombat>2</iCombat>
+			<iCombat>1</iCombat>
 			<iAggression>3</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>2</iXPValueAttack>
+			<iXPValueDefense>1</iXPValueDefense>
 			<iWithdrawalProb>10</iWithdrawalProb>
 			<iEarlyWithdraw>60</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -23427,7 +28749,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_WOMBAT</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -23436,16 +28758,38 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>6</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>1</Constant>
+								<Random>1</Random>
+							</Plus>
+						</iYield>
+						<iYield>5</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>
@@ -23522,8 +28866,8 @@
 			<iCombat>3</iCombat>
 			<iAggression>1</iAggression>
 			<bBlendIntoCity>1</bBlendIntoCity>
-			<iXPValueAttack>9</iXPValueAttack>
-			<iXPValueDefense>9</iXPValueDefense>
+			<iXPValueAttack>6</iXPValueAttack>
+			<iXPValueDefense>4</iXPValueDefense>
 			<iWithdrawalProb>50</iWithdrawalProb>
 			<iEarlyWithdraw>75</iEarlyWithdraw>
 			<UnitMeshGroups>
@@ -23541,7 +28885,7 @@
 			<KillOutcomes>
 				<Outcome>
 					<OutcomeType>OUTCOME_SUBDUE</OutcomeType>
-					<iChance>10</iChance>
+					<iChance>5</iChance>
 					<UnitType>UNIT_SUBDUED_ZEBRA</UnitType>
 					<bUnitToCity>
 						<Has>
@@ -23550,16 +28894,48 @@
 						</Has>
 					</bUnitToCity>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 				<Outcome>
 					<OutcomeType>OUTCOME_HUNTING_KILL</OutcomeType>
-					<iChance>90</iChance>
+					<iChance>95</iChance>
 					<Yields>
-						<iYield>1</iYield>
-						<iYield>1</iYield>
+						<iYield>
+							<Plus>
+								<Constant>90</Constant>
+								<Random>110</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>11</Constant>
+								<Random>14</Random>
+							</Plus>
+						</iYield>
+						<iYield>
+							<Plus>
+								<Constant>7</Constant>
+								<Random>5</Random>
+							</Plus>
+						</iYield>
 					</Yields>
 				</Outcome>
 			</KillOutcomes>

--- a/Assets/XML/Units/U_Animals_CIV4UnitInfos.xml
+++ b/Assets/XML/Units/U_Animals_CIV4UnitInfos.xml
@@ -7733,6 +7733,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
@@ -7847,6 +7848,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
@@ -8751,6 +8753,7 @@
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -11417,6 +11420,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -11540,6 +11544,7 @@
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>2</iCombat>
 			<iAggression>3</iAggression>
@@ -11854,6 +11859,7 @@
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -11987,6 +11993,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -12460,6 +12467,7 @@
 				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>3</iAggression>
@@ -14150,6 +14158,7 @@
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -14951,6 +14960,7 @@
 				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -16428,6 +16438,7 @@
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -18288,6 +18299,7 @@
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -18650,6 +18662,7 @@
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -19199,6 +19212,7 @@
 				<TerrainType>TERRAIN_DUNES</TerrainType>
 				<TerrainType>TERRAIN_ICE</TerrainType>
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -20572,6 +20586,7 @@
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>3</iAggression>
@@ -20832,6 +20847,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_FOREST_ANCIENT</FeatureType>
@@ -21229,6 +21245,7 @@
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -22452,6 +22469,7 @@
 				<TerrainType>TERRAIN_BADLAND</TerrainType>
 				<TerrainType>TERRAIN_SALT_FLATS</TerrainType>
 				<TerrainType>TERRAIN_SCRUB</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_BAMBOO</FeatureType>
@@ -23209,6 +23227,7 @@
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>1</iAggression>
@@ -24035,6 +24054,7 @@
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TAIGA</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>
@@ -26344,6 +26364,7 @@
 				<TerrainType>TERRAIN_TRENCH</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -26622,6 +26643,7 @@
 				<TerrainType>TERRAIN_SEA_DEEP_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_SEA_POLAR</TerrainType>
 				<TerrainType>TERRAIN_SEA_TROPICAL</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<iCombat>1</iCombat>
 			<iAggression>0</iAggression>
@@ -27327,6 +27349,7 @@
 				<TerrainType>TERRAIN_TRENCH_POLAR</TerrainType>
 				<TerrainType>TERRAIN_TRENCH_TROPICAL</TerrainType>
 				<TerrainType>TERRAIN_TUNDRA</TerrainType>
+				<TerrainType>TERRAIN_PEAK</TerrainType>
 			</TerrainImpassableTypes>
 			<FeatureImpassableTypes>
 				<FeatureType>FEATURE_JUNGLE</FeatureType>


### PR DESCRIPTION
-Updated hunting unit reward xp according to unit size might and aggression (small and weaker animals give less, bigger give more)

-Updated unit strength to better match their size might and aggression

-Reduced subdue chance on animal kill for all animals to 5% from 10% in order to buff hunter hunting and reduce unit hunting

-Added some animals missing subdue chance

-Updated animal food reward according to the size of the animal and the quality of meat

-Updated animal hammer reward according to the size of the animal and the quantity of bone and other construction usable materials

-Add animal commercial value according to its commercially viable parts(hide, tusks, oil, feathers etc...)