### PR TITLE
FogWar Decay Modmod + small XMLS fixes + CTD fixes & some Refactoring

### DIFF
--- a/Assets/Python/Revolution/Gameready/AIAutoPlay.py
+++ b/Assets/Python/Revolution/Gameready/AIAutoPlay.py
@@ -103,7 +103,7 @@ class AIAutoPlay :
 		self.checkPlayer()
 		for i in range(GC.getMAX_PC_PLAYERS()):
 			if GC.getPlayer(i).isHumanDisabled():
-				GAME.setForcedAIAutoPlay(i, 0)
+				GAME.setForcedAIAutoPlay(i, 0, False)
 
 
 	def onBeginPlayerTurn(self, argsList):

--- a/Assets/XML/Buildings/GreatWonders_CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/GreatWonders_CIV4BuildingInfos.xml
@@ -5348,7 +5348,7 @@
 			<PrereqTech>TECH_IMPERIALISM</PrereqTech>
 			<Bonus>BONUS_GLASSWARE</Bonus>
 			<PrereqBonuses>
-				<BonusType>BONUS_STEEL_WARES</BonusType>
+				<Bonus>BONUS_STEEL_WARES</Bonus>
 			</PrereqBonuses>
 			<GreatPeopleUnitType>UNIT_GREAT_ENGINEER</GreatPeopleUnitType>
 			<iGreatPeopleRateChange>2</iGreatPeopleRateChange>

--- a/Assets/XML/Buildings/NationalWonders_CIV4BuildingInfos.xml
+++ b/Assets/XML/Buildings/NationalWonders_CIV4BuildingInfos.xml
@@ -646,7 +646,7 @@
 			<Description>TXT_KEY_BUILDING_CAPITAL_ADMINISTRATION</Description>
 			<Civilopedia>TXT_KEY_BUILDING_CAPITAL_ADMINISTRATION_PEDIA</Civilopedia>
 			<PrereqTech>TECH_SOCIAL_CONTRACT</PrereqTech>
-			<iPrereqPopulation>15</iPrereqPopulation>
+			<iPrereqPopulation>20</iPrereqPopulation>
 			<PrereqInCityBuildings>
 				<BuildingType>BUILDING_PALACE</BuildingType>
 				<BuildingType>BUILDING_METROPOLITAN_ADMINISTRATION</BuildingType>

--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -13020,7 +13020,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_MISC_ATTACKER_PURSUED_SUSTAIN_HUMAN</Tag>
 		<English>Your %s1_UnitName attempted to hit and run but has been entrapped into combat with a %s2_Enemy %s3_EnUName and forced to fight for its life</English>
-		<French>[COLOR_YELLOW][NUM1:Votre:Votre:Vos:Vos] %s1_UnitName [NUM1:a:a:ont:ont] tenté une attaque éclair, mais [NUM1:a:a:ont:ont] été rattrap[NUM1:é:ée:és:ées] par [NUM3:un:une:des:des] %s3_EnUName (%s2_Enemy) et [NUM1:a:a:ont:ont] été forcé à combattre[COLOR_REVERT]</French>
+		<French>[COLOR_YELLOW][NUM1:Votre:Votre:Vos:Vos] %s1_UnitName [NUM1:a:a:ont:ont] tenté une attaque éclair, mais [NUM1:a:a:ont:ont] été détect[NUM1:é:ée:és:ées] par [NUM3:le:la:les:les] %s3_EnUName (%s2_Enemy) et [NUM1:a:a:ont:ont] été forcé à combattre[COLOR_REVERT]</French>
 		<Italian>[NUM1:Il tuo:La tua:I tuoi:Le tue] %s1_UnitName [NUM1:è riuscito:è riuscita:sono riusciti:sono riuscite] a causare dei danni, prima di essere circondata da un'unità %s3_EnUName %s2_Enemy e costretta a combattere per la propria vita.</Italian>
 		<Polish>Twoja jednostka: %s1_UnitName pr&#243;bowa&#179;a uciec przed %s3_EnUName (%s2_Enemy) ale zosta&#179;a dopadni&#234;ta i musi teraz walczy&#230; o &#191;ycie</Polish>
 		<Russian>Ваш %s1_UnitName был перехвачен %s2_Enemy игрока %s3_EnUName после неудачного нападения со спины и теперь вынужден сражаться за свою жизнь.</Russian>
@@ -14674,7 +14674,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_MISC_EXPERIENCE_DRAFT</Tag>
 		<English>%d1 XP (Drafted Units get half normal XP)</English>
