### PR TITLE
 AI Attack City Patch - Merge Range and Collaterals

### DIFF
--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -1073,7 +1073,7 @@ void CvCityAI::AI_chooseProduction()
 
 	int iNbMinimalAttackers = 3;
 	if (bIsPeacefull) iNbMinimalAttackers -= 2;
-	if (bIsWarMonger) iNbMinimalAttackers += 2;
+	if (bIsWarMonger) iNbMinimalAttackers += 5;
 
 	//TB Note: min 1 hunter goes under the priority level of settling initiation because this is exploitable with ambushers (or just plain bad luck for the hunters which is not unlikely).  Destroy all hunters and you cripple growth.
 	//Koshling - made having at least 1 hunter a much higher priority
@@ -2342,37 +2342,36 @@ void CvCityAI::AI_chooseProduction()
 		//Calvitix Boost if Warmonger (Conquest Victory > 35)
 		if (bIsWarMonger)
 		{
-			iStartAttackStackRand += 100;
+			iStartAttackStackRand += 200;
 		}
 		else
 		{
 			iStartAttackStackRand -= (iAttackCityCount + iAttackCount);
-		}
+			//Calvitix Nerf if Peacefull Leader (Conquest Victory < 20)
+			if (bIsPeacefull)
+			{
+				iStartAttackStackRand -= 100;
 
-		//Calvitix Nerf if Peacefull Leader (Conquest Victory < 20)
-		if (bIsPeacefull)
-		{
-			iStartAttackStackRand -= 20;
-		}
+			}
+			if (!bLandWar && !bDanger)
+			{
+				iStartAttackStackRand -= 50;
+			}
 
