### PR TITLE
AI Army Experimental Branch

### DIFF
--- a/Assets/XML/GameText/Global_CIV4GameText.xml
+++ b/Assets/XML/GameText/Global_CIV4GameText.xml
@@ -567,13 +567,23 @@
 	</TEXT>
 	<TEXT>
 		<Tag>TXT_ACO_CIBLE</Tag>
-		<English>Target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</English>
-		<French>Cible : [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</French>
-		<German>Target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</German>
-		<Italian>target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</Italian>
-		<Polish>target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</Polish>
-		<Spanish>target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</Spanish>
-		<Russian>target: [COLOR_NEGATIVE_TEXT]%s2[COLOR_REVERT]</Russian>
+		<English>Target: </English>
+		<French>Cible : </French>
+		<German>Target: </German>
+		<Italian>target: </Italian>
+		<Polish>target: </Polish>
+		<Spanish>target: </Spanish>
+		<Russian>target: </Russian>
+	</TEXT>	
+	<TEXT>
+		<Tag>TXT_ACO_ATTACKER</Tag>
+		<English>Attacker: </English>
+		<French>Attaquant : </French>
+		<German>Attacker: </German>
+		<Italian>Attacker: </Italian>
+		<Polish>Attacker: </Polish>
+		<Spanish>Attacker: </Spanish>
+		<Russian>Attacker: </Russian>
 	</TEXT>	
 	<TEXT>
 		<Tag>TXT_ACO_WITHDRAW</Tag>

--- a/Sources/C2C (VS2019).vcxproj
+++ b/Sources/C2C (VS2019).vcxproj
@@ -222,6 +222,7 @@
     <ClCompile Include="CounterSet.cpp" />
     <ClCompile Include="CvAllocator.cpp" />
     <ClCompile Include="CvAllocator.h" />
+    <ClCompile Include="CvArmy.cpp" />
     <ClCompile Include="CvBonusInfo.cpp" />
     <ClCompile Include="CvDiplomacyClasses.cpp" />
     <ClCompile Include="CvHallOfFameInfo.cpp" />
@@ -377,6 +378,7 @@
     <ClCompile Include="SCvDebug.cpp" />
     <ClCompile Include="SCvInternalGlobals.cpp" />
     <ClCompile Include="SCyDebug.cpp" />
+    <ClInclude Include="CvArmy.h" />
     <ClInclude Include="CvDiplomacyClasses.h" />
     <ClInclude Include="CvPlayerOptionInfo.h" />
     <ClInclude Include="CvPythonCityLoader.h" />

--- a/Sources/C2C (VS2019).vcxproj.filters
+++ b/Sources/C2C (VS2019).vcxproj.filters
@@ -265,6 +265,9 @@
     <Filter Include="Source\DataDefinitions">
       <UniqueIdentifier>{3be3e26d-e7a2-4fe2-a227-e848ce210a71}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source\Base\Army">
+      <UniqueIdentifier>{e81796e9-a40c-45e3-a2b6-d6230ade5ffd}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FDataIOStream.cpp">
@@ -758,6 +761,9 @@
     </ClCompile>
     <ClCompile Include="CvUnitSelectionCriteria.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CvArmy.cpp">
+      <Filter>Source\Base\Army</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1309,6 +1315,9 @@
     </ClInclude>
     <ClInclude Include="CvTraitInfo.h">
       <Filter>Source\DataDefinitions</Filter>
+    </ClInclude>
+    <ClInclude Include="CvArmy.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Sources/CvArmy.cpp
+++ b/Sources/CvArmy.cpp
@@ -1,0 +1,599 @@
+﻿#include "CvArmy.h"
+#include "CvUnit.h"
+#include "CvSelectionGroup.h"
+#include "CvString.h"
+#include "CvPlayerAI.h"
+
+#define NO_INDEX -1
+
+#ifdef CVARMY_BREAKSAVE
+
+CvArmy::CvArmy()
+{
+    reset(0, NO_PLAYER, true);
+}
+
+CvArmy::~CvArmy()
+{
+    uninit();
+}
+
+void CvArmy::init(int iID, PlayerTypes eOwner, int eMissionType)
+{
+    // Initialize saved data
+    reset(iID, eOwner);
+
+    // Initialize non-saved data
+    m_eMission = eMissionType;
+    m_iLeaderGroupID = NO_INDEX;
+    m_pTargetPlot = NULL;
+}
+
+void CvArmy::uninit()
+{
+    m_groupIDs.clear();
+    m_iLeaderGroupID = NO_INDEX;
+    m_pTargetPlot = NULL;
+}
+
+void CvArmy::reset(int iID, PlayerTypes eOwner, bool bConstructorCall)
+{
+    // Uninit class
+    uninit();
+
+    // Initialize data members
+    m_iID = iID;
+    m_eOwner = eOwner;
+    m_eMission = 0;
+    m_iLeaderGroupID = NULL;
+    m_pTargetPlot = NULL;
+}
+
+
+void CvArmy::addGroup(CvSelectionGroup* pGroup)
+{
+    if (pGroup != NULL)
+    {
+        if (pGroup->getHeadUnit() != NULL)
+        {
+            m_groupIDs.push_back(pGroup->getID());
+            pGroup->setArmyID(m_iID); // mark the group with this army's ID
+        }
+    }
+}
+
+void CvArmy::removeGroup(CvSelectionGroup* pGroup)
+{
+    if (pGroup == NULL)
+        return;
+
+    std::vector<int>::iterator it = std::find(m_groupIDs.begin(), m_groupIDs.end(), pGroup->getID());
+    if (it != m_groupIDs.end())
+    {
+        m_groupIDs.erase(it);
+        pGroup->setArmyID(-1); // reset group's army ID
+    }
+
+    // Reset leader if necessary
+    if (pGroup->getID() == m_iLeaderGroupID)
+        m_iLeaderGroupID = NO_INDEX;
+}
+
+
+bool CvArmy::CheckTargetDefendPlot()
+{
+    CvSelectionGroup* pLeaderGroup = getLeader();
+    if (pLeaderGroup == NULL) return false;
+    if (pLeaderGroup->getHeadUnit() == NULL) return false;
+    CvPlot* pLeaderPlot = pLeaderGroup->getHeadUnit()->plot();
+    CvArea* pArea = pLeaderPlot->area();
+    if (m_pTargetPlot == NULL || pLeaderGroup->at(m_pTargetPlot->getX(), m_pTargetPlot->getY()))
+    {
+        const CvPlayerAI& player = GET_PLAYER(pLeaderGroup->getHeadUnit()->getOwner());
+        CvCity* pTargetCity = NULL;// player.AI_p  AI_findTargetCity(pArea);
+        if (pTargetCity != NULL)
+        {
+            setTargetPlot(pTargetCity->plot());
+            // set the army's target plot
+            return true;
+        }
+    }
+    return false;
+}
+
+
+bool CvArmy::CheckTargetCity()
+{
+    CvSelectionGroup* pLeaderGroup = getLeader();
+    if (pLeaderGroup == NULL) return false;
+    if (pLeaderGroup->getHeadUnit() == NULL) return false;    
+    CvPlot* pLeaderPlot = pLeaderGroup->getHeadUnit()->plot();
+    CvArea* pArea = pLeaderPlot->area();
+    if (m_pTargetPlot == NULL || pLeaderGroup->at(m_pTargetPlot->getX(), m_pTargetPlot->getY()))
+    {
+        const CvPlayerAI& player = GET_PLAYER(pLeaderGroup->getHeadUnit()->getOwner());
+        CvCity* pTargetCity = player.AI_findTargetCity(pArea);
+        if (pTargetCity != NULL)
+        {
+            setTargetPlot(pTargetCity->plot());
+            // set the army's target plot
+            return true;
+        }
+    }
+    return false;
+}
+
+CvSelectionGroup* CvArmy::findNewLeader()
+{
+    // Leader is dead or invalid -> recalculate
+    int iBestStrength = -1;
+    int iBestGroupID = -1;
+
+    for (std::vector<int>::const_iterator it = m_groupIDs.begin(); it != m_groupIDs.end(); ++it)
+    {
+        CvSelectionGroup* pGroup = GET_PLAYER(getOwner()).getSelectionGroup(*it);
+        if (pGroup == NULL || pGroup->getHeadUnit() == NULL)
+            continue;
+
+        int iStrength = pGroup->getNumUnits(); // helper in DLL: total combat strength
+        if (iStrength > iBestStrength)
+        {
+            iBestStrength = iStrength;
+            iBestGroupID = *it;
+        }
+    }
+
+    // 2) If none found, look nearby (e.g. 3 tiles)
+    CvSelectionGroup* pLeader = NULL;
+    if (iBestGroupID != -1)
+    {
+        pLeader = GET_PLAYER(getOwner()).getSelectionGroup(iBestGroupID);
+        const int iSearchRange = 2;
+        CvSelectionGroup* pLeader = GET_PLAYER(getOwner()).getSelectionGroup(iBestGroupID);
+        for (CvPlayer::group_iterator it = GET_PLAYER(getOwner()).groups().begin();
+             it != GET_PLAYER(getOwner()).groups().end(); ++it)
+        {
+            CvSelectionGroup* pGroup = *it;
+            if (pGroup == NULL || pGroup->getHeadUnit() == NULL)
+                continue;
+
+            // skip groups already in another army
+            if (pGroup->getDomainType() != DOMAIN_LAND || (pGroup->getArmyID() != -1 && pGroup->getArmyID() != getID()))
+                continue;
+
+            // distance check (relative to old leader's plot if exists, otherwise skip)
+            if (pLeader != NULL && pLeader->plot() != NULL)
+            {
+                CvPlot* pPlot = pGroup->plot();
+                if (pPlot == NULL)
+                    continue;
+
+                int iDist = plotDistance(
+                    pLeader->plot()->getX(), pLeader->plot()->getY(),
+                    pPlot->getX(), pPlot->getY()
+                );
+                if (iDist > iSearchRange)
+                    continue;
+            }
+
+            int iStrength = pGroup->getNumUnits();
+            if (iStrength > iBestStrength)
+            {
+                iBestStrength = iStrength;
+                iBestGroupID = pGroup->getID();
+            }
+        }
+    }
+
+
+    if (iBestGroupID != -1)
+    {
+        // Update leader
+        m_iLeaderGroupID = iBestGroupID;
+        pLeader = GET_PLAYER(getOwner()).getSelectionGroup(iBestGroupID);
+        FAssert(pLeader);
+        CvUnit * pLeaderUnit = pLeader->getHeadUnit();
+        if (pLeaderUnit != NULL)
+        {
+            UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
+            FAssert(pGroup);
+            MissionAITypes eMissionAI = pLeader->AI_getMissionAIType();
+            CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+            CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+            CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+            LOG_UNIT_BLOCK(3, {
+                if (StrUnitName.length() == 0)
+                {
+                    StrUnitName = pLeaderUnit->getName(0).GetCString();
+                }
+
+                logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], is new Leader of Army %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pLeader->getNumUnits(), m_iID);
+                //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
+            });
+        }
+        return GET_PLAYER(getOwner()).getSelectionGroup(iBestGroupID);
+    }
+
+    // No valid leader left
+    m_iLeaderGroupID = -1;
+    return NULL;
+}
+
+
+void CvArmy::doTurn()
+{
+    if (m_iLeaderGroupID == NO_INDEX)
+        return;
+    CvSelectionGroup* pLeaderGroup = getLeader();
+    if (pLeaderGroup == NULL)
+    {
+        pLeaderGroup = findNewLeader();
+        if (pLeaderGroup == NULL)
+        {
+            disband();
+            return;
+        }
+    }
+
+    if (pLeaderGroup->getHeadUnit() == NULL)
+    {
+        disband();
+        return;
+    }
+
+    CvPlot* pLeaderPlot = pLeaderGroup->plot();
+    if (pLeaderPlot == NULL)
+        return;
+
+    switch (m_eMission)
+    {
+    case ARMY_MISSION_ATTACK_CITY:
+    {
+        bool allReady = true;
+
+        if (m_pTargetPlot == NULL)
+        {
+            CheckTargetCity();
+        }
+        // 1) Phase de regroupement autour du leader
+        for (std::vector<int>::iterator it = m_groupIDs.begin(); it != m_groupIDs.end(); ++it)
+        {
+            CvSelectionGroup* pGroup = GET_PLAYER(getOwner()).getSelectionGroup(*it);
+            try
+            {
+                if (pGroup == NULL)
+                    continue;
+                if (pGroup->getHeadUnit() == NULL)
+                {
+                    removeGroup(pGroup);
+                    pGroup->kill();
+                    continue;
+                }
+            }
+            catch (...) {
+                try
+                {
+                    removeGroup(pGroup);
+                }
+                catch (...) {}
+                continue;
+            }
+        
+
+
+            CvPlot* pPlot = pGroup->plot();
+            if (pPlot == NULL)
+                continue;
+
+            int iDist = plotDistance(pPlot->getX(), pPlot->getY(),
+                                     pLeaderPlot->getX(), pLeaderPlot->getY());
+
+            // Si le groupe est à plus de 1 case du leader, le faire avancer
+            if (iDist > 2)
+            {
+                allReady = false;
+                pGroup->pushMission(
+                    MISSION_MOVE_TO,
+                    pLeaderPlot->getX(),
+                    pLeaderPlot->getY(),
+                    0,
+                    false, true,
+                    MISSIONAI_GROUP,
+                    pLeaderPlot
+                );
+
+                if (pGroup != NULL)
+                {
+                    const CvUnit* pLeaderUnit = pGroup->getHeadUnit();
+                    if (pLeaderUnit != NULL)
+                    {
+                        UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
+                        FAssert(pGroup);
+                        MissionAITypes eMissionAI = pGroup->AI_getMissionAIType();
+                        CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+                        CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+                        CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+                        LOG_UNIT_BLOCK(3, {
+                            if (StrUnitName.length() == 0)
+                            {
+                                StrUnitName = pLeaderUnit->getName(0).GetCString();
+                            }
+
+                            logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d, is joining its leader at (%d,%d), distance %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pGroup->getNumUnits(), m_iID, pLeaderPlot->getX(), pLeaderPlot->getY(), iDist);
+                            //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
+                        });
+                    }
+                }
+            }
+        }
+
+        // 2) Une fois tous les groupes prêts, avancer ensemble (leader + suiveurs)
+        if (allReady)
+        {
+            
+            CvPlot* pRefPlot = pLeaderGroup->plot();
+
+            int distToTarget = plotDistance(pRefPlot->getX(), pRefPlot->getY(),
+                        m_pTargetPlot->getX(), m_pTargetPlot->getY());
+
+
+            if (distToTarget <= 20)
+            {
+                CvPlayer& player = GET_PLAYER(pLeaderGroup->getOwner());
+                for (CvPlayer::group_iterator it = player.groups().begin(); it != player.groups().end(); ++it)
+                {
+                    CvSelectionGroup* pGroup = *it;
+                    if (pGroup == NULL || pGroup == pLeaderGroup)
+                        continue;
+                    if (pGroup->getHeadUnit() == NULL)
+                    {
+                        removeGroup(pGroup);
+                        pGroup->kill();
+                        continue;
+                    }
+
+                    CvPlot* pPlot = pGroup->plot();
+                    if (pPlot == NULL)
+                        continue;
+
+                    if (pGroup->getDomainType() != DOMAIN_LAND || pGroup->AI_getMissionAIType() == MISSIONAI_GUARD_CITY
+                        || pGroup->AI_isCityGarrison(pGroup->plot()->getPlotCity()))
+                        continue;
+
+                    int dist = plotDistance(pRefPlot->getX(), pRefPlot->getY(),
+                                            pPlot->getX(), pPlot->getY());
+                    if (dist <= 5) // distance <= 3 cases
+                    {
+                        CvUnit* pLeaderUnit = pGroup->getHeadUnit();
+                        if (pLeaderUnit == NULL)
+                        {
+                            removeGroup(pGroup);
+                        }
+                        pLeaderUnit->AI_setUnitAIType(UNITAI_ATTACK_CITY);
+                        addGroup(pGroup);
+
+                        UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
+                        MissionAITypes eMissionAI = pGroup->AI_getMissionAIType();
+                        CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+                        CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+                        CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+
+                        LOG_UNIT_BLOCK(3, {                            
+                            //UnitAITypes eUnitAi = pGroup->getHeadUnit()->AI_getUnitAIType();
+                            //MissionAITypes eMissionAI = pGroup->AI_getMissionAIType();
+                            //CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+                            //CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+                            //CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+                            if (StrUnitName.length() == 0)
+                            {
+                                StrUnitName = pLeaderUnit->getName(0).GetCString();
+                            }
+
+                            logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d is Ready forced incorporation to Attack at (%d,%d) distance %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pGroup->getNumUnits(), m_iID, m_pTargetPlot->getX(), m_pTargetPlot->getY(), dist);
+                            //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
+                        });
+                        pGroup->pushMission(MISSION_SKIP);
+                        pGroup->pushMissionInternal(MISSION_MOVE_TO_UNIT, pLeaderGroup->getOwner(), pLeaderGroup->getHeadUnit()->getID(), 0, false, false, MISSIONAI_GROUP, NULL, pLeaderGroup->getHeadUnit());
+
+                    }
+                }
+            }
+            
+            LOG_UNIT_BLOCK(3, {
+                const CvUnit * pLeaderUnit = pLeaderGroup->getHeadUnit();
+                UnitAITypes eUnitAi = pLeaderGroup->getHeadUnit()->AI_getUnitAIType();
+                MissionAITypes eMissionAI = pLeaderGroup->AI_getMissionAIType();
+                CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+                CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+                CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+                if (StrUnitName.length() == 0)
+                {
+                    StrUnitName = pLeaderUnit->getName(0).GetCString();
+                }
+
+                logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d is Ready will Command Attack at (%d,%d) distance %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pLeaderGroup->getNumUnits(), m_iID, m_pTargetPlot->getX(), m_pTargetPlot->getY(), distToTarget);
+                //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
+            });
+            // Leader avance
+            //m_pLeader->pushMission(
+            //    MISSION_MOVE_TO,
+            //    m_pTargetPlot->getX(),
+            //    m_pTargetPlot->getY(),
+            //    0,
+            //    false, true,
+            //    MISSIONAI_ASSAULT,
+            //    m_pTargetPlot
+            //);
+
+            // Suiveurs avancent
+            for (std::vector<int>::iterator it = m_groupIDs.begin(); it != m_groupIDs.end(); ++it)
+            {
+                CvSelectionGroup* pGroup = GET_PLAYER(getOwner()).getSelectionGroup(*it);
+                if (pGroup == NULL)
+                    continue;
+                if (pGroup->getHeadUnit() == NULL)
+                {
+                    removeGroup(pGroup);
+                    pGroup->kill();
+                    continue;
+                }
+                //pGroup->pushMission(
+                //    MISSION_MOVE_TO,
+                //    m_pTargetPlot->getX(),
+                //    m_pTargetPlot->getY(),
+                //    0,
+                //    false, true,
+                //    MISSIONAI_ASSAULT,
+                //    m_pTargetPlot
+                //);
+                LOG_UNIT_BLOCK(3, {
+                    const CvUnit * pLeaderUnit = pGroup->getHeadUnit();
+                    UnitAITypes eUnitAi = pGroup->getHeadUnit()->AI_getUnitAIType();
+                    MissionAITypes eMissionAI = pGroup->AI_getMissionAIType();
+                    CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
+                    CvWString MissionInfos = MissionAITypeToString(eMissionAI);
+                    CvWString StrUnitName = pLeaderUnit->getNameNoDesc();
+                    if (StrUnitName.length() == 0)
+                    {
+                        StrUnitName = pLeaderUnit->getName(0).GetCString();
+                    }
+
+                    logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d is Ready and follow leader to Attack at (%d,%d)...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pGroup->getNumUnits(), m_iID, m_pTargetPlot->getX(), m_pTargetPlot->getY());
+                    //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
+                });
+            }
+        }
+        break;
+    }
+
+    case ARMY_MISSION_DEFEND_BORDER:
+    {
+        
+        if (m_pTargetPlot == NULL)
+        {
+            CheckTargetDefendPlot();
+        }
+        
+        // Leader et suiveurs vont défendre la case cible
+        if (pLeaderGroup->plot() != m_pTargetPlot)
+        {
+            pLeaderGroup->pushMission(
+                MISSION_MOVE_TO,
+                m_pTargetPlot->getX(),
+                m_pTargetPlot->getY(),
+                0,
+                false, true,
+                MISSIONAI_GUARD_BONUS,
+                m_pTargetPlot
+            );
+        }
+
+        for (std::vector<int>::iterator it = m_groupIDs.begin(); it != m_groupIDs.end(); ++it)
+        {
+            CvSelectionGroup* pGroup = GET_PLAYER(getOwner()).getSelectionGroup(*it);
+            if (pGroup == NULL)
+                continue;
+            if (pGroup->getHeadUnit() == NULL)
+            {
+                removeGroup(pGroup);
+                pGroup->kill();
+                continue;
+            }
+
+            if (pGroup->plot() != m_pTargetPlot)
+            {
+                pGroup->pushMission(
+                    MISSION_MOVE_TO,
+                    m_pTargetPlot->getX(),
+                    m_pTargetPlot->getY(),
+                    0,
+                    false, true,
+                    MISSIONAI_GUARD_BONUS,
+                    m_pTargetPlot
+                );
+            }
+        }
+        break;
+    }
+
+    default:
+        break;
+    }
+}
+
+void CvArmy::disband()
+{
+    // Detach all groups
+    for (std::vector<int>::iterator it = m_groupIDs.begin(); it != m_groupIDs.end(); ++it)
+    {
+        CvSelectionGroup* pGroup = GET_PLAYER(getOwner()).getSelectionGroup(*it);
+        if (pGroup != NULL)
+        {
+            pGroup->setArmyID(-1); // plus d’armée
+        }
+    }
+    m_groupIDs.clear();
+    m_iLeaderGroupID = NULL;
+}
+
+CvSelectionGroup* CvArmy::getGroupByIndex(int iIndex) const
+{
+    if (iIndex < 0 || iIndex >= (int)m_groupIDs.size())
+        return NULL;
+
+    return GET_PLAYER(getOwner()).getSelectionGroup(m_groupIDs[iIndex]);
+}
+
+CvSelectionGroup* CvArmy::getGroup(int iGroupID) const
+{
+    // Check if the army actually contains this group ID
+    if (std::find(m_groupIDs.begin(), m_groupIDs.end(), iGroupID) == m_groupIDs.end())
+    {
+        return NULL; // group not in this army
+    }
+
+    // Return the actual group pointer
+    return GET_PLAYER(getOwner()).getSelectionGroup(iGroupID);
+}
+
+
+CvSelectionGroup* CvArmy::getLeader() const
+{
+    return GET_PLAYER(getOwner()).getSelectionGroup(m_iLeaderGroupID);
+}
+
+void CvArmy::setLeader(CvSelectionGroup* pLeader)
+{
+    if (pLeader != NULL)
+    {
+        m_iLeaderGroupID = pLeader->getID();
+        pLeader->setArmyID(m_iID);
+    }
+    else
+    {
+        m_iLeaderGroupID = NO_INDEX;
+    }
+
+}
+
+
+void CvArmy::setLeader(int iLeaderGroupID)
+{
+    if (iLeaderGroupID == NO_INDEX)
+    {
+        m_iLeaderGroupID = NO_INDEX;
+        return;
+    }
+    // Store the ID
+    CvSelectionGroup* pLeader = GET_PLAYER(getOwner()).getSelectionGroup(iLeaderGroupID);
+    if (pLeader != NULL)
+    {
+        m_iLeaderGroupID = iLeaderGroupID;
+        setLeader(pLeader);
+    }
+
+}
+
+
+
+#endif