-		<French>%d1 EXP (Drafted Units get half normal XP)</French>
+		<French>%d1 EXP (Les unités conscrites reçoivent la moitié de l'EXP)</French>
 		<German>%d1 EP (Drafted Units get half normal XP)</German>
 		<Spanish>%d1 PE (Drafted Units get half normal XP)</Spanish>
 		<Polish>%d1 EXP (Drafted Units get half normal XP)</Polish>

--- a/Assets/XML/GameText/Hints_CIV4GameText.xml
+++ b/Assets/XML/GameText/Hints_CIV4GameText.xml
@@ -2936,7 +2936,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_ROM_HINT_33</Tag>
 		<English>Caveman2Cosmos: New eras have been added to this mod. Such as the Prehistoric, Transhuman, and Galactic eras.</English>
-		<French>Caveman2Cosmos: De nouvelles Eres ont été ajoutées dans ce mod. les Eres préhistorique, Transhumaine et galactique vous permettent d'effectuer plus des dizaine de nouvelles Recherches, d'accéder à de nouvelle unités...</French>
+		<French>Caveman2Cosmos: De nouvelles ères ont été ajoutées dans ce mod. ces ères (préhistorique, Transhumaine,Galactique, et plus loin...) vous permettent d'effectuer plus des dizaine de nouvelles recherches, d'accéder à de nouvelles unités...</French>
 		<Italian>Caveman2Cosmos: Questa Mod presenta nuove ere, come quella preistorica, quella transumana e quella galattica.</Italian>
 		<Spanish>Caveman2Cosmos: Se han añadido nuevas épocas en este mod, como la Prehistoria, la Época transhumana y la Época galáctica.</Spanish>
 		<Polish>Caveman2Cosmos: Zosta&#179;a dodana nowa Era. Era transhumanizmu dodaje do gry 60 technologi przysz&#179;o&#156;ci i daje dost&#234;p do pot&#234;&#191;nych mech&#243;w i robot&#243;w. Koniec gry zosta&#179; przeniesiony z 2050 do 2275.</Polish>

--- a/Assets/XML/GameText/Promotions_CIV4GameText.xml
+++ b/Assets/XML/GameText/Promotions_CIV4GameText.xml
@@ -473,7 +473,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTIONHELP_DOMAIN_CARGO_CHANGE</Tag>
 		<English>[ICON_BULLET]Outfits unit to transport %s1_Change Units [COLOR_WARNING_TEXT](And then allows NO OTHER domains!)[COLOR_REVERT]</English>
-		<French>[ICON_BULLET]Equipe l'unité pour transporter %s1_Change Unités</French>
+		<French>[ICON_BULLET]Équipe l'unité pour transporter des %s1_Change</French>
 		<German>[ICON_BULLET]ermöglicht den Transport von %s1_Change</German>
 		<Polish>[ICON_BULLET]Przystosowuje jednostk&#234; do transportu %s1_Change innych jednostek</Polish>
 		<Russian>[ICON_BULLET]Переоснащен для перевозки %s1_Change Units [COLOR_WARNING_TEXT](блокирует все ПРОЧИЕ улучшения!)[COLOR_REVERT]</Russian>
@@ -1363,7 +1363,7 @@
 	<TEXT>
 		<Tag>TXT_KEY_PROMOTIONHELP_SPECIAL_CARGO_CHANGE</Tag>
 		<English>[ICON_BULLET]Outfits unit to transport %s1_Change Units [COLOR_WARNING_TEXT](And then allows NO OTHER type!)[COLOR_REVERT]</English>
-		<French>[ICON_BULLET]Equipe l'unité pour transporter %s1_Change Unités</French>
+		<French>[ICON_BULLET]Équipe l'unité pour transporter des %s1_Change</French>
 		<German>[ICON_BULLET]ermöglicht den Transport von %s1:4_Change</German>
 		<Polish>[ICON_BULLET]Przygotowuje jednostk&#234; do transportu innych jednostek %s1_Change</Polish>
 		<Russian>[ICON_BULLET]Переоснащен для перевозки %s1_Change Units [COLOR_WARNING_TEXT](исключая любые ДРУГИЕ отряды!)[COLOR_REVERT]</Russian>

--- a/Assets/XML/Terrain/Manufactured_CIV4BonusInfos.xml
+++ b/Assets/XML/Terrain/Manufactured_CIV4BonusInfos.xml
@@ -2918,6 +2918,7 @@
 			<ArtDefineTag>ART_DEF_BONUS_PLASTEEL</ArtDefineTag>
 			<TechReveal>TECH_HYPERMAGNETICS</TechReveal>
 			<TechCityTrade>TECH_HYPERMAGNETICS</TechCityTrade>
+			<iAIObjective>10</iAIObjective>
 		</BonusInfo>
 		<BonusInfo>
 			<Type>BONUS_MARTIAN_FRUIT</Type>

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -4568,7 +4568,12 @@ void CvGame::setActivePlayer(PlayerTypes eNewValue, bool bForceHotSeat)
 
 		if (GC.IsGraphicsInitialized())
 		{
+#ifdef ENABLE_FOGWAR_DECAY
+			GC.getMap().InitFogDecay();
+			GC.getMap().updateFog(true);
+#else
 			GC.getMap().updateFog();
+#endif
 			GC.getMap().updateVisibility();
 			GC.getMap().updateSymbols();
 			GC.getMap().updateMinimapColor();
@@ -11443,8 +11448,12 @@ void CvGame::recalculateModifiers()
 
 	GC.getMap().setupGraphical();
 	GC.getMap().updateVisibility();
+#ifdef ENABLE_FOGWAR_DECAY
+	GC.getMap().InitFogDecay();
+	GC.getMap().updateFog(true);
+#else
 	GC.getMap().updateFog();
-
+#endif
 	Cy::call_optional(PYCivModule, "recalculateModifiers");
 
 	m_bRecalculatingModifiers = false;

--- a/Sources/CvGameCoreDLL.cpp
+++ b/Sources/CvGameCoreDLL.cpp
@@ -307,9 +307,13 @@ void IFPBeginSample(ProfileLinkageInfo* linkageInfo, bool bAsConditional)
 
 void IFPEndSample(ProfileLinkageInfo* linkageInfo, bool bAsConditional)
 {
+	if (!linkageInfo || !linkageInfo->sample)
+	{
+		return;
+	}
 	if ( iThreadSlot != -1 )
 	{
-		if ( !bAsConditional && _currentSample != linkageInfo && linkageInfo->sample->Parent != -1 )
+		if ( !bAsConditional && _currentSample != linkageInfo &&  linkageInfo->sample->Parent != -1 )
 		{
 			char	buffer[200];
 

--- a/Sources/CvGameCoreDLL.h
+++ b/Sources/CvGameCoreDLL.h
@@ -3,6 +3,9 @@
 #ifndef CvGameCoreDLL_h__
 #define CvGameCoreDLL_h__
 
+
+#define ENABLE_FOGWAR_DECAY
+
 //
 // includes (pch) for gamecore dll files
 // Author - Mustafa Thamer

--- a/Sources/CvGameCoreUtils.cpp
+++ b/Sources/CvGameCoreUtils.cpp
@@ -4629,3 +4629,32 @@ CvString MissionAITypeToDescription(MissionAITypes eMissionAI)
 	default:                                   return "Unknown mission AI";
 	}
 }
+
+CvString AutomateTypeToDescription(AutomateTypes eAutomateAI)
+{
+	switch (eAutomateAI)
+	{
+	case NO_AUTOMATE:              return "---";
+	case AUTOMATE_BUILD:           return "Construct improvements";
+	case AUTOMATE_NETWORK:         return "Build and maintain networks";
+	case AUTOMATE_CITY:            return "Manage city automation";
+	case AUTOMATE_EXPLORE:         return "Explore the map";
+	case AUTOMATE_RELIGION:        return "Spread religion";
+	case AUTOMATE_PILLAGE:         return "Pillage enemy lands";
+	case AUTOMATE_HUNT:            return "Hunt down enemies";
+	case AUTOMATE_CITY_DEFENSE:    return "Defend the city";
+	case AUTOMATE_BORDER_PATROL:   return "Patrol borders";
+	case AUTOMATE_HURRY:           return "Hurry production";
+	case AUTOMATE_PIRATE:          return "Raid and plunder at sea";
+	case AUTOMATE_AIRSTRIKE:       return "Conduct air strikes";
+	case AUTOMATE_AIRBOMB:         return "Bomb enemy targets";
+	case AUTOMATE_AIR_RECON:       return "Perform air reconnaissance";
+	case AUTOMATE_UPGRADING:       return "Upgrade unit";
+	case AUTOMATE_CANCEL_UPGRADING:return "Cancel unit upgrade";
+	case AUTOMATE_PROMOTIONS:      return "Apply promotions";
+	case AUTOMATE_CANCEL_PROMOTIONS:return "Cancel promotions";
+	case AUTOMATE_SHADOW:          return "Shadow enemy units";
+	default:                       return "---";
+	}
+}
+

--- a/Sources/CvGameCoreUtils.h
+++ b/Sources/CvGameCoreUtils.h
@@ -432,4 +432,5 @@ CvString MissionAITypeToString(MissionAITypes eMissionAI);
 // Conversion enum -> brut string found a city..., Move to...
 CvString MissionAITypeToDescription(MissionAITypes eMissionAI);
 
+CvString AutomateTypeToDescription(AutomateTypes eAutomateAI);
 #endif

--- a/Sources/CvGameTextMgr.cpp
+++ b/Sources/CvGameTextMgr.cpp
@@ -2916,7 +2916,16 @@ void CvGameTextMgr::setUnitHelp(CvWStringBuffer &szString, const CvUnit* pUnit, 
 				CvWString szStringUnitAi = "";
 				getUnitAIString(szStringUnitAi, eUnitAI);
 				MissionAITypes eMissionAI = pUnit->getGroup()->AI_getMissionAIType();
-				CvWString MissionInfos = MissionAITypeToDescription(eMissionAI);
+				CvWString MissionInfos = "";
+				if (eMissionAI != NO_MISSIONAI)
+				{
+					MissionInfos = MissionAITypeToDescription(eMissionAI);
+				}
+				else if (pUnit->isAutomated())
+				{
+					AutomateTypes eAutomateAI = pUnit->getGroup()->getAutomateType();
+					MissionInfos = AutomateTypeToDescription(eAutomateAI);
+				}
 				szString.append(gDLL->getText("TXT_KEY_UNITHELP_ROLE", szStringUnitAi.GetCString(), MissionInfos.GetCString()));
 			}
 #endif

--- a/Sources/CvMap.cpp
+++ b/Sources/CvMap.cpp
@@ -509,15 +509,25 @@ void CvMap::updateFlagSymbolsInternal(bool bForce)
 }
 
 
-void CvMap::updateFog()
+void CvMap::updateFog(const bool bApplyDecay)
 {
 	PROFILE_FUNC();
 
 	for (int iI = 0; iI < numPlots(); iI++)
 	{
-		plotByIndex(iI)->updateFog();
+		plotByIndex(iI)->updateFog(bApplyDecay);
 	}
 }
+
+#ifdef ENABLE_FOGWAR_DECAY
+void CvMap::InitFogDecay()
+{
+	for (int iI = 0; iI < numPlots(); iI++)
+	{
+		plotByIndex(iI)->InitFogDecay();
+	}
+}
+#endif
 
 
 void CvMap::updateVisibility()
@@ -1510,7 +1520,7 @@ void CvMap::afterSwitch()
 	Cy::call(PYScreensModule, "initMinimap");
 
 	setupGraphical();
-	updateFog();
+	updateFog(true);
 	updateSymbols();
 	updateFlagSymbols();
 	updateMinimapColor();

--- a/Sources/CvMap.cpp
+++ b/Sources/CvMap.cpp
@@ -1340,6 +1340,11 @@ void CvMap::read(FDataStreamBase* pStream)
 	WRAPPER_READ_OBJECT_END(wrapper);
 
 	OutputDebugString("Reading Map: End\n");
+
+#ifdef ENABLE_FOGWAR_DECAY
+	InitFogDecay();
+#endif
+
 }
 
 // save object to a stream

--- a/Sources/CvMap.h
+++ b/Sources/CvMap.h
@@ -89,7 +89,8 @@ public:
 
 	void updateFlagSymbolsInternal(bool bForce);
 	void updateFlagSymbols();
-	void updateFog();
+	void updateFog(const bool bApplyDecay = false);
+	void InitFogDecay();
 	void updateVisibility();
 	void updateSymbolVisibility();
 	void updateSymbols();

--- a/Sources/CvMapInterfaceBase.h
+++ b/Sources/CvMapInterfaceBase.h
@@ -54,7 +54,7 @@ public:
 	virtual void erasePlots() = 0;
 
 	virtual void updateFlagSymbols() = 0;
-	virtual void updateFog() = 0;
+	virtual void updateFog(const bool bApplyDecay = false) = 0;
 	virtual void updateSymbolVisibility() = 0;
 	virtual void updateMinimapColor() = 0;
 	virtual void updateCenterUnit() = 0;

--- a/Sources/CvPathGenerator.cpp
+++ b/Sources/CvPathGenerator.cpp
@@ -272,20 +272,28 @@ public:
 	{
 		PROFILE_FUNC();
 
-		if (pPlot->m_pathGenerationSeq != m_seq)
+		// Fast path: cache hit
+		if (pPlot->m_pathGenerationSeq == m_seq)
 		{
-			if (!bCreateIfNotFound)
-			{
-				return NULL;
-			}
-			pPlot->m_currentPathInfo = m_allocationPool.allocateNode();
-			pPlot->m_pathGenerationSeq = m_seq;
-
-			pPlot->m_currentPathInfo->pNode = NULL;
-			pPlot->m_currentPathInfo->bKnownInvalidNode = false;
-			pPlot->m_currentPathInfo->m_iEdgesValidated = 0;
+			return pPlot->m_currentPathInfo;
 		}
-		return pPlot->m_currentPathInfo;
+
+		// Cache miss: allocate and initialize if allowed
+		if (!bCreateIfNotFound)
+		{
+			return NULL;
+		}
+
+		// Value-initialize for safety
+		CvPathGeneratorPlotInfo* pInfo = m_allocationPool.allocateNode();
+		pInfo->pNode = NULL;
+		pInfo->bKnownInvalidNode = false;
+		pInfo->m_iEdgesValidated = 0;
+
+		pPlot->m_currentPathInfo = pInfo;
+		pPlot->m_pathGenerationSeq = m_seq;
+
+		return pInfo;
 	}
 
 	static void clearPlotInfo(const CvPlot* pPlot)

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -3844,7 +3844,8 @@ void CvPlayer::doTurn()
 		//Calvitix, Modmod FOGWAR PlotDecay
 		if (isHumanPlayer())
 		{
-			GC.getMap().updateFog(true); //Calvitix, to applyPlotDecay
+			if (GET_TEAM(getTeam()).getVisibilityDecay() != NO_DECAY)
+				GC.getMap().updateFog(true); //Calvitix, to applyPlotDecay
 		}
 #endif
 	}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -1178,7 +1178,11 @@ void CvPlot::updateFog(const bool bApplyDecay)
 		)
 		{
 #ifdef ENABLE_FOGWAR_DECAY
-			if (bIsHuman && bApplyDecay) m_iVisibilityDecay = GET_TEAM(team).getVisibilityDecay();
+			if (bIsHuman && bApplyDecay)
+			{
+				m_iVisibilityDecay = GET_TEAM(team).getVisibilityDecay();
+				m_iVisibilityDecay += getVisibilityDecayBonus();
+			}
 #endif
 			gDLL->getEngineIFace()->LightenVisibility(getFOWIndex());
 		}