-		//Calvitix Boost if Warmonger (Conquest Victory < 20)
-		if (bIsPeacefull)
-		{
-			iStartAttackStackRand -= 20;
 		}
 
 
 		if (iStartAttackStackRand > 0)///CHECK THIS OUT
 		{
 			if (bIsWarMonger) {
-				iAttackCityTarget = iAttackCityTarget * 150 / 100;
-				iAttackTarget = iAttackTarget * 150 / 100;
+				iAttackCityTarget = iAttackCityTarget * 450 / 100;
+				iAttackTarget = iAttackTarget * 450 / 100;
 			}
 			if (bIsPeacefull) {
 				iAttackCityTarget = iAttackCityTarget * 75 / 100;
 				iAttackTarget = iAttackTarget * 75 / 100;
 			}
-			LOG_BBAI_CITY(2, ("#32 City %S, Will Start to build an Attack Stack (%d). For the moment : Attack : %d / %d and Attack_City : %d / %d", getName().GetCString(), iStartAttackStackRand, iAttackCount, iAttackTarget, iAttackCityCount, iAttackCityTarget));
+			LOG_BBAI_CITY(2, ("#32 City %S, Will Start to build an Attack Stack, StackRand = %d. For the moment : Attack : %d / %d and Attack_City : %d / %d", getName().GetCString(), iStartAttackStackRand, iAttackCount, iAttackTarget, iAttackCityCount, iAttackCityTarget));
 			if (iAttackCount == 0)
 			{
 				if (!bFinancialTrouble
@@ -2395,6 +2394,13 @@ void CvCityAI::AI_chooseProduction()
 					if (iAttackCount / iAttackTarget <= iAttackCityCount / iAttackCityTarget)
 					{
 						LOG_BBAI_CITY(3, ("#32 City %S, Attack Stack add Attack Unit Order. For the moment : Attack : %d and Attack_City : %d", getName().GetCString(), iAttackCount, iAttackCityCount));
+						if (GC.getGame().getSorenRandNum(4, "AI prefer collateral") == 0)
+						{
+							if (AI_chooseUnit("add Collateral unit to stack", UNITAI_COLLATERAL))
+							{
+								return;
+							}
+						}
 						if (AI_chooseUnit("add to attack stack", UNITAI_ATTACK))
 						{
 							return;
@@ -2402,6 +2408,13 @@ void CvCityAI::AI_chooseProduction()
 					}
 				}
 				LOG_BBAI_CITY(3, ("#32 City %S, Attack Stack add Attack_City Unit Order. For the moment : Attack : %d and Attack_City : %d", getName().GetCString(), iAttackCount, iAttackCityCount));
+				if (GC.getGame().getSorenRandNum(5, "AI prefer collateral") == 0)
+				{
+					if (AI_chooseUnit("add Collateral unit to stack", UNITAI_COLLATERAL))
+					{
+						return;
+					}
+				}
 				if (AI_chooseUnit("add to city attack stack", UNITAI_ATTACK_CITY))
 				{
 					return;
@@ -2410,7 +2423,7 @@ void CvCityAI::AI_chooseProduction()
 		}
 		else
 		{
-			LOG_BBAI_CITY(2, ("#32 City %S, Attack Stack too low : iStartAttackStackRand = %d. For the moment : Attack : %d / %d and Attack_City : %d / %d", getName().GetCString(), iStartAttackStackRand, iAttackCount, iAttackTarget, iAttackCityCount, iAttackCityTarget));
+			LOG_BBAI_CITY(2, ("#32 City %S, Attack Stack too low : StackRand = %d. For the moment : Attack : %d / %d and Attack_City : %d / %d", getName().GetCString(), iStartAttackStackRand, iAttackCount, iAttackTarget, iAttackCityCount, iAttackCityTarget));
 		}
 	}
 

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -2312,7 +2312,7 @@ void CvCityAI::AI_chooseProduction()
 	m_iTempBuildPriority--;
 
 	//#32 Main Attack Force Stack
-	if (!bInhibitUnits && !bGetBetterUnits && (bIsCapitalArea) && (iAreaBestFoundValue < (iMinFoundValue * 2)))
+	if (!bInhibitUnits && !bGetBetterUnits && (bIsCapitalArea) && (iAreaBestFoundValue < (iMinFoundValue * 2)) && !bStrategyTurtle)
 	{
 		// BBAI TODO: Check that this works to produce early rushes on tight maps
 		//Building city hunting stack.

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -2346,7 +2346,7 @@ void CvCityAI::AI_chooseProduction()
 		}
 		else
 		{
-			iStartAttackStackRand -= (iAttackCityCount + iAttackCount);
+			iStartAttackStackRand -= (iAttackCityCount + iAttackCount)*2;
 			//Calvitix Nerf if Peacefull Leader (Conquest Victory < 20)
 			if (bIsPeacefull)
 			{
@@ -2368,8 +2368,8 @@ void CvCityAI::AI_chooseProduction()
 				iAttackTarget = iAttackTarget * 450 / 100;
 			}
 			if (bIsPeacefull) {
-				iAttackCityTarget = iAttackCityTarget * 75 / 100;
-				iAttackTarget = iAttackTarget * 75 / 100;
+				iAttackCityTarget = iAttackCityTarget * 25 / 100;
+				iAttackTarget = iAttackTarget * 25 / 100;
 			}
 			LOG_BBAI_CITY(2, ("#32 City %S, Will Start to build an Attack Stack, StackRand = %d. For the moment : Attack : %d / %d and Attack_City : %d / %d", getName().GetCString(), iStartAttackStackRand, iAttackCount, iAttackTarget, iAttackCityCount, iAttackCityTarget));
 			if (iAttackCount == 0)
@@ -2391,7 +2391,7 @@ void CvCityAI::AI_chooseProduction()
 			{
 				if (iAttackCount < iAttackTarget)
 				{
-					if (iAttackCount / iAttackTarget <= iAttackCityCount / iAttackCityTarget)
+					if ((iAttackCount*100 / iAttackTarget) <= (iAttackCityCount*100 / iAttackCityTarget))
 					{
 						LOG_BBAI_CITY(3, ("#32 City %S, Attack Stack add Attack Unit Order. For the moment : Attack : %d and Attack_City : %d", getName().GetCString(), iAttackCount, iAttackCityCount));
 						if (GC.getGame().getSorenRandNum(4, "AI prefer collateral") == 0)
@@ -4360,7 +4360,7 @@ bool CvCityAI::AI_scoreBuildingsFromListThreshold(std::vector<ScoredBuilding>& s
 					if (iValue > 0)
 				{
 					//Calvitix, log only Values > 0
-					logBBAI("City %S base value for %S (flags %08lx)=%I64d", getName().GetCString(), buildingInfo.getDescription(), iFocusFlags, iValue);
+						logAiEvaluations(3, "City %S base value for %S (flags %08lx)=%I64d", getName().GetCString(), buildingInfo.getDescription(), iFocusFlags, iValue);
 				}
 				});
 
@@ -4423,7 +4423,7 @@ bool CvCityAI::AI_scoreBuildingsFromListThreshold(std::vector<ScoredBuilding>& s
 						// We only value the unlocked building at 1/2 rate
 						iValue += AI_buildingValueThreshold((BuildingTypes)iI, iFocusFlags, 0, false, true) / 2;
 
-						LOG_BBAI_CITY(3, ("    enables %S - increase value to %I64d", GC.getBuildingInfo((BuildingTypes)iI).getDescription(), iValue));
+						LOG_EVALAI_CITY(3, (3, "    enables %S - increase value to %I64d", GC.getBuildingInfo((BuildingTypes)iI).getDescription(), iValue));
 					}
 				}
 			}
@@ -4448,7 +4448,7 @@ bool CvCityAI::AI_scoreBuildingsFromListThreshold(std::vector<ScoredBuilding>& s
 			LOG_CITY_BLOCK(3, {
 				if (iValue > 0)
 			{
-				logBBAI("City %S final value for %S (flags %08lx)=%I64d", getName().GetCString(), buildingInfo.getDescription(), iFocusFlags, iValue);
+				logAiEvaluations(3,"City %S final value for %S (flags %08lx)=%I64d", getName().GetCString(), buildingInfo.getDescription(), iFocusFlags, iValue);
 			}
 			});
 
@@ -12536,7 +12536,7 @@ void CvCityAI::CalculateAllBuildingValues(int iFocusFlags)
 	const bool bLandWar = bDefense || pArea->getAreaAIType(eTeam) == AREAAI_OFFENSIVE || pArea->getAreaAIType(eTeam) == AREAAI_MASSING;
 	const bool bDanger = AI_isDanger();
 
-	LOG_BBAI_CITY(1, (
+	LOG_EVALAI_CITY(3, (1, 
 			"      City %S CalculateAllBuildingValues for flags %08lx (already has %08lx)",
 			getName().GetCString(), iFocusFlags, cachedBuildingValues->m_iCachedFlags
 		));

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -4091,6 +4091,8 @@ void CvPlayer::dumpStats() const
 	{
 		logBBAI("		%S (%s): %d", GC.getUnitInfo((UnitTypes)(itr->first >> 16)).getDescription(), GC.getUnitAIInfo((UnitAITypes)(itr->first & 0xFFFF)).getType(), itr->second);
 	}
+	logBBAI("	EndUnits");
+
 }
 
 

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -30,6 +30,7 @@
 #include "CvDLLFAStarIFaceBase.h"
 #include "CvDLLInterfaceIFaceBase.h"
 #include "CvDLLUtilityIFaceBase.h"
+#include "BetterBTSAI.h"
 #include "FAStarNode.h"
 
 // Plot danger cache
@@ -3259,7 +3260,7 @@ int CvPlayerAI::AI_targetCityValue(const CvCity* pCity, bool bRandomize, bool bI
 	iValue = ((iValue * 100) / intSqrt(iDefense));
 
 	LOG_PLAYER_BLOCK(3, {
-		logBBAI("Player %d Estimation of Target City %S, Final Value %d, Population %d, Defense Unit : %d, Fortifications : %d, Defense Dmg : %d, Wonders : %d, Religion : %d, Plots : %d, Special : %d, Random : %d,...", getID(), pCity->getName().GetCString(), iValue, iPopulation, iDefense, iDefenseMod, iDefenseDmg, iWonderPts, iReligionPts, iPlots, iSpecial, iRandom);
+		logAiEvaluations(3,"Player %d Estimation of Target City %S, Final Value %d, Population %d, Defense Unit : %d, Fortifications : %d, Defense Dmg : %d, Wonders : %d, Religion : %d, Plots : %d, Special : %d, Random : %d,...", getID(), pCity->getName().GetCString(), iValue, iPopulation, iDefense, iDefenseMod, iDefenseDmg, iWonderPts, iReligionPts, iPlots, iSpecial, iRandom);
 	});
 
 

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -1464,6 +1464,10 @@ void CvPlayerAI::AI_unitUpdate()
 		{
 			std::vector< std::pair<int, int> > groupList;
 			//Define a Priority Sorting (see AI_movementPriority)
+			LOG_PLAYER_BLOCK(4, {
+				logAiEvaluations(4,"AI_unitUpdate : Setting the GroupList for Player %d", getID());
+			});
+
 			for (CLLNode<int>* pCurrUnitNode = headGroupCycleNode(); pCurrUnitNode != NULL; pCurrUnitNode = nextGroupCycleNode(pCurrUnitNode))
 			{
 				CvSelectionGroup* pLoopSelectionGroup = getSelectionGroup(pCurrUnitNode->m_data);
@@ -1471,9 +1475,17 @@ void CvPlayerAI::AI_unitUpdate()
 
 				int iPriority = AI_movementPriority(pLoopSelectionGroup);
 				groupList.push_back(std::make_pair(iPriority, pCurrUnitNode->m_data));
+				LOG_PLAYER_BLOCK(4, {
+					logAiEvaluations(4,"item : %d; %d", iPriority, pCurrUnitNode->m_data);
+				});
 			}
 
 			algo::sort(groupList);
+
+			LOG_PLAYER_BLOCK(4, {
+				logAiEvaluations(4,"AI_unitUpdate : List sorted, Applying AI_update for each item for Player %d", getID());
+			});
+
 			for (size_t i = 0; i < groupList.size(); i++)
 			{
 				CvSelectionGroup* pLoopSelectionGroup = getSelectionGroup(groupList[i].second);
@@ -1485,6 +1497,12 @@ void CvPlayerAI::AI_unitUpdate()
 				}
 			}
 		}
+	}
+	else
+	{
+		LOG_PLAYER_BLOCK(4, {
+			logAiEvaluations(4,"AI_unitUpdate : Has Busy Unit for Player %d", getID());
+		});
 	}
 }
 

--- a/Sources/CvSelectionGroupAI.cpp
+++ b/Sources/CvSelectionGroupAI.cpp
@@ -129,7 +129,7 @@ bool CvSelectionGroupAI::AI_update()
 				StrUnitName = this->getHeadUnit()->getName(0).GetCString();
 			}
 
-			logBBAI("Player %d Group ID %d, mené par %S of Type %S, at (%d, %d), Mission %S [stack size %d], Something wrong, Force Update...", getOwner(), m_iID, StrUnitName.GetCString(), StrunitAIType.GetCString(), getX(), getY(), MissionInfos.GetCString(), getNumUnits());
+			logBBAI("Player %d Group ID %d, mené par %d %S of Type %S, at (%d, %d), Mission %S [stack size %d], Was fortified/BuildUp, Force to Awake...", getOwner(), m_iID, this->getHeadUnit()->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), getX(), getY(), MissionInfos.GetCString(), getNumUnits());
 		});
 		clearMissionQueue(); // XXX ???
 		setActivityType(ACTIVITY_AWAKE);
