### PR TITLE
no auto raze for cities with wonders

### DIFF
--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -11680,7 +11680,7 @@ bool CvGame::isAutoRaze(const CvCity* city, const PlayerTypes eNewOwner, bool bC
 
 	if (isOption(GAMEOPTION_CHALLENGE_ONE_CITY)
 	|| getMaxCityElimination() > 0
-	|| bConquest && city->getPopulation() == 1)
+	|| (bConquest && city->getPopulation() == 1 && city->getNumWorldWonders() == 0))
 	{
 		return true;
 	}


### PR DESCRIPTION
Cities with wonders are no longer auto razed if they hav only 1 population.