--- a/Sources/CvArmy.cpp
+++ b/Sources/CvArmy.cpp
@@ -357,7 +357,7 @@ void CvArmy::doTurn()
                         continue;
 
                     if (pGroup->getDomainType() != DOMAIN_LAND || pGroup->AI_getMissionAIType() == MISSIONAI_GUARD_CITY
-                        || pGroup->AI_isCityGarrison(pGroup->plot()->getPlotCity()))
+                        || pGroup->AI_isCityGarrison(pGroup->plot()->getPlotCity()))                        
                         continue;
 
                     int dist = plotDistance(pRefPlot->getX(), pRefPlot->getY(),
@@ -369,10 +369,15 @@ void CvArmy::doTurn()
                         {
                             removeGroup(pGroup);
                         }
+                        UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
+
+                        if (eUnitAi == UNITAI_PROPERTY_CONTROL || eUnitAi == UNITAI_INFILTRATOR)
+                            continue;
+
                         pLeaderUnit->AI_setUnitAIType(UNITAI_ATTACK_CITY);
                         addGroup(pGroup);
 
-                        UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
+                        //UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
                         MissionAITypes eMissionAI = pGroup->AI_getMissionAIType();
                         CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
                         CvWString MissionInfos = MissionAITypeToString(eMissionAI);
@@ -389,7 +394,7 @@ void CvArmy::doTurn()
                                 StrUnitName = pLeaderUnit->getName(0).GetCString();
                             }
 