@@ -159,6 +159,11 @@ bool CvSelectionGroupAI::AI_update()
 				char szOut[1024];
 				CvWString szTempString;
 				getUnitAIString(szTempString, pHeadUnit->AI_getUnitAIType());
+				LOG_PLAYER_BLOCK(1, {
+					logAiEvaluations(1, "Unit stuck in loop( Warning before short circuit (pass: %d) ): %S(%S)[%d, %d] (%S)\n",
+					iPass, pHeadUnit->getName().GetCString(), GET_PLAYER(pHeadUnit->getOwner()).getName(),
+					pHeadUnit->getX(), pHeadUnit->getY(), szTempString.GetCString());
+				});
 				sprintf
 				(
 					szOut, "Unit stuck in loop( Warning before short circuit (pass: %d) ): %S(%S)[%d, %d] (%S)\n",
@@ -179,6 +184,11 @@ bool CvSelectionGroupAI::AI_update()
 				char szOut[1024];
 				CvWString szTempString;
 				getUnitAIString(szTempString, pHeadUnit->AI_getUnitAIType());
+				LOG_PLAYER_BLOCK(1, {
+					logAiEvaluations(1, "Unit stuck in loop: %S(%S)[%d, %d] (%S)\n",
+					pHeadUnit->getName().GetCString(), GET_PLAYER(pHeadUnit->getOwner()).getName(),
+					pHeadUnit->getX(), pHeadUnit->getY(), szTempString.GetCString());
+				});
 				sprintf
 				(
 					szOut, "Unit stuck in loop: %S(%S)[%d, %d] (%S)\n",
@@ -191,13 +201,30 @@ bool CvSelectionGroupAI::AI_update()
 
 				pHeadUnit->finishMoves();
 			}
+			
 			else if (readyToMove())
 			{
 				FErrorMsg("splitting group");
+				LOG_PLAYER_BLOCK(1, {
+					CvPlot * pPlot = this->plot();
+					int XCoord = -99;
+					int YCoord = -99;
+					if (pPlot != NULL)
+					{
+						XCoord = pPlot->getX();
+						YCoord = pPlot->getY();
+					}
+					logAiEvaluations(1, "pHeadUnit NULL, Splitting Group %d [%d, %d]",
+					this->m_iID,
+					XCoord, YCoord);
+				});
 				splitGroup(1);
 				break;
 			}
-			else FErrorMsg("error");
+			else
+			{
+				FErrorMsg("error in CvSelectionGroupAI::AI_update()");
+			}
 
 			break;
 		}