@@ -1240,7 +1244,56 @@ void CvPlot::updateVisibility()
 void CvPlot::InitFogDecay()
 {
 	const TeamTypes& team = GC.getGame().getActiveTeam();
-	m_iVisibilityDecay = GET_TEAM(team).getVisibilityDecay();
+	if (team != NO_TEAM)
+	{
+		m_iVisibilityDecay = GET_TEAM(team).getVisibilityDecay();
+	}
+	if (m_iVisibilityDecay <= 0)
+	{
+		m_iVisibilityDecay = 2;
+	}
+	m_iVisibilityDecay = GC.getGame().getSorenRandNum(m_iVisibilityDecay, "InitFog Decay");
+	m_iVisibilityDecay += getVisibilityDecayBonus();
+
+}
+
+short CvPlot::getVisibilityDecayBonus()
+{
+	const FeatureTypes eFeature = getFeatureType();
+	const BonusTypes eBonusType = getBonusType();
+	int iVisibilityDecay = 0;
+	if (eFeature != NO_FEATURE)
+	{
+		const CvFeatureInfo& kFeatureInfo = GC.getFeatureInfo(eFeature);
+		const CvString featureString = kFeatureInfo.getType();
+		const CvBonusInfo& kBonusInfo = GC.getBonusInfo(eBonusType);
+		if (featureString == "FEATURE_OASIS" || featureString == "FEATURE_CAVES" || featureString == "FEATURE_CITY_RUINS"
+		|| featureString.find("FEATURE_PLATY_") != std::string::npos)
+		{
+			iVisibilityDecay += 3;
+		}
+	}
+	if (eBonusType != NO_BONUS)
+	{
+		iVisibilityDecay += 3;
+	}
+	if (getOwner() != NO_PLAYER)
+	{
+		iVisibilityDecay += 1;
+	}
+	if (isCityRadius())
+	{
+		iVisibilityDecay += 2;
+	}
+	if (isCity())
+	{
+		iVisibilityDecay += 6;
+	}
+	if (isFreshWater())
+	{
+		iVisibilityDecay += 3;
+	}
+	return iVisibilityDecay;
 }
 #endif
 

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -191,7 +191,7 @@ public:
 	void updateVisibility();
 #ifdef ENABLE_FOGWAR_DECAY
 	void InitFogDecay();
