### PR TITLE
Hotfixes

### DIFF
--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -15617,7 +15617,10 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 
 
 
-
+	if (m_orderQueue.empty() && owner.isHumanPlayer(true))
+	{
+		owner.setIdleCity(getID(), false);
+	}
 
 
 	if (bAppend && !m_orderQueue.empty() && !(m_orderQueue.begin()->eOrderType == ORDER_MAINTAIN))
@@ -15660,12 +15663,6 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 			popOrder(0);
 		}
 		LOG_BBAI_CITY(3, ("    City %S has process on head, and queue added. Removing  %S", getName().GetCString(), str.GetCString()));
-	}
-
-
-	if (m_orderQueue.empty() && owner.isHumanPlayer(true))
-	{
-		owner.setIdleCity(getID(), false);
 	}
 
 

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -15455,6 +15455,7 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 	bool bValid = false;
 	bool bJustAddedProcess = false;
 	CvPlayerAI& owner = GET_PLAYER(getOwner());
+	bool bIsHuman = owner.isHumanPlayer(true);
 
 	OrderData order;
 
@@ -15495,7 +15496,7 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 				}
 
 				//don't add the same unit if already 2 of them (if prod take more than 2 turns), and the first item in queue is not already finished, and the cost of the order is more than 3 turns
-				if ((bAppend && !bForce) && ((alreadyQueued > 1 && getProductionTurnsLeft(unitType, 2) > 2) || alreadyQueued > 4)) {
+				if (!bIsHuman && (bAppend && !bForce) && ((alreadyQueued > 1 && getProductionTurnsLeft(unitType, 2) > 2) || alreadyQueued > 4)) {
 					if (gCityLogLevel >= 3)
 					{
 						const CvWString szStringUnitAi = GC.getUnitAIInfo(order.getUnitAIType()).getType();
@@ -15537,7 +15538,7 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 				}
 
 				//don't add the same building after
-				if ((bAppend && !bForce) && alreadyQueued > 0) {
+				if (!bIsHuman && (bAppend && !bForce) && alreadyQueued > 0) {
 					if (gCityLogLevel >= 3)
 					{
 						logBBAI("    City %S building %S already in queue", getName().GetCString(), GC.getBuildingInfo(buildingType).getDescription());
@@ -15617,7 +15618,7 @@ void CvCity::pushOrder(OrderTypes eOrder, int iData1, int iData2, bool bSave, bo
 
 
 
-	if (m_orderQueue.empty() && owner.isHumanPlayer(true))
+	if (m_orderQueue.empty() && bIsHuman)
 	{
 		owner.setIdleCity(getID(), false);
 	}

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -38105,7 +38105,10 @@ bool CvUnit::canAmbush(const CvPlot* pPlot, bool bAssassinate) const
 		const CvUnit* pDefender = pPlot->getBestDefender(NO_PLAYER, getOwner(), this, true, true, false, bAssassinate);
 		if (pDefender != NULL)
 		{
-			return true;
+			if (!pDefender->isInvisible(getTeam(), false))
+			{
+				return true;
+			}
 		}
 		if (pPlot->isVisiblePotentialEnemyDefender(this) || pPlot->isVisiblePotentialEnemyDefenderless(this))
 		{


### PR DESCRIPTION
- Revert City Idle place for Human player (to prevent the city screen to endless appear)
- Add Check if Invisible in Assassinate button
- The Limit of 2 units in city queue only for AI (not human)