@@ -784,7 +811,8 @@ int CvSelectionGroupAI::AI_compareStacks(const CvPlot* pPlot, StackCompare::flag
 	}
 
 	bool bDivideFirst = false;
-	int compareRatio = AI_sumStrength(pPlot, eDomainType, flags);
+	int iAttackStrength = AI_sumStrength(pPlot, eDomainType, flags);
+	int compareRatio = iAttackStrength;
 	if (compareRatio >= (MAX_INT/100))
 	{
 		compareRatio /= 100;
@@ -815,12 +843,26 @@ int CvSelectionGroupAI::AI_compareStacks(const CvPlot* pPlot, StackCompare::flag
 		strengthFlags |= StrengthFlags::TestPotentialEnemy;
 	}
 	int defenderSum = pPlot->AI_sumStrength(NO_PLAYER, eOwner, eDomainType, strengthFlags, iRange);
-
 	if (bDivideFirst)
 	{
 		defenderSum /= 100;
 	}
 	compareRatio /= std::max(1, defenderSum);
+	LOG_UNIT_BLOCK(4, {
+		CvUnit* pUnit = this->getHeadUnit();
+		FAssert(pUnit != NULL);
+		UnitAITypes eUnitAi = pUnit->AI_getUnitAIType();
+		MissionAITypes eMissionAI = this->AI_getMissionAIType();
+		CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+		CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+		CvWString StrUnitName = pUnit->getName();
+		if (StrUnitName.length() == 0)
+		{
+			StrUnitName = pUnit->getName(0).GetCString();
+		}
+		logAiEvaluations(4,"Player %d Group ID %d Head ID %d, %S of Type %S, at (%d, %d), Evaluation of Combat Odds [stack size %d], Attack %d Defense %d, Ratio %d", 
+			getOwner(), m_iID, pUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pPlot->getX(), pPlot->getY(), getNumUnits(), iAttackStrength, defenderSum, compareRatio);
+	});
 
 	return compareRatio;
 }