-	short getVisibilityDecayBonus();
+	short getVisibilityDecayBonus(bool pSeaPlot = false);
 #endif
 
 	void updateSymbolDisplay();
@@ -821,7 +821,7 @@ public:
 	void updateRiverCrossing();
 
 	DllExport bool isRevealed(TeamTypes eTeam, bool bDebug) const;
-	void setRevealed(const TeamTypes eTeam, const bool bNewValue, const bool bTerrainOnly, const TeamTypes eFromTeam, const bool bUpdatePlotGroup);
+	void setRevealed(const TeamTypes eTeam, const bool bNewValue, const bool bTerrainOnly, const TeamTypes eFromTeam, const bool bUpdatePlotGroup, const bool bUpdateFog = true);
 	bool isAdjacentRevealed(TeamTypes eTeam, bool bDebug = false) const;
 	bool isAdjacentNonrevealed(TeamTypes eTeam) const;
 

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -187,8 +187,11 @@ public:
 	void checkCityRevolt();
 	void checkFortRevolt();
 
-	void updateFog();
+	void updateFog(const bool bApplyDecay = false);
 	void updateVisibility();
+#ifdef ENABLE_FOGWAR_DECAY
+	void InitFogDecay();
+#endif
 
 	void updateSymbolDisplay();
 	void updateSymbolVisibility();
