### PR TITLE
Requested typo fix and tooltip fix

### DIFF
--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -1250,7 +1250,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ACTION_CONSUME_GREAT_PEOPLE</Tag>
-		<English>[COLOR_WARNING_TEXT]Will consume %d1_Num[ICON_GREATPEOPLE][COLOR_REVERT]</English>
+		<English>[COLOR_WARNING_TEXT]Will consume %d1_Num [ICON_GREATPEOPLE][COLOR_REVERT]</English>
 		<French>[COLOR_WARNING_TEXT]Consommera %d1_Num[ICON_GREATPEOPLE][COLOR_REVERT]</French>
 		<German>[COLOR_WARNING_TEXT]Wird %d1_Num[ICON_GREATPEOPLE] verbrauchen[COLOR_REVERT]</German>
 		<Italian>[COLOR__WARNING_TEXT] %d1_Num[ICON_GREATPEOPLE][NUM1:verrà:verranno] sacrificati[COLOR_REVERT]</Italian>
@@ -1507,7 +1507,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_ACTION_MORE_GREAT_PEOPLE</Tag>
-		<English>[COLOR_WARNING_TEXT]Requires %d1_Num More [ICON_GREATPEOPLE][COLOR_REVERT]</English>
+		<English>[COLOR_WARNING_TEXT]Requires %d1_Num More [ICON_GREATPEOPLE] Type(s)[COLOR_REVERT]</English>
 		<French>[COLOR_WARNING_TEXT]Il faut %d1_Num [ICON_GREATPEOPLE] de plus[COLOR_REVERT]</French>
 		<German>[COLOR_WARNING_TEXT]Erfordert %d1_Num weitere [ICON_GREATPEOPLE][COLOR_REVERT]</German>
 		<Italian>[ICON_BULLET][COLOR_WARNING_TEXT]Richiede altri %d1_Num [ICON_GREATPEOPLE][COLOR_REVERT]</Italian>

--- a/Assets/XML/GameText/Mission_CIV4GameText.xml
+++ b/Assets/XML/GameText/Mission_CIV4GameText.xml
@@ -1177,7 +1177,7 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_KEY_MISSION_START_GOLDENAGE_HELP</Tag>
-		<English>This order will consume one or more Great People (of different types) and initiate a Golden Age (extra [ICON_PRODUCTION], [ICON_COMMERCE], [ICON_GREATPEOPLE], no Anarchy).</English>
+		<English>This order consumes one or more Great People to start a Golden Age. If multiple are needed, they must be of different types (e.g., not two Great Prophets). Great Generals and Admirals do not count. Bonus to: [ICON_PRODUCTION], [ICON_COMMERCE], [ICON_GREATPEOPLE], no Anarchy.</English>
 		<French>Cette ordre consommera plusieurs personnages illustres (de types différents) et déclenchera un âge d'or ([ICON_PRODUCTION], [ICON_COMMERCE], [ICON_GREATPEOPLE] supplémentaires, pas d'anarchie).</French>
 		<German>Opfern Sie eine oder mehrere Große Persönlichkeiten (unterschiedlicher Klassen), um ein Goldenes Zeitalter (zusätzliche [ICON_PRODUCTION], [ICON_COMMERCE], [ICON_GREATPEOPLE], keine Anarchie) zu begründen.</German>
 		<Italian>[NEWLINE]Consumando nel processo uno o più gran personaggi (di tipi differenti), si avvia un'età dell'oro (extra [ICON_PRODUCTION], [ICON_COMMERCE], [ICON_GREATPEOPLE], nessuna anarchia per i cambi di forma di governo).</Italian>


### PR DESCRIPTION
Specific request to undo a previous typo fix for inflaton field, its an actual word not a mispelling of inflation. Done.
Tooltip for start golden age was confusing people so edited the text there as well to eliminate ambiguity.