--- a/Sources/CvSelectionGroupAI.cpp
+++ b/Sources/CvSelectionGroupAI.cpp
@@ -118,7 +118,7 @@ bool CvSelectionGroupAI::AI_update()
 	if (isForceUpdate())
 	{
 		
-		LOG_UNIT_BLOCK(3, {
+		LOG_UNIT_BLOCK(4, {
 			UnitAITypes eUnitAi = this->getHeadUnit()->AI_getUnitAIType();
 			MissionAITypes eMissionAI = AI_getMissionAIType();
 			CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -15201,6 +15201,16 @@ void CvUnit::joinGroup(CvSelectionGroup* pSelectionGroup, bool bRemoveSelected, 
 				{
 					m_iGroupID = FFreeList::INVALID_INDEX;
 				}
+
+				LOG_UNIT_BLOCK(4, {
+					CvWString StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
+					CvWString StrUnitName = m_szName;
+					if (StrUnitName.length() == 0)
+					{
+						StrUnitName = getName(0).GetCString();
+					}
+					logBBAI("	Player %d Unit ID %d, %S of Type %S at (%d,%d) [stack size %d] groups have joigned here, new GroupID %d.", getOwner(), getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), getX(), getY(), getGroup()->getNumUnits(), m_iGroupID);
+				});
 			}
 			else
 			{


### PR DESCRIPTION
**AI Tweaks to patch prec. update**
- Add the production of Collateral Units for Main Attack Stack (Tag 32)
- Extend the MergeRange of Collateral Units and Attack City Stacks
- Change Level of some less used logs
- Give more Strength goals to Warmonger, and less for peacefull Leaders

**AI near behavior fix (when 1 tile near)**
- Fix a bug when stack is choosing again the target city, and at 1 tile from a city (pathing fail)
- When 2 stacks are at 1 tile, the first move, and send skip to the other (try to avoid ping-pong place exchange)
- Dont' Train Attack units if turtle strategy
- Add Logs for GroupList - Potentiel global failure that give Endless loop
- Add Logs for Bombard and Ratio calculation in Attack
- Avoid long range Hunt for hunters (they will move one by one, to eventually discover animals and directly capture them)