@@ -1037,6 +1040,10 @@ protected:
 	int* m_paiBuildProgress;
 
 	short* m_aiLastSeenTurn;
+
+#ifdef ENABLE_FOGWAR_DECAY
+	short m_iVisibilityDecay;
+#endif
 
 	//	This array will be sparsely populated on most plots so not worth
 	//	an indirection, but look to find a way to use the sparseness to reduce memory usage

--- a/Sources/CvPlot.h
+++ b/Sources/CvPlot.h
@@ -191,6 +191,7 @@ public:
 	void updateVisibility();
 #ifdef ENABLE_FOGWAR_DECAY
 	void InitFogDecay();
+	short getVisibilityDecayBonus();
 #endif
 
 	void updateSymbolDisplay();

--- a/Sources/CvSelectionGroup.cpp
+++ b/Sources/CvSelectionGroup.cpp
@@ -5453,6 +5453,7 @@ TeamTypes CvSelectionGroup::getHeadTeam() const
 
 void CvSelectionGroup::clearMissionQueue()
 {
+	PROFILE_FUNC();
 	FAssert(getOwner() != NO_PLAYER);
 	FAssert(getHeadUnit());
 

--- a/Sources/CvTeam.cpp
+++ b/Sources/CvTeam.cpp
@@ -5064,7 +5064,9 @@ bool CvTeam::isHasTech(TechTypes eIndex) const
 	}
 	FASSERT_BOUNDS(0, GC.getNumTechInfos(), eIndex);
 	FAssertMsg(m_pabHasTech, "m_pabHasTech is not expected to be equal with NULL");