-                            logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d is Ready forced incorporation to Attack at (%d,%d) distance %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pGroup->getNumUnits(), m_iID, m_pTargetPlot->getX(), m_pTargetPlot->getY(), dist);
+                            logBBAI("Player %d Unit ID %d, %S of Type %S, at (%d, %d), Mission %S [stack size %d], Army %d is forced incorporation to Attack at (%d,%d) distance %d...", getOwner(), pLeaderUnit->getID(), StrUnitName.GetCString(), StrunitAIType.GetCString(), pLeaderUnit->getX(), pLeaderUnit->getY(), MissionInfos.GetCString(), pGroup->getNumUnits(), m_iID, m_pTargetPlot->getX(), m_pTargetPlot->getY(), dist);
                             //logBBAI("       Attack (estim after Bomb.) : %d, AttackRatio : %d", iComparePostBombard, iAttackRatio);
                         });
                         pGroup->pushMission(MISSION_SKIP);

--- a/Sources/CvArmy.cpp
+++ b/Sources/CvArmy.cpp
@@ -196,7 +196,7 @@ CvSelectionGroup* CvArmy::findNewLeader()
         if (pLeaderUnit != NULL)
         {
             UnitAITypes eUnitAi = pLeaderUnit->AI_getUnitAIType();
-            FAssert(pGroup);
+            FAssert(pLeader);
             MissionAITypes eMissionAI = pLeader->AI_getMissionAIType();
             CvWString StrunitAIType = GC.getUnitAIInfo(eUnitAi).getType();
             CvWString MissionInfos = MissionAITypeToString(eMissionAI);

--- a/Sources/CvArmy.h
+++ b/Sources/CvArmy.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#ifndef CIV4_ARMY_H
+#define CIV4_ARMY_H
+
+#include "CvArea.h"
+#include "CvContractBroker.h"
+#include "CvGameAI.h"
+#include "CvGlobals.h"
+
+#ifdef CVARMY_BREAKSAVE
+
+class CvSelectionGroup;
+
+class CvArmy
+{
+public:
+    CvArmy();
+    ~CvArmy();
+
+    void init(int iID, PlayerTypes eOwner, int eMissionType);
+    void uninit();
+    void reset(int iID = 0, PlayerTypes eOwner = NO_PLAYER, bool bConstructorCall = false);
+
+    // Getters/Setters
+    CvSelectionGroup* getLeader() const;
+    void setLeader(CvSelectionGroup* pLeader);
+    void setLeader(int pLeaderID);
+
+    int getID() const { return m_iID; }
+    void setID(int iID) { m_iID = iID; }
+
+    PlayerTypes getOwner() const { return m_eOwner; }
+
+    int getMission() const { return m_eMission; }
+    void setMission(int eMission) { m_eMission = eMission; }
+
+    CvPlot* getTargetPlot() const { return m_pTargetPlot; }
+    void setTargetPlot(CvPlot* pPlot) { m_pTargetPlot = pPlot; }
+
+    void addGroup(CvSelectionGroup* pGroup);
+    void removeGroup(CvSelectionGroup* pGroup);
+
+    bool CheckTargetDefendPlot();
+    bool CheckTargetCity();
+    CvSelectionGroup* findNewLeader();
+    void doTurn();
+
+    void disband();
+
+    CvSelectionGroup* getGroup(int iGroupID) const;
+    CvSelectionGroup* getGroupByIndex(int iIndex) const;
+
+private:
+    int m_iID;
+    PlayerTypes m_eOwner;
+    int m_eMission;                // e.g., ARMY_MISSION_ATTACK_CITY
+    CvPlot* m_pTargetPlot;
+    int m_iLeaderGroupID;
+    std::vector<int> m_groupIDs; // Liste des IDs des groupes
+
+};
+
+#endif
+
+#endif

--- a/Sources/CvDefines.h
+++ b/Sources/CvDefines.h
@@ -7,6 +7,8 @@
 
 // The following #defines should not be moddable...
 
+#define CVARMY_BREAKSAVE
+
 #define MOVE_IGNORE_DANGER								(0x00000001)
 #define MOVE_SAFE_TERRITORY								(0x00000002)
 #define MOVE_NO_ENEMY_TERRITORY							(0x00000004)

--- a/Sources/CvEnums.h
+++ b/Sources/CvEnums.h
@@ -5,6 +5,8 @@
 
 // enums.h
 
+
+
 #include "CvDefines.h"
 
 enum GameStateTypes
@@ -1789,6 +1791,18 @@ enum MissionAITypes
 	MISSIONAI_WAIT_FOR_ESCORT,
 	MISSIONAI_WAIT_FOR_SEE_INVISIBLE
 };
