### PR TITLE
Set a Sea Workers needed Global Limit (to avoid IA Spamming)

### DIFF
--- a/Assets/XML/GameText/Units_CIV4GameText.xml
+++ b/Assets/XML/GameText/Units_CIV4GameText.xml
@@ -1497,6 +1497,15 @@
 		<Russian>[ICON_BULLET]Макс. HP: %d1 (обычно 100.)</Russian>
 	</TEXT>
 	<TEXT>
+		<Tag>TXT_KEY_UNITHELP_ROLE</Tag>
+		<English>[ICON_BULLET]Role: %s1 , Mission: %s2</English>
+		<French>[ICON_BULLET]Rôle: %s1 , Mission: %s2</French>
+		<German>[ICON_BULLET]Role: %s1 , Mission: %s2</German>
+		<Italian>[ICON_BULLET]Role: %s1 , Mission: %s2</Italian>
+		<Polish>[ICON_BULLET]Role: %s1 , Mission: %s2)</Polish>
+		<Russian>[ICON_BULLET]Role: %s1 , Mission: %s2</Russian>
+	</TEXT>
+	<TEXT>
 		<Tag>TXT_KEY_UNITHELP_MAX_START_ERA</Tag>
 		<English>[NEWLINE][ICON_BULLET]Can only be Built on %s1_Name and Earlier Starts</English>
 		<French>[NEWLINE][ICON_BULLET]Peut uniquement être constuit par %s1_Name et dans les premières Eres</French>

--- a/Assets/XML/Units/CIV4UnitInfos.xml
+++ b/Assets/XML/Units/CIV4UnitInfos.xml
@@ -120,6 +120,7 @@ Base XP gained when defending
 			<iXPValueDefense>6</iXPValueDefense>
 			<iAsset>5</iAsset>
 			<iPower>1000</iPower>
+			<bSuicide>1</bSuicide>
 			<UnitMeshGroups>
 				<iGroupSize>1</iGroupSize>
 				<fMaxSpeed>0.75</fMaxSpeed>

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -6716,7 +6716,7 @@ int CvCityAI::AI_neededSeaWorkers() const
 	{
 		return 0;
 	}
-
+	#define	NB_MAX_SEA_WORKERS 5.0
 	int iNeededSeaWorkers = GET_PLAYER(getOwner()).countUnimprovedBonuses(pWaterArea);
 
 	// Check if second water area city can reach was any unimproved bonuses
@@ -6728,8 +6728,11 @@ int CvCityAI::AI_neededSeaWorkers() const
 	/************************************************************************************************/
 	/* BETTER_BTS_AI_MOD                       END                                                  */
 	/************************************************************************************************/
-
-	return iNeededSeaWorkers;
+	//Calvitix, limit the amount of Sea Workers
+	WorldSizeTypes eWorldSize = GC.getMap().getWorldSize();
+	int iWorldSize = (int)eWorldSize;
+	int iMaxSeaWorkers = 4 + int(NB_MAX_SEA_WORKERS * pow((iWorldSize + 1) / 6.0, 0.8));
+	return std::min(iNeededSeaWorkers, iMaxSeaWorkers);
 }
 
 

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -3361,7 +3361,7 @@ void CvUnitAI::AI_attackCityMove()
 					StrUnitName = getName(0).GetCString();
 				}
 
-				logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Check Bombard effect at (%d,%d)...", getOwner(), m_iID, StrUnitName.GetCString(), StrunitAIType.GetCString(), getX(), getY(), MissionInfos.GetCString(), getGroup()->getNumUnits(), pTargetCity->getX(), pTargetCity->getY());
+				logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Check Attack Ratio and Bombard possibility at (%d,%d)...", getOwner(), m_iID, StrUnitName.GetCString(), StrunitAIType.GetCString(), getX(), getY(), MissionInfos.GetCString(), getGroup()->getNumUnits(), pTargetCity->getX(), pTargetCity->getY());
 				logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
 			});
 			if (iComparePostBombard < iAttackRatio && !bAtWar)
@@ -21343,7 +21343,7 @@ bool CvUnitAI::AI_nextCityToImprove(CvCity* pCity)
 									//pBestPlot = pPlot;
 									pBestCity = pLoopCity;
 									//CvPlot* pEndTurnPlot = getPathEndTurnPlot();
-									FAssert(!(NULL == pCity || pCity->AI_getWorkersNeeded() == 0 || pCity->getNumWorkers() > pCity->AI_getWorkersNeeded() + 1));
+									FAssert(!(NULL == pBestCity || pBestCity->AI_getWorkersNeeded() == 0 || pBestCity->getNumWorkers() > pBestCity->AI_getWorkersNeeded() + 1));
 								}
 							}
 						}


### PR DESCRIPTION
- Limit set to 6 => ~30, depending on Map Size.

Small fixes :
- Set ICBM as suicidal (otherwise, cause a endless loop)
- Add Text for DebugLite (to have Role/Mission of AI during Tests)