-	return m_pabHasTech[eIndex];
+	if (m_pabHasTech)
+		return m_pabHasTech[eIndex];
+	return false;
 }
 
 

--- a/Sources/CvTeamAI.cpp
+++ b/Sources/CvTeamAI.cpp
@@ -144,7 +144,8 @@ void CvTeamAI::AI_reset(bool bConstructor)
 	m_iDogpileWarRand = 0;
 	m_iMakePeaceRand = 0;
 #ifdef	ENABLE_FOGWAR_DECAY
-	m_bPermanentMap = false;
+	m_bPermanentMapLand = false;
+	m_bPermanentMapSea = false;
 #endif
 }
 
@@ -5033,53 +5034,111 @@ bool CvTeamAI::AI_hasAdjacentLandPlots(TeamTypes eTeam) const
 }
 
 #ifdef ENABLE_FOGWAR_DECAY
-int CvTeamAI::getVisibilityDecay()
+int CvTeamAI::getVisibilityDecay(bool pSeaPlot)
 {
-	if (m_bPermanentMap || !isHuman()) return NO_DECAY;
+	if ((pSeaPlot && m_bPermanentMapSea) || !isHuman()) return NO_DECAY;
+	if ((!pSeaPlot && m_bPermanentMapLand) || !isHuman()) return NO_DECAY;
 
+	if (pSeaPlot)
+	{
+		int iPathfinding = GC.getInfoTypeForString("TECH_NAVIGATION"); 
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			m_bPermanentMapSea = true;
+			return NO_DECAY;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_COMPASS");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 40;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_CARTOGRAPHY");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 30;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_PAPER");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 20;
+		}		
+		iPathfinding = GC.getInfoTypeForString("TECH_RUDDER");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 15;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_SEAFARING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 12;
+		}
+		
+		iPathfinding = GC.getInfoTypeForString("TECH_WRITING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 9;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_STARGAZING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 6;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_SAILING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 3;
+		}
+		return 1;
+	}
+	else
+	{
+		int iPathfinding = GC.getInfoTypeForString("TECH_CARTOGRAPHY");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			m_bPermanentMapLand = true;
+			return NO_DECAY;
+		}		
+		iPathfinding = GC.getInfoTypeForString("TECH_SURVEYING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 40;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_WRITING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 25;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_EXPLORATION");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 18;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_IDEOGRAMS");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 15;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_PICTOGRAPHS");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 12;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_HUNTING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 9;
+		}
 