+
+
+enum ArmyMissionType
+{
+	ARMY_MISSION_NONE,
+	ARMY_MISSION_ATTACK_CITY,
+	ARMY_MISSION_DEFEND_BORDER,
+	ARMY_MISSION_ESCORT,
+	ARMY_MISSION_PATROL,
+	// etc.
+};
+
 
 // any additions need to be reflected in GlobalTypes.xml
 enum CommandTypes

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -6995,7 +6995,7 @@ void CvGame::createBarbarianUnits()
 		{
 			const CvPlot* pPlot = GC.getMap().syncRandPlot((RANDPLOT_NOT_VISIBLE_TO_CIV | RANDPLOT_ADJACENT_LAND | RANDPLOT_PASSIBLE), pLoopArea->getID(), GC.getMIN_BARBARIAN_STARTING_DISTANCE());
 
-			if (pPlot == NULL)
+			if (pPlot == NULL || !pPlot->isMapCategoryType(GC.getMAPCATEGORY_EARTH()))
 				continue;
 
 			UnitTypes eBestUnit = NO_UNIT;

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -328,6 +328,7 @@ CvPlayer::~CvPlayer()
 		SAFE_DELETE(m_units[i]);
 		SAFE_DELETE(m_selectionGroups[i]);
 	}
+	//SAFE_DELETE(m_armies);
 }
 
 