-	int iWriting = GC.getInfoTypeForString("TECH_WRITING");
-	if (isHasTech((TechTypes)iWriting))
-	{
-		m_bPermanentMap = true;
-		return NO_DECAY;
-	}
-	int iPathfinding = GC.getInfoTypeForString("TECH_EXPLORATION");
-	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 18;
-	}
-	iPathfinding = GC.getInfoTypeForString("TECH_IDEOGRAMS");
-//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 15;
-	}
-	iPathfinding = GC.getInfoTypeForString("TECH_PICTOGRAPHS");
-	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 12;
-	}
-	iPathfinding = GC.getInfoTypeForString("TECH_HUNTING");
-	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 9;
-	}
-	
-	iPathfinding = GC.getInfoTypeForString("TECH_TRACKING");
-	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 6;
-	}
-	iPathfinding = GC.getInfoTypeForString("TXT_KEY_TECH_TRAILS");
-	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
-	if (isHasTech((TechTypes)iPathfinding))
-	{
-		return 3;
+		iPathfinding = GC.getInfoTypeForString("TECH_TRACKING");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 6;
+		}
+		iPathfinding = GC.getInfoTypeForString("TECH_TRAILS");
+		if (isHasTech((TechTypes)iPathfinding))
+		{
+			return 3;
+		}
 	}
 	return 1;
 }

--- a/Sources/CvTeamAI.cpp
+++ b/Sources/CvTeamAI.cpp
@@ -143,6 +143,9 @@ void CvTeamAI::AI_reset(bool bConstructor)
 	m_iLimitedWarPowerRatio = 0;
 	m_iDogpileWarRand = 0;
 	m_iMakePeaceRand = 0;
+#ifdef	ENABLE_FOGWAR_DECAY
+	m_bPermanentMap = false;
+#endif
 }
 
 
@@ -5028,3 +5031,56 @@ bool CvTeamAI::AI_hasAdjacentLandPlots(TeamTypes eTeam) const
 	}
 	return false;
 }
+
+#ifdef ENABLE_FOGWAR_DECAY
+int CvTeamAI::getVisibilityDecay()
+{
+	if (m_bPermanentMap || !isHuman()) return NO_DECAY;
+
+
+	int iWriting = GC.getInfoTypeForString("TECH_WRITING");
+	if (isHasTech((TechTypes)iWriting))
+	{
+		m_bPermanentMap = true;
+		return NO_DECAY;
+	}
+	int iPathfinding = GC.getInfoTypeForString("TECH_EXPLORATION");
+	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 18;
+	}
+	iPathfinding = GC.getInfoTypeForString("TECH_IDEOGRAMS");
+//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 15;
+	}
+	iPathfinding = GC.getInfoTypeForString("TECH_PICTOGRAPHS");
+	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 12;
+	}
+	iPathfinding = GC.getInfoTypeForString("TECH_HUNTING");
+	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 9;
+	}
+	
+	iPathfinding = GC.getInfoTypeForString("TECH_TRACKING");
+	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 6;
+	}
+	iPathfinding = GC.getInfoTypeForString("TXT_KEY_TECH_TRAILS");
+	//	int iPathfinding = GC.getInfoTypeForString("TECH_SCIENTIFIC_METHOD");
+	if (isHasTech((TechTypes)iPathfinding))
+	{
+		return 3;
+	}
+	return 1;
+}
+#endif

--- a/Sources/CvTeamAI.h
+++ b/Sources/CvTeamAI.h
@@ -869,7 +869,7 @@ public:
      * Returns an number that will be the base for the plot decay. The higher the number is, the lastest the plot will disappear.
      * The number is by default 1, and will be set to 3,6,9,12... depending on which Tech the player already has
      */
-    int getVisibilityDecay();
+    int getVisibilityDecay(bool pSeaPlot = false);
 #endif
 
 protected:
@@ -907,7 +907,8 @@ protected:
 	int m_iDogpileWarRand;
 	int m_iMakePeaceRand;
 #ifdef ENABLE_FOGWAR_DECAY
-    bool m_bPermanentMap;
+    bool m_bPermanentMapLand;
+    bool m_bPermanentMapSea;
 #endif
 
 

--- a/Sources/CvTeamAI.h
+++ b/Sources/CvTeamAI.h
@@ -6,6 +6,7 @@
 #define CIV4_TEAM_AI_H
 
 #include "CvTeam.h"
+#include "CvGameCoreDLL.h"
 
 class CvArea;
 class CvCity;
@@ -863,6 +864,13 @@ public:
      */
 	bool AI_hasAdjacentLandPlots(TeamTypes eTeam) const;
 
+#ifdef ENABLE_FOGWAR_DECAY
+    /**
+     * Returns an number that will be the base for the plot decay. The higher the number is, the lastest the plot will disappear.
+     * The number is by default 1, and will be set to 3,6,9,12... depending on which Tech the player already has
+     */
+    int getVisibilityDecay();
+#endif
 
 protected:
 
@@ -898,6 +906,10 @@ protected:
 	int m_iLimitedWarPowerRatio;
 	int m_iDogpileWarRand;
 	int m_iMakePeaceRand;
+#ifdef ENABLE_FOGWAR_DECAY
+    bool m_bPermanentMap;
+#endif
+
 
 	int AI_noTechTradeThreshold(bool bRecalculate = false) const;
 	int AI_techTradeKnownPercent(bool bRecalculate = false) const;
@@ -922,5 +934,8 @@ protected:
 
 // helper for accessing static functions
 #define GET_TEAM CvTeamAI::getTeam
+
+#define NO_DECAY -1
+#define MAX_DECAY 6
 
 #endif

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -3529,7 +3529,7 @@ void CvUnitAI::AI_attackCityMove()
 						return;
 					}
 				}
-				if ((iComparePostBombard >= iAttackRatio) || (pTargetCity->getDefenseDamage() < ((GC.getMAX_CITY_DEFENSE_DAMAGE() * 1) / 2)) || (iOurOffense / iEnemyOffense) > 2 || pTargetCity->plot()->getNumDefenders(pTargetCity->getOwner()) <= 2)
+				if ((iComparePostBombard >= iAttackRatio) || (pTargetCity->getDefenseDamage() < ((GC.getMAX_CITY_DEFENSE_DAMAGE() * 1) / 2)) || (iOurOffense / (iEnemyOffense+1)) > 39/20 || pTargetCity->plot()->getNumDefenders(pTargetCity->getOwner()) <= 2)
 				{
 					if (iComparePostBombard < std::max(150, GC.getBBAI_SKIP_BOMBARD_MIN_STACK_RATIO()) && (pTargetCity->isDirectAttackable() || canIgnoreNoEntryLevel()))
 					{
@@ -22211,10 +22211,14 @@ bool CvUnitAI::processContracts(int iMinPriority)
 		{
 			CvString JoinInfos = "";
 			CvString MissionInfos = "";
-			if (pJoinUnit != NULL)
+			if (pJoinUnit)
 			{
-				JoinInfos = "[to join ]" + pJoinUnit->getID();
-				MissionInfos = MissionAITypeToString(pJoinUnit->getGroup()->AI_getMissionAIType());
+				const CvSelectionGroup* pGroup = pJoinUnit->getGroup();
+				JoinInfos = CvString::format("[to join ] %d",pJoinUnit->getID());
+				if (pGroup)
+				{
+					MissionInfos = MissionAITypeToString(pGroup->AI_getMissionAIType());
+				}
 				//GC.getUnitAIInfo(AI_getUnitAIType())->getType();
 				
 			}
@@ -29756,14 +29760,6 @@ bool CvUnitAI::AI_fulfillPropertyControlNeed()
 
 	const CvPlayer& player = GET_PLAYER(getOwner());
 
-	//Copy, to avoid modif during scoring
-	std::vector<CvCity*> citySnapshot;
-	for (CvPlayer::city_iterator it = player.beginCities(); it != player.endCities(); ++it)
-	{
-		CvCity* city = *it;  // city_iterator supporte l'opérateur *
-		FAssert(city != nullptr); // sécurité
-		citySnapshot.push_back(city);
-	}
 
 	using namespace scoring;
 	ScoreResult<CvCity> bestCityScore = findBestScore<CvCity, GreatestScore>(

--- a/Sources/CvViewport.cpp
+++ b/Sources/CvViewport.cpp
@@ -484,9 +484,9 @@ void CvViewport::updateFlagSymbols()
 	m_pMap->updateFlagSymbols();
 }
 
-void CvViewport::updateFog()
+void CvViewport::updateFog(const bool bApplyDecay)
 {
-	m_pMap->updateFog();
+	m_pMap->updateFog(bApplyDecay);
 }
 
 void CvViewport::updateSymbolVisibility()

--- a/Sources/CvViewport.h
+++ b/Sources/CvViewport.h
@@ -94,7 +94,7 @@ public:
 	virtual void erasePlots();
 
 	virtual void updateFlagSymbols();
-	virtual void updateFog();
+	virtual void updateFog(const bool bApplyDecay);
 	virtual void updateSymbolVisibility();
 	virtual void updateMinimapColor();
 	virtual void updateCenterUnit();


### PR DESCRIPTION
[FogWar Decay Modmod + small fixes](https://github.com/Calvitix/Caveman2Cosmos/commit/650d4644d3646174d1c4ed51772e92bc72d00eb0)

- Add the FogWar Decay modmod, activated via define ENABLE_FOGWAR_DECAY
- Add a AutomateType to Description in GameCoreUtils - to show it in Hover infos
- Several fixes / addition in French text XML
- Change Central Administration to need 30 -> 15, and Capital -> 20

CTD fixes & some Refactoring
- Prevent CTD when profiling in IFPEndSample()
- Prevent CTD when iEnemyOffence = 0 in CvUnitAI::AI_attackCityMove() when unit next to target city
- Prevent CTD in log message in CvUnitAI::processContract()
- Refactor Cvcity methods : hasRawVicinityBonus and calculateCultureDistance  (that have been spotted via profiling)
- Refactor CvCityAI::AI_addBestCitizen, and CvGame::updateMoves()
- Refactor : CvPlayer::recalculateResourceConsumption()