@@ -345,7 +346,13 @@ void CvPlayer::baseInit(PlayerTypes eID)
 		m_cities[i]->init();
 		m_units[i]->init();
 		m_selectionGroups[i]->init();
+
 	}
+#ifdef CVARMY_BREAKSAVE
+	m_armies.init(1);
+	m_armies.setCurrentID(0);
+#endif // CVARMY_BREAKSAVE
+
 	m_eventsTriggered.init();
 	//--------------------------------
 	// Init non-saved data
@@ -709,6 +716,9 @@ void CvPlayer::uninit()
 		m_selectionGroups[i]->uninit();
 	}
 	m_eventsTriggered.uninit();
+
+	m_armies.uninit();
+
 
 	clearMessages();
 
@@ -31095,3 +31105,26 @@ int CvPlayer::getHeritageCommerceEraChange(const CommerceTypes eType, const EraT
 	}
 	return iCommerce100;
 }
+
+#ifdef CVARMY_BREAKSAVE
+
+CvArmy* CvPlayer::getArmy(int iArmyID) const
+{
+	if (iArmyID < 0)
+		return NULL;
+
+	// FFreeListTrashArray fournit getAt(id) qui retourne NULL si l'objet n'existe pas
+	return m_armies.getAt(iArmyID);
+}
+
+void CvPlayer::deleteArmy(int iArmyID)
+{
+	CvArmy* pArmy = m_armies.getAt(iArmyID);
+	if (pArmy != NULL)
+	{
+		pArmy->disband();       // nettoyer les groupes
+		m_armies.removeAt(iArmyID); // supprime l’objet de la liste
+	}
+}
+
+#endif

--- a/Sources/CvPlayer.h
+++ b/Sources/CvPlayer.h
@@ -19,6 +19,9 @@
 #include "CvUnitAI.h"
 #include "index_iterator_base.h"
 #include "LinkedList.h"
+#ifdef CVARMY_BREAKSAVE
+	#include "CvArmy.h"
+#endif
 
 class CvArea;
 class CvDiploParameters;
@@ -27,6 +30,7 @@ class CvPlot;
 class CvPopupInfo;
 class CvUnitSelectionCriteria;
 class CvUpgradeCache;
+class CvPlayerAI;
 
 #define	UNIT_BIRTHMARK_TEMP_UNIT	20000
 
@@ -1143,6 +1147,13 @@ public:
 	CvUnit* addUnit();
 	void deleteUnit(int iID);
 
+#ifdef CVARMY_BREAKSAVE
+	CvArmy* getArmy(int iArmyID) const;
+
+	void deleteArmy(int iArmyID);
+
+#endif
+
 	// selection groups iteration
 	DECLARE_INDEX_ITERATOR(const CvPlayer, CvSelectionGroup, group_iterator, firstSelectionGroup, nextSelectionGroup);
 	group_iterator beginGroups() const { return group_iterator(this); }
@@ -2006,6 +2017,10 @@ protected:
 	std::vector<FFreeListTrashArray<CvCityAI>*>			  m_cities;
 	std::vector<FFreeListTrashArray<CvUnitAI>*>			  m_units;
 	std::vector<FFreeListTrashArray<CvSelectionGroupAI>*> m_selectionGroups;
+
+#ifdef CVARMY_BREAKSAVE
+	FFreeListTrashArray<CvArmy>							  m_armies;
+#endif 
 
 	FFreeListTrashArray<EventTriggeredData> m_eventsTriggered;
 	CvEventMap m_mapEventsOccured;

--- a/Sources/CvPlayerAI.h
+++ b/Sources/CvPlayerAI.h
@@ -15,6 +15,7 @@ class CvCity;
 class CvEventTriggerInfo;
 class CvSelectionGroup;
 class CvUnitSelectionCriteria;
+class CvArmy;
 
 /**
  * Stores information about a mission target for AI planning.
@@ -490,6 +491,9 @@ public:
 	int AI_getUnitWeight(UnitTypes eUnit) const;
 	int AI_getUnitCombatWeight(UnitCombatTypes eUnitCombat) const;
 
+#ifdef CVARMY_BREAKSAVE
+	void AI_formArmies();   // Nouvelle fonction de création des armées
+#endif
 
 	/**
 	 * \brief Calculate the relative viability of a unit type for a given AI role.
@@ -703,6 +707,7 @@ protected:
 
 	bool m_bWasFinancialTrouble;
 	int m_iTurnLastProductionDirty;
+
 
 	void AI_doCounter();
 	void AI_doMilitary();

--- a/Sources/CvSelectionGroup.cpp
+++ b/Sources/CvSelectionGroup.cpp
@@ -104,6 +104,8 @@ void CvSelectionGroup::reset(int iID, PlayerTypes eOwner, bool bConstructorCall)
 	m_bLastPlotVisible = false;
 	m_bLastPlotRevealed = false;
 
+	m_iArmyID = -1;
+
 	if (!bConstructorCall)
 	{
 		AI_reset();
@@ -513,6 +515,9 @@ bool CvSelectionGroup::pushMissionInternal(MissionTypes eMission, int iData1, in
 		}
 		clearMissionQueue();
 	}
+
+	if (getHeadUnit() == NULL)
+		return false;
 
 	if (bManual)
 	{

--- a/Sources/CvSelectionGroup.h
+++ b/Sources/CvSelectionGroup.h
@@ -109,6 +109,9 @@ public:
 	bool hasCargo() const;
 	int getCargo(bool bVolume = false) const;
 
+	int getArmyID() const { return m_iArmyID; }
+	void setArmyID(int iArmyID) { m_iArmyID = iArmyID; }
+
 	bool canAllSelectedMove() const;
 	DllExport bool canAllMove() const;
 	DllExport bool canMoveInto(CvPlot* pPlot, bool bAttack = false);
@@ -440,6 +443,7 @@ private:
 	static const CvSelectionGroup* m_pCachedMovementGroup;
 	static bst::scoped_ptr<CachedPathGenerator> m_cachedPathGenerator;
 	static CachedPathGenerator& getCachedPathGenerator();
+	int m_iArmyID;
 
 public:
 	static void setGroupToCacheFor(CvSelectionGroup* group);


### PR DESCRIPTION
Experimental Army Concept : 
- An army is created when a stack reach at least 6 members. It will try to enroll all others Attack and Attack City stacks in the Area, and all the idle units that can reach the Army's Leader. They will have all the same target.
- If a Unit belong to an army, the targetplot is automatically the target of the army
- It handles when Army leader is killed, when the forces are not enough, the army is disbanded.
- Add the need of a healer in a Attack_City Stack = will provide Job offer in broker to have one.
- an Attack_City Stak will need at least 2 Capture City units (hired via broker)
- If the stack ends in a city, eject a defender in that city.
- Add ArmyID in SelectionGroup
- Add in PlayerAI the Ability to form armies, and a specifid Do_turn() before the units movements.