### PR TITLE
Patch

### DIFF
--- a/Assets/Python/CvDiplomacy.py
+++ b/Assets/Python/CvDiplomacy.py
@@ -442,7 +442,7 @@ class CvDiplomacy:
 				elif bUsSuperior and not diploInfo.getDiplomacyPowerTypes(i, DiplomacyPowerTypes.DIPLOMACYPOWER_WEAKER):
 					continue
 
-				elif diploInfo.getDiplomacyPowerTypes(i, DiplomacyPowerTypes.DIPLOMACYPOWER_EQUAL):
+				elif not diploInfo.getDiplomacyPowerTypes(i, DiplomacyPowerTypes.DIPLOMACYPOWER_EQUAL):
 					continue
 
 			# passed all tests, so add to response list

--- a/Assets/Python/CvGameUtils.py
+++ b/Assets/Python/CvGameUtils.py
@@ -80,7 +80,6 @@ class CvGameUtils:
 					iTech = GC.getProcessInfo(iProcess).getTechPrereq()
 					if iTech == -1 or CyTeam.isHasTech(iTech):
 						return True
-					return False
 			elif PROCESS == TYPE:
 				bFound = True
 		return False

--- a/Assets/Python/CvMapGeneratorUtil.py
+++ b/Assets/Python/CvMapGeneratorUtil.py
@@ -95,7 +95,7 @@ class FractalWorld:
 
 	def findBestSplitY(self, stripRadius):
 		stripSize = 2*stripRadius
-		if stripSize > self.iNumPlotsX:
+		if stripSize > self.iNumPlotsY:
 			return 0
 
 		numPlots = self.iNumPlotsX * self.iNumPlotsY
@@ -640,7 +640,7 @@ class MultilayeredFractal:
 	def shiftRegionPlots(self, iRegionWidth, iRegionHeight, iStrip=15):
 		# Minimizes land plots along the region's edges by shifting the coordinates.
 		stripRadius = min(15, iStrip)
-		stripRadius = max(3, iStrip)
+		stripRadius = max(3, stripRadius)
 		best_split_x, best_split_y = 0,0
 		best_split_x = self.findBestRegionSplitX(iRegionWidth, iRegionHeight, stripRadius)
 		best_split_y = self.findBestRegionSplitY(iRegionWidth, iRegionHeight, stripRadius)
@@ -663,7 +663,7 @@ class MultilayeredFractal:
 
 	def findBestRegionSplitY(self, iRegionWidth, iRegionHeight, stripRadius):
 		stripSize = 2*stripRadius
-		if stripSize > iRegionWidth:
+		if stripSize > iRegionHeight:
 			return 0
 
 		numPlots = iRegionWidth * iRegionHeight

--- a/Assets/Python/Revolution/RevEvents.py
+++ b/Assets/Python/Revolution/RevEvents.py
@@ -1043,12 +1043,14 @@ def assimilateHandler(iPlayerID, netUserData, popupReturn):
 			if LOG_DEBUG:
 				print "[REV] Rebel motherland %s extra attidude to %s now %d"%(pMotherland.getCivilizationDescription(0), GC.getPlayer(netUserData[1]).getCivilizationDescription(0), pMotherland.AI_getAttitudeExtra(netUserData[0]))
 
-			[iOdds, attackerTeam, victimTeam] = RevUtils.computeWarOdds(pMotherland, GC.getPlayer(netUserData[1]), GC.getPlayer(netUserData[0]).getCapitalCity().area(), False, True, True)
+			pRebelCapital = GC.getPlayer(netUserData[0]).getCapitalCity()
+			if not pRebelCapital.isNone():
+				[iOdds, attackerTeam, victimTeam] = RevUtils.computeWarOdds(pMotherland, GC.getPlayer(netUserData[1]), pRebelCapital.area(), False, True, True)
 
-			if attackerTeam.canDeclareWar(victimTeam.getID()) and iOdds > GAME.getSorenRandNum(100, 'Revolution: War'):
-				if LOG_DEBUG:
-					print "[REV] Rebel motherland takes exception, team %d declare war on team %d"%(attackerTeam.getID(), victimTeam.getID())
-				attackerTeam.declareWar( victimTeam.getID(), True, WarPlanTypes.NO_WARPLAN )
+				if attackerTeam.canDeclareWar(victimTeam.getID()) and iOdds > GAME.getSorenRandNum(100, 'Revolution: War'):
+					if LOG_DEBUG:
+						print "[REV] Rebel motherland takes exception, team %d declare war on team %d"%(attackerTeam.getID(), victimTeam.getID())
+					attackerTeam.declareWar( victimTeam.getID(), True, WarPlanTypes.NO_WARPLAN )
 
 		GC.getPlayer(netUserData[1]).assimilatePlayer(netUserData[0])
 	elif popupReturn.getButtonClicked() == 1:

--- a/Assets/Python/Screens/Advisors/CvDomesticAdvisor.py
+++ b/Assets/Python/Screens/Advisors/CvDomesticAdvisor.py
@@ -736,8 +736,10 @@ class CvDomesticAdvisor:
 		return self.objectNotPossible
 
 	def calculatePotentialConscriptUnit(self, city, szKey, arg):
-		szReturn = unicode(GC.getUnitInfo(city.getConscriptUnit()).getDescription() )
-		return szReturn
+		iUnit = city.getConscriptUnit()
+		if iUnit == -1:
+			return u""
+		return unicode(GC.getUnitInfo(iUnit).getDescription())
 
 	def calculateConscriptUnit(self, city, szKey, arg):
 		if city.canConscript():

--- a/Sources/CvCity.cpp
+++ b/Sources/CvCity.cpp
@@ -4350,7 +4350,7 @@ void CvCity::conscript(bool bOnCapture)
 	{
 		return;
 	}
-	const int iNumConscripts = -getConscriptPopulation();
+	const int iNumConscripts = getConscriptPopulation();
 	const int iAngerLength = flatConscriptAngerLength();
 	changePopulation(-1);
 	changeConscriptAngerTimer(iAngerLength);
@@ -5247,8 +5247,6 @@ void CvCity::processSpecialist(SpecialistTypes eSpecialist, int iChange)
 		changeExtraYield((YieldTypes)iI, (GC.getSpecialistInfo(eSpecialist).getYieldChange(iI) + GET_PLAYER(getOwner()).getSpecialistYieldPercentChanges(eSpecialist, (YieldTypes)iI) / 100) * iChange);
 	}
 
-	int iCommerceChangeTotal = 0;
-	int iCommerceChangeModifierTotal = 0;
 	for (int iI = 0; iI < NUM_COMMERCE_TYPES; iI++)
 	{
 		//changeSpecialistCommerce(((CommerceTypes)iI), (GC.getSpecialistInfo(eSpecialist).getCommerceChange(iI) * iChange));
@@ -5260,8 +5258,8 @@ void CvCity::processSpecialist(SpecialistTypes eSpecialist, int iChange)
 		//every time an adjustment to SpecialistCommercePercentChanges takes place.  That would be the patient and correct way to address this.
 		if (GC.getSpecialistInfo(eSpecialist).getCommerceChange(iI) != 0)
 		{
-			iCommerceChangeTotal += (100 * GC.getSpecialistInfo(eSpecialist).getCommerceChange(iI));
-			iCommerceChangeModifierTotal += (iCommerceChangeTotal * GET_PLAYER(getOwner()).getSpecialistCommercePercentChanges(eSpecialist, (CommerceTypes)iI)) / 100;
+			int iCommerceChangeTotal = (100 * GC.getSpecialistInfo(eSpecialist).getCommerceChange(iI));
+            int iCommerceChangeModifierTotal = (iCommerceChangeTotal * GET_PLAYER(getOwner()).getSpecialistCommercePercentChanges(eSpecialist, (CommerceTypes)iI)) / 100;
 			iCommerceChangeTotal += iCommerceChangeModifierTotal;
 			changeSpecialistCommerceTimes100(((CommerceTypes)iI), iCommerceChangeTotal * iChange);
 		}
@@ -8840,8 +8838,8 @@ int CvCity::getAdditionalHealthByCivic(CivicTypes eCivic, int& iGood, int& iBad,
 
 		int iTempGood = 0; int iTempBad = 0; int iTempBadBuilding = 0;
 		int iHealthOld = getAdditionalHealthByCivic(GET_PLAYER(getOwner()).getCivics((CivicOptionTypes)(GC.getCivicInfo(eCivic).getCivicOptionType())), iTempGood, iTempBad, iTempBadBuilding, false, iExtraPop, bCivicOptionVacuum, iIgnoreNoUnhealthyPopulationCount, iIgnoreBuildingOnlyHealthyCount);
-		iGood += iTempBad;
-		iBad += iTempGood;
+		iGood -= iTempGood;
+		iBad -= iTempBad;
 		iBadBuilding -= iTempBadBuilding; //can become negative
 
 		return iHealthNew - iHealthOld;
@@ -10365,7 +10363,7 @@ int CvCity::getCultureUpdateTimer() const
 void CvCity::setCultureUpdateTimer(int iNewValue)
 {
 	m_iCultureUpdateTimer = iNewValue;
-	FASSERT_NOT_NEGATIVE(getOccupationTimer());
+	FASSERT_NOT_NEGATIVE(getCultureUpdateTimer());
 }
 
 
@@ -11001,6 +10999,8 @@ int CvCity::getAdditionalExtraYieldByBuilding(YieldTypes eIndex, BuildingTypes e
 {
 	PROFILE_EXTRA_FUNC();
 	const CvBuildingInfo& building = GC.getBuildingInfo(eBuilding);
+	const int iMaxTradeRoutes = getMaxTradeRoutes();
+	const int extra = building.getGlobalTradeRoutes() + building.getCoastalTradeRoutes() + building.getTradeRoutes();
 
 	int iExtraYield = getBaseYieldRateFromBuilding100(eIndex, eBuilding) / 100;
 
@@ -11018,7 +11018,7 @@ int CvCity::getAdditionalExtraYieldByBuilding(YieldTypes eIndex, BuildingTypes e
 #endif
 		// BUG - Fractional Trade Routes - end
 
-		for (int iI = 0; iI < getTradeRoutes(); ++iI)
+		for (int iI = 0; iI < std::min(getTradeRoutes() + extra, iMaxTradeRoutes); iI++)
 		{
 			const CvCity* pCity = getTradeCity(iI);
 			if (pCity)
@@ -21689,9 +21689,11 @@ int64_t CvCity::calcCorporateMaintenance() const
 		{
 			const CorporationTypes eCorporation = (CorporationTypes)iI;
 
+			int64_t iCorpTaxes = 0;
+
 			for (int iCommerce = 0; iCommerce < NUM_COMMERCE_TYPES; ++iCommerce)
 			{
-				iTaxes += 100 * GC.getCorporationInfo(eCorporation).getHeadquarterCommerce(iCommerce);
+				iCorpTaxes += 100 * GC.getCorporationInfo(eCorporation).getHeadquarterCommerce(iCommerce);
 			}
 
 			int iNumBonuses = 0;
@@ -21700,7 +21702,7 @@ int64_t CvCity::calcCorporateMaintenance() const
 				iNumBonuses += getNumBonuses(eBonus);
 			}
 
-			iTaxes +=
+			iCorpTaxes +=
 			(
 				GC.getCorporationInfo(eCorporation).getMaintenance() * iNumBonuses *
 				GC.getWorldInfo(GC.getMap().getWorldSize()).getCorporationMaintenancePercent()
@@ -21710,13 +21712,14 @@ int64_t CvCity::calcCorporateMaintenance() const
 
 			if (iAveragePopulation > 0)
 			{
-				iTaxes *= getPopulation();
-				iTaxes /= iAveragePopulation;
+				iCorpTaxes *= getPopulation();
+				iCorpTaxes /= iAveragePopulation;
 			}
-			iTaxes = getModifiedIntValue64(iTaxes, GET_PLAYER(getOwner()).getCorporationMaintenanceModifier() + GET_TEAM(getTeam()).getCorporationMaintenanceModifier());
+			iCorpTaxes = getModifiedIntValue64(iCorpTaxes, GET_PLAYER(getOwner()).getCorporationMaintenanceModifier() + GET_TEAM(getTeam()).getCorporationMaintenanceModifier());
 
-			iTaxes *= GC.getHandicapInfo(getHandicapType()).getCorporationMaintenancePercent();
-			iTaxes /= 100;
+			iCorpTaxes *= GC.getHandicapInfo(getHandicapType()).getCorporationMaintenancePercent();
+			iCorpTaxes /= 100;
+			iTaxes += iCorpTaxes;
 		}
 	}
 	FASSERT_NOT_NEGATIVE(iTaxes);
@@ -21950,19 +21953,13 @@ void CvCity::removeWorstCitizenActualEffects(int iNumCitizens, int& iGreatPeople
 	int iNumRemoved = 0;
 	int iNumSpecialistsRemoved = 0;
 
-	// if we are using more specialists than the free ones we get
-	while (getAssignedSpecialistCount() < iNumRemoved && iNumRemoved < iNumCitizens)
-	{
-		// Does generic 'citizen' specialist exist?
-		if (iGenericSpecialist != NO_SPECIALIST
-		// Do we have at least one more generic citizen than we are forcing?
-		&& getSpecialistCount((SpecialistTypes)iGenericSpecialist) > getForceSpecialistCount((SpecialistTypes)iGenericSpecialist))
-		{
-			paeRemovedSpecailists[iNumRemoved] = (SpecialistTypes)(iGenericSpecialist);
-			iNumRemoved++;
-			iNumSpecialistsRemoved++;
-		}
-	}
+	// A generic-citizen fast-removal loop used to live here; its guard
+    // (getAssignedSpecialistCount() < iNumRemoved, with iNumRemoved starting at 0)
+    // was always false, so it never executed. Removed as dead code (#64) - the
+    // valuation loop below already performs all removals. Reviving the optimisation
+    // would need the available generic-citizen count to decrement per iteration,
+    // otherwise the corrected condition loops forever.
+
 	bool bAvoidGrowth = false;
 	bool bIgnoreGrowth = false;
 
@@ -22757,7 +22754,7 @@ void unitHasSources(const CvPropertyManipulators* pMani, bool* bHasSources)
 static bool unitHasCityOrPlotPropertySources(const CvUnit* pUnit)
 {
 	PROFILE_EXTRA_FUNC();
-	bool bHasSources;
+	bool bHasSources = false;
 
 	pUnit->getGameObject()->foreachManipulator(bind(unitHasSources, _1, &bHasSources));
 

--- a/Sources/CvCityAI.cpp
+++ b/Sources/CvCityAI.cpp
@@ -1400,7 +1400,7 @@ void CvCityAI::AI_chooseProduction()
 						//int iBestAirValue = player.AI_bestCityUnitAIValue(UNITAI_ATTACK_AIR, this, &eBestAttackAircraft);
 
 						int iAircraftHave = player.AI_getNumAIUnits(UNITAI_ATTACK_AIR) + player.AI_getNumAIUnits(UNITAI_DEFENSE_AIR) + player.AI_getNumAIUnits(UNITAI_MISSILE_AIR);
-						int iAircraftNeed = (2 + player.getNumCities() * (3 * GC.getUnitInfo(eBestAttackAircraft).getAirCombat())) / (2 * std::max(1, GC.getGame().getBestLandUnitCombat()));
+						int iAircraftNeed = (2 + player.getNumCities() * (3 * (eBestAttackAircraft != NO_UNIT ? GC.getUnitInfo(eBestAttackAircraft).getAirCombat() : 0))) / (2 * std::max(1, GC.getGame().getBestLandUnitCombat()));
 
 						UnitTypeWeightArray airUnitTypes;
 						airUnitTypes.push_back(std::make_pair(UNITAI_ATTACK_AIR, 60));
@@ -2169,9 +2169,19 @@ void CvCityAI::AI_chooseProduction()
 	//#23 Minimal attack force because of Danger, both land and sea
 	if (bDanger && !bInhibitUnits)
 	{
-		const int iAttackNeeded = iNbMinimalAttackers + std::max(0, AI_neededDefenders() - (iPlotCityDefenderCount + iPlotOtherCityAICount)) + intSqrt(player.getNumCities()); //Try to add some attack units at minimum
-		const int iOwnedAttackers = player.AI_totalAreaUnitAIs(pArea, UNITAI_ATTACK);
-		LOG_BBAI_CITY(2, ("#23 City %S, Will Start to build mini Attack forces, due to Danger. For the moment : Owned : %d, Needed : %d", getName().GetCString(), iOwnedAttackers, iAttackNeeded));
+		const int iDefShortfall = std::max(0, AI_neededDefenders() - (iPlotCityDefenderCount + iPlotOtherCityAICount));
+        const int iSqrtCities = intSqrt(player.getNumCities());
+        const int iAttackNeeded = iNbMinimalAttackers + iDefShortfall + iSqrtCities; //Try to add some attack units at minimum
+        const int iOwnedAttackers = player.AI_totalAreaUnitAIs(pArea, UNITAI_ATTACK);
+
+        // [CIT/danger] -- inputs to the dominant "minimal attack (danger)" production driver.
+        // fire=1 means this city trains a UNITAI_ATTACK unit this pass. The gate compares an
+        // AREA-wide UNITAI_ATTACK count (ownedAtk) against a PER-CITY need; if ownedAtk stays
+        // stuck below need while many cities keep firing, the trained units are being reassigned
+        // out of UNITAI_ATTACK (the role count never catches up) -> perpetual cheap-military spam.
+//         logCityAI(2, "[CIT/danger] city=%S owner=%d minAtk=%d defShortfall=%d sqrtCities=%d need=%d ownedAtk=%d fire=%d",
+//             getName().GetCString(), (int)eOwner, iNbMinimalAttackers, iDefShortfall, iSqrtCities,
+//             iAttackNeeded, iOwnedAttackers, (iOwnedAttackers < iAttackNeeded) ? 1 : 0); UNCOM
 		
 		if (iOwnedAttackers < iAttackNeeded
 		&& AI_chooseUnitImmediate("minimal attack (danger)", UNITAI_ATTACK))
@@ -4510,7 +4520,7 @@ bool CvCityAI::AI_scoreBuildingsFromListThreshold(std::vector<ScoredBuilding>& s
 				{
 					// Add value of the free building taking into account our focus, and scale it by the number of cities that don't
 					// yet have the building.
-					iValue += (AI_buildingValue(eFreeBuilding, iFocusFlags) * (player.getNumCities() - player.getBuildingCountPlusMaking(eBuilding)));
+					iValue += (AI_buildingValue(eFreeBuilding, iFocusFlags) * (player.getNumCities() - player.getBuildingCountPlusMaking(eFreeBuilding)));
 				}
 
 				LOG_CITY_BLOCK(3, {
@@ -9123,9 +9133,9 @@ bool CvCityAI::AI_chooseBuilding(int iFocusFlags, int iMaxTurns, int iMinThresho
 		CvPlayer& player = GET_PLAYER(getOwner());
 		if (nbBuildings > (NB_MAX_BUILDINGS + player.getCurrentEra() / 2))
 		{
-			LOG_BBAI_CITY(3, ("Player %d, city: %S, too many building already ordered (nb buildings = %d, nb desired turns = %d, Std = %d)", getOwner(), getName().GetCString(), nbBuildings, desiredQueueTurns, stdDesiredQueueTurns));
+			break;
 		}
-		break;
+
 
 	}
 #ifdef USE_UNIT_TENDERING
@@ -10791,7 +10801,7 @@ int CvCityAI::AI_calculateCulturePressure(bool bGreatWork) const
 					iTempValue *= 2;
 					if (bGreatWork && GET_PLAYER(getOwner()).AI_getAttitude(pLoopPlot->getOwner()) == ATTITUDE_FRIENDLY)
 					{
-						iValue /= 10;
+						iTempValue /= 10;
 					}
 				}
 				else if (bGreatWork)
@@ -14740,15 +14750,8 @@ bool CvCityAI::AI_choosePropertyControlBuildingAndUnit(int iTriggerPercentOfProp
 				iEval /= iCheck;
 				iCheck *= iTrainReluctance;
 				//TBNote: May still need to take a count of units ordered... there's only so many units the AI should be willing to train at once for some tasks.  I'm thinking of polution control here.
-				//	Don't bother trying to build units for hopelessly out-of-control properties
-				//	or else we'll spam units endlessly in cases we cannot really control
-				int iLimit = 250 * ((1 + (int)player.getCurrentEra())/5);
 				int iAcceptanceLimit = 100 * ((1 + (int)player.getCurrentEra())/2); //Acceptable Value 
 				int iAcceptanceRate = iCurrentValue/100 * 5; //Accept a 5% rate increase
-				if (iTrainReluctance > 0)
-				{
-					iLimit /= iTrainReluctance;
-				}
 
 				//Calvitix : Evaluate the future evolution of the property, with actuel change, and estimate the number of turn to achieve goal 
 				#define MIN_PROPERTY_TOTAL_TO_DEAL_WITH  -1000
@@ -14791,7 +14794,7 @@ bool CvCityAI::AI_choosePropertyControlBuildingAndUnit(int iTriggerPercentOfProp
 					logAiEvaluations(3, "City %S, step %d %%, worried about property %S. But Maximal Prop Control reached :  value(%d) / total units (%d)", getName().GetCString(), iTriggerPercentOfPropertyOpRange, szProperty.GetCString(), iPropControlInArea, iUnitsInArea);
 				}
 
-				if (iEval > iCheck && iCurrentPercent < iLimit && !isGettingBetter && !isGoodEnough && !ismaxPropUnitsReached)
+				if (iEval > iCheck && !isGettingBetter && !isGoodEnough && !ismaxPropUnitsReached)
 				{
 					//	Order a suitable unit if possible
 					CvUnitSelectionCriteria criteria;

--- a/Sources/CvDeal.cpp
+++ b/Sources/CvDeal.cpp
@@ -520,7 +520,7 @@ bool CvDeal::isUncancelableVassalDeal(PlayerTypes eByPlayer, CvWString* pszReaso
 				if (pszReason)
 				{
 					CvWStringBuffer szBuffer;
-					GAMETEXT.setVassalRevoltHelp(szBuffer, eMaster, GET_PLAYER(getFirstPlayer()).getTeam());
+					GAMETEXT.setVassalRevoltHelp(szBuffer, eMaster, GET_PLAYER(getSecondPlayer()).getTeam());
 					*pszReason = szBuffer.getCString();
 				}
 				return true;

--- a/Sources/CvGame.cpp
+++ b/Sources/CvGame.cpp
@@ -4644,7 +4644,16 @@ void CvGame::setHandicapType(HandicapTypes eHandicap)
 				{
 					for (int j = 0; j < MAX_PLAYERS; j++)
 					{
-						GET_PLAYER((PlayerTypes)j).setUnitExtraCost((UnitTypes)i, GET_PLAYER((PlayerTypes)j).getNewCityProductionValue());
+						// Skip empty/leaderless player slots: getNewCityProductionValue() ->
+                        // getProductionModifier() -> hasTrait() asserts (getLeaderType() >= 0) for
+                        // unused slots, and dead/never-used players have no city production to cost.
+                        // On a mature-game load (averageHandicaps -> setHandicapType) the unguarded
+                        // loop fired this assert hundreds of times, bloating Asserts.log to ~hundreds
+                        // of MB and stalling the load on Assert builds.
+                        if (GET_PLAYER((PlayerTypes)j).isAlive())
+                        {
+                            GET_PLAYER((PlayerTypes)j).setUnitExtraCost((UnitTypes)i, GET_PLAYER((PlayerTypes)j).getNewCityProductionValue());
+                        }
 					}
 				}
 			}
@@ -4897,7 +4906,7 @@ TeamTypes CvGame::getRankTeam(int iRank) const
 
 void CvGame::setRankTeam(int iRank, TeamTypes eTeam)
 {
-	FASSERT_BOUNDS(0, MAX_TEAMS, eTeam);
+	FASSERT_BOUNDS(0, MAX_TEAMS, iRank);
 
 	if (getRankTeam(iRank) != eTeam)
 	{
@@ -6666,7 +6675,7 @@ void CvGame::doHeadquarters()
 
 							for (int iK = 0; iK < GC.getNumCorporationInfos(); iK++)
 							{
-								iValue += GET_PLAYER((PlayerTypes)iJ).getHasCorporationCount((CorporationTypes)iK) * 20;
+								iValue += GET_PLAYER(kLoopTeam.getLeaderID()).getHasCorporationCount((CorporationTypes)iK) * 20;
 							}
 
 							if (iValue < iBestValue)
@@ -8303,6 +8312,13 @@ void CvGame::read(FDataStreamBase* pStream)
 	WRAPPER_READ(wrapper,"CvGame",&m_bDiploVictoryEnabled);
 	WRAPPER_READ_ARRAY(wrapper,"CvGame",MAX_PLAYERS, m_aiFlexibleDifficultyTimer);
 
+	// Modder game options (BUG menu / ModderGameOptionTypes). These were previously not saved and
+    // relied on Python re-pushing them from the BUG ini on load; that left them at 0 for any consumer
+    // that runs during load/first-turn (e.g. the leader trait-promotion threshold), which read the
+    // 0 fallback instead of the player's chosen value (#156). Tag-based wrapper: absent in old saves,
+    // in which case the array keeps its reset default of 0 and the Python push still fills it.
+    WRAPPER_READ_ARRAY(wrapper,"CvGame",NUM_MODDERGAMEOPTION_TYPES, m_aiModderGameOption);
+
 	// Super forts adaptation to C2C - has this game state had its choke points calculated?
 	WRAPPER_READ(wrapper,"CvGame", &m_iChokePointCalculationVersion);
 
@@ -8601,6 +8617,10 @@ void CvGame::write(FDataStreamBase* pStream)
 	WRAPPER_WRITE(wrapper, "CvGame", m_iMercyRuleCounter);
 	WRAPPER_WRITE(wrapper, "CvGame", m_bDiploVictoryEnabled);
 	WRAPPER_WRITE_ARRAY(wrapper, "CvGame", MAX_PLAYERS, m_aiFlexibleDifficultyTimer);
+
+	// Modder game options (BUG menu / ModderGameOptionTypes) - persist so the value is authoritative
+    // on load instead of relying on a Python re-push that may land after first-turn consumers. See read().
+    WRAPPER_WRITE_ARRAY(wrapper, "CvGame", NUM_MODDERGAMEOPTION_TYPES, m_aiModderGameOption);
 
 	// Super forts adaptation to C2C - has this game state had its choke points calculated?
 	WRAPPER_WRITE(wrapper,"CvGame", m_iChokePointCalculationVersion);
@@ -9360,7 +9380,7 @@ void CvGame::doVoteResults()
 					szBuffer += NEWLINE + gDLL->getText("TXT_KEY_POPUP_DIPLOMATIC_VOTING_VICTORY", GET_TEAM(eTeam).getName().GetCString(), countVote(*pVoteTriggered, (PlayerVoteTypes)eTeam), getVoteRequired(eVote, eVoteSource), countPossibleVote(eVote, eVoteSource));
 				}
 
-				for (int iI = MAX_PC_TEAMS; iI >= 0; --iI)
+				for (int iI = MAX_PC_TEAMS -1; iI >= 0; --iI)
 				{
 					for (int iJ = 0; iJ < MAX_PC_PLAYERS; iJ++)
 					{
@@ -10060,7 +10080,11 @@ void CvGame::doFlexibleDifficulty()
 			int stddevHandi = static_cast<int>((stddev * (basicMaxCap/diff*100))/100);
 			int handicapBias = static_cast<int>(stddevHandi*((multiplier*playerX.getHandicapType())-(multiplier*default_difficult)));
 
-			double normalized = 1.80*((double)(iCurrentScore-iLowestScore)/(double)(iBestScore-iLowestScore))-0.90;
+			const double scoreRange = (double)(iBestScore - iLowestScore);
+            double normalized = (scoreRange != 0.0) ? 1.80*((double)(iCurrentScore-iLowestScore)/scoreRange)-0.90 : 0.0;
+            // Keep normalized strictly inside (-1, 1) so the atanh logs stay finite (avoid log(0) at the extremes).
+            if (normalized > 0.999) { normalized = 0.999; }
+            else if (normalized < -0.999) { normalized = -0.999; }
 			double atanh2 = 2.0 * (std::log(1.0+normalized) - std::log(1.0-normalized))/2.0;
 
 			int increase1 = 100*(iCurrentScore+((int)((double)iCurrentScore*atanh2)))-handicapBias;
@@ -11640,7 +11664,7 @@ int CvGame::getTopPopCount() const
 
 int CvGame::getWinForLosingResearchModifier(const int iCities, const int iPop) const
 {
-	return 100 - (100 * iCities / getTopCityCount() + 100 * iPop / getTopPopCount()) / 2;
+	return 100 - (100 * iCities / std::max(1, getTopCityCount()) + 100 * iPop / std::max(1, getTopPopCount())) / 2;
 }
 
 

--- a/Sources/CvMap.cpp
+++ b/Sources/CvMap.cpp
@@ -250,11 +250,15 @@ void CvMap::reset(CvMapInitData* pInitInfo)
 			m_iGridWidth = GC.getMapInfo(getType()).getGridWidth();
 			m_iGridHeight = GC.getMapInfo(getType()).getGridHeight();
 		}
-		if (GC.getMapInfo(getType()).getWrapX() > 0 && GC.getMapInfo(getType()).getWrapY() > 0)
-		{
-			m_bWrapX = GC.getMapInfo(getType()).getWrapX();
-			m_bWrapY = GC.getMapInfo(getType()).getWrapY();
-		}
+		// X-wrap and Y-wrap are independent (e.g. a cylinder is wrapX=1, wrapY=0), so set each on its own.
+        if (GC.getMapInfo(getType()).getWrapX() > 0)
+        {
+            m_bWrapX = true;
+        }
+        if (GC.getMapInfo(getType()).getWrapY() > 0)
+        {
+            m_bWrapY = true;
+        }
 	}
 /*******************************/
 /***** Parallel Maps - End *****/

--- a/Sources/CvPlayer.cpp
+++ b/Sources/CvPlayer.cpp
@@ -2674,7 +2674,7 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 
 				for (int iJ = 0; iJ < MAX_PC_PLAYERS; iJ++)
 				{
-					if (GET_PLAYER((PlayerTypes)iJ).isAlive() && GET_PLAYER((PlayerTypes)iI).getStateReligion() == (ReligionTypes)iI)
+					if (GET_PLAYER((PlayerTypes)iJ).isAlive() && GET_PLAYER((PlayerTypes)iJ).getStateReligion() == (ReligionTypes)iI)
 					{
 						AI_invalidateAttitudeCache((PlayerTypes)iJ);
 						GET_PLAYER((PlayerTypes)iJ).AI_invalidateAttitudeCache(eNewOwner);
@@ -2720,8 +2720,10 @@ void CvPlayer::acquireCity(CvCity* pOldCity, bool bConquest, bool bTrade, bool b
 
 				iOccupationTime *= GC.getGameSpeedInfo(GC.getGame().getGameSpeedType()).getSpeedPercent(); // Extra 100x
 
-				// Normalize: Full timer at 0 culture, no timer when culture == occupation threshold.
-				iOccupationTime *= 1000 - 1000 * iTeamCulturePercent / GC.getDefineINT("OCCUPATION_CULTURE_PERCENT_THRESHOLD"); // Extra 1000x
+				// Normalize: timer at 0 culture, no timer when culture == occupation threshold.
+                // Culture factor scale cut from 1000 to 200 so conquest occupation is ~1/5 as long (#153).
+                // Interim calibration; the conquest-anarchy mechanic may be reworked later.
+                iOccupationTime *= 200 - 200 * iTeamCulturePercent / GC.getDefineINT("OCCUPATION_CULTURE_PERCENT_THRESHOLD"); // Extra 200x (was 1000x)
 
 				iOccupationTime = getModifiedIntValue(iOccupationTime, iOccupationTimeModifier);
 
@@ -7322,7 +7324,9 @@ int CvPlayer::getProductionNeeded(ProjectTypes eProject) const
 	iProductionNeeded *= GC.getGameSpeedInfo(GC.getGame().getGameSpeedType()).getHammerCostPercent();
 
 	const EraTypes eEra = getCurrentEra();
-	int iModifier = 0;
+	// Fall back to the current era's create percent when the project has no tech prereq;
+    // otherwise iModifier stayed 0 and zeroed the whole cost (project became ~free).
+    int iModifier = GC.getEraInfo(eEra).getCreatePercent();
 	if (GC.getProjectInfo(eProject).getTechPrereq() != NO_TECH)
     {
         iModifier = GC.getEraInfo((EraTypes)GC.getTechInfo(GC.getProjectInfo(eProject).getTechPrereq()).getEra()).getCreatePercent();
@@ -7571,7 +7575,7 @@ void CvPlayer::processBuilding(BuildingTypes eBuilding, int iChange, CvArea* pAr
 		{
 			for (int iI = 0; iI < MAX_PC_PLAYERS; iI++)
 			{
-				changeTradeRoutes(iWorldTradeRoute);
+				GET_PLAYER((PlayerTypes)iI).changeTradeRoutes(iWorldTradeRoute);
 			}
 		}
 	}
@@ -8620,11 +8624,18 @@ bool CvPlayer::canDoCivics(CivicTypes eCivic) const
 	}
 
 	if (!isNPC()
-	&& GC.getCivicInfo(eCivic).getCityLimit(getID()) > 0
-	&& GC.getCivicInfo(eCivic).getCityOverLimitUnhappy() == 0
-	&& GC.getCivicInfo(eCivic).getCityLimit(getID()) < getNumCities()
-	|| !isHasCivicOption((CivicOptionTypes)GC.getCivicInfo(eCivic).getCivicOptionType())
-	&& !GET_TEAM(getTeam()).isHasTech(GC.getCivicInfo(eCivic).getTechPrereq()))
+    && (
+        (
+            GC.getCivicInfo(eCivic).getCityLimit(getID()) > 0
+            && GC.getCivicInfo(eCivic).getCityOverLimitUnhappy() == 0
+            && GC.getCivicInfo(eCivic).getCityLimit(getID()) < getNumCities()
+        )
+        ||
+        (
+            !isHasCivicOption((CivicOptionTypes)GC.getCivicInfo(eCivic).getCivicOptionType())
+            && !GET_TEAM(getTeam()).isHasTech(GC.getCivicInfo(eCivic).getTechPrereq())
+        )
+    ))
 	{
 		return false;
 	}
@@ -13830,12 +13841,10 @@ bool CvPlayer::isUnitMaxedOut(const UnitTypes eIndex, const int iExtra) const
 	{
 		return false;
 	}
-	/* Toffer: FAssertMsg(GC.getUnitInfo(eIndex).getMaxPlayerInstances() == 0 ...
-	Special assert exception rule for the initial settler unit that is never trainable.
-	Settler units are trainable even when their hammer cost is set to -1 due to their unique hammer cost calculation. */
-	FAssertMsg(GC.getUnitInfo(eIndex).getMaxPlayerInstances() == 0 || getUnitCount(eIndex) <= GC.getUnitInfo(eIndex).getMaxPlayerInstances(),
-		CvString::format("getUnitCount=%d is expected not to be greater than MaxPlayerInstances=%d for %s",
-		getUnitCount(eIndex), GC.getUnitInfo(eIndex).getMaxPlayerInstances(), GC.getUnitInfo(eIndex).getType()).c_str());
+	// NB: the national-unit cap is ERA-SCALED below (iMaxUnits), so a stale assert against the
+    // raw getMaxPlayerInstances() base wrongly fired thousands of times per turn (e.g. 7 assassins
+    // vs base 5 in a later era where the real cap is >=15). The meaningful check is against the
+    // scaled cap and lives just before the return.
 
 
 //    this scale will be used for national units only... the idea is to start them 5 at prehistoric and scale by 5 per age...
@@ -23894,9 +23903,9 @@ bool CvPlayer::isValidTriggerCorporation(const CvEventTriggerInfo& kTrigger, con
 	}
 	else
 	{
-		if (getHasCorporationCount(eCorporation) > 0)
+		if (getHasCorporationCount(eCorporation) == 0)
 		{
-			return true;
+			return false;
 		}
 
 		if (kTrigger.isHeadquarters())
@@ -23909,7 +23918,7 @@ bool CvPlayer::isValidTriggerCorporation(const CvEventTriggerInfo& kTrigger, con
 		}
 	}
 
-	return false;
+	return true;
 }
 
 void CvPlayer::launch(VictoryTypes eVictory)
@@ -24260,7 +24269,7 @@ bool CvPlayer::canDoResolution(VoteSourceTypes eVoteSource, const VoteSelectionS
 				TeamTypes eMaster = getTeam();
 				for (int iMaster = 0; iMaster < MAX_PC_TEAMS; ++iMaster)
 				{
-					if (iMaster != getID() && kOurTeam.isVassal((TeamTypes)iMaster))
+					if (iMaster != (int)getTeam() && kOurTeam.isVassal((TeamTypes)iMaster))
 					{
 						if (GET_TEAM((TeamTypes)iMaster).isVotingMember(eVoteSource))
 						{
@@ -28000,7 +28009,7 @@ void CvPlayer::changeSpecialistYieldPercentChanges(SpecialistTypes eIndex1, Yiel
 
 		foreach_(CvCity* pLoopCity, cities())
 		{
-			const int iExistingValue = (pLoopCity->getSpecialistCount(eIndex1) * getSpecialistYieldPercentChanges(eIndex1, eIndex2) - iOldValue) / 100;
+			const int iExistingValue = pLoopCity->getSpecialistCount(eIndex1) * (getSpecialistYieldPercentChanges(eIndex1, eIndex2) - iOldValue) / 100;
 			// set the new
 			pLoopCity->changeExtraYield(eIndex2, iExistingValue);
 		}
@@ -28489,6 +28498,7 @@ void CvPlayer::clearModifierTotals()
 
 	// Similarly assets for pop, land, and units
 	m_iAssets = 10 * (getTotalPopulation() + getTotalLandScored());
+	m_iUnitPower = 0;
 
 	foreach_(const CvUnit* pLoopUnit, units())
 	{
@@ -28711,17 +28721,17 @@ void CvPlayer::processTrait(TraitTypes eTrait, int iChange)
 
 	foreach_(const DomainModifier2& pair, GC.getTraitInfo(eTrait).getDomainFreeExperience())
 	{
-		changeNationalDomainFreeExperience(pair.first, pair.second);
+		changeNationalDomainFreeExperience(pair.first, pair.second * iChange);
 	}
 
 	foreach_(const DomainModifier2& pair, GC.getTraitInfo(eTrait).getDomainProductionModifiers())
 	{
-		changeNationalDomainProductionModifier(pair.first, pair.second);
+		changeNationalDomainProductionModifier(pair.first, pair.second * iChange);
 	}
 
 	foreach_(const TechModifier& pair, GC.getTraitInfo(eTrait).getTechResearchModifiers())
 	{
-		changeNationalTechResearchModifier(pair.first, pair.second);
+		changeNationalTechResearchModifier(pair.first, pair.second * iChange);
 	}
 
 	for (int iI = 0; iI < GC.getTraitInfo(eTrait).getNumUnitCombatFreeExperiences(); iI++)
@@ -29377,7 +29387,7 @@ void CvPlayer::updateExtraSpecialistCommerce()
 
 int CvPlayer::getSpecialistExtraYield(YieldTypes eIndex) const
 {
-	FASSERT_BOUNDS(0, NUM_COMMERCE_TYPES, eIndex);
+	FASSERT_BOUNDS(0, NUM_YIELD_TYPES, eIndex);
 	return m_aiSpecialistExtraYield[eIndex];
 }
 
@@ -29721,9 +29731,14 @@ uint64_t CvPlayer::getLeaderLevelupNextCultureTotal() const
 	uint64_t iPromoThreshold = 1000;
 	uint64_t iX = 1000;
 	// Set from the BUG menu (Stones2Stars tab) via MODDERGAMEOPTION_NEXT_TRAIT_CULTURE_REQ_PERCENT.
-    // Falls back to 25 (the former GlobalDefines default) before the BUG value has been pushed in.
+    // Falls back to 200 (the maximum dropdown value, i.e. the slowest / highest requirement) when the
+    // option has not been pushed in yet - old saves loaded with this DLL, and the first promotion
+    // checks at game start before ANewDawnSettings.setXMLOptionsfromIniFile() runs. Using the maximum
+    // guarantees an unset option can never spuriously cross the trait threshold; the real value takes
+    // over and the threshold recalculates as soon as the save load / BUG push provides it. The previous
+    // fallback of 25 made the requirement ~7x too cheap, so leaders gained traits far too fast (#156).
     int iReqPercent = GC.getGame().getModderGameOption(MODDERGAMEOPTION_NEXT_TRAIT_CULTURE_REQ_PERCENT);
-    if (iReqPercent == 0) iReqPercent = 25;
+    if (iReqPercent == 0) iReqPercent = 200;
     int iY = 10 * iReqPercent / 100;
 
 	if (GC.getGame().isOption(GAMEOPTION_LEADER_START_NO_POSITIVE_TRAITS))

--- a/Sources/CvPlayerAI.cpp
+++ b/Sources/CvPlayerAI.cpp
@@ -4377,7 +4377,7 @@ int CvPlayerAI::techPathValuePerUnitCost(techPath* path, TechTypes eTech, bool b
 	}
 	foreach_(const TechTypes & loopTech, *path)
 	{
-		int iTempCost = std::max(1, GET_TEAM(getTeam()).getResearchCost(eTech) - GET_TEAM(getTeam()).getResearchProgress(eTech));
+		int iTempCost = std::max(1, GET_TEAM(getTeam()).getResearchCost(loopTech) - GET_TEAM(getTeam()).getResearchProgress(loopTech));
 		int iTempValue = AI_TechValueCached(loopTech, bAsync);
 
 		if (gPlayerLogLevel > 2)
@@ -11313,11 +11313,12 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 				}
 #endif // BATTLEWORN
 				//TB Combat Mods End
-				break;
+
 
 				if (kUnitInfo.canMergeSplit() && GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS)){
 					iValue = int(iValue * EVAL_MERGE_FACTOR);
 				}
+				break;
 
 			}
 			case UNITAI_CITY_COUNTER:
@@ -11769,11 +11770,12 @@ int CvPlayerAI::AI_unitValue(UnitTypes eUnit, UnitAITypes eUnitAI, const CvArea*
 					iValue /= 2;
 					//better because it enables the unit to move through opponent territory with a RoP
 				}
-				break;
+
 
 			if (kUnitInfo.canMergeSplit() && GC.getGame().isOption(GAMEOPTION_COMBAT_SIZE_MATTERS)){
 				iValue = int(iValue * EVAL_MERGE_FACTOR);
 			}
+                break;
 
 			}
 			default: FErrorMsg("error");
@@ -13032,7 +13034,6 @@ int CvPlayerAI::AI_unitTargetMissionAIs(const CvUnit* pUnit, MissionAITypes* aeM
 			{
 				iPathTurns++;
 			}
-			iCount = iPathTurns;
 		}
 
 		// If the mission parameters state any amount of movement is ok or the amount of movement allowed is valid
@@ -20339,7 +20340,7 @@ void CvPlayerAI::AI_doDiplo()
 															*
 															GET_TEAM(GET_PLAYER((PlayerTypes)iI).getTeam()).getResearchLeft((TechTypes)iJ)
 														);
-													if (iValue > iBestValue)
+													if (iValue > iBestValue2)
 													{
 														iBestValue2 = iValue;
 														eBestGiveTech2 = (TechTypes)iJ;
@@ -21256,6 +21257,7 @@ int CvPlayerAI::AI_eventValue(EventTypes eEvent, const EventTriggeredData& kTrig
 		{
 			int iWarValue = (GET_TEAM(getTeam()).getDefensivePower() - GET_TEAM(GET_PLAYER(kTriggeredData.m_eOtherPlayer).getTeam()).getPower(true));// / std::max(1, GET_TEAM(getTeam()).getDefensivePower());
 			iWarValue -= 30 * AI_getAttitudeVal(kTriggeredData.m_eOtherPlayer);
+			iValue += iWarValue;
 		}
 
 		if (kEvent.getMaxPillage() > 0)
@@ -21265,6 +21267,7 @@ int CvPlayerAI::AI_eventValue(EventTypes eEvent, const EventTriggeredData& kTrig
 			iPillageValue *= 25 - iOtherPlayerAttitudeWeight;
 			iPillageValue *= iGameSpeedPercent;
 			iPillageValue /= 12500;
+			iValue += iPillageValue;
 		}
 
 		iValue += (iDiploValue * iGameSpeedPercent) / 100;
@@ -21544,7 +21547,7 @@ bool CvPlayerAI::AI_disbandUnit(int iExpThreshold)
 				//	For now make them less valuable the more you have (strictly this should depend
 				//	on what you need in terms of their buildable buildings, but start with an
 				//	approximation that is better than nothing
-				iValue *= std::min(0, getNumCities() * 2 - AI_getNumAIUnits(UNITAI_SUBDUED_ANIMAL)) / std::min(1, getNumCities());
+				iValue *= std::max(0, getNumCities() * 2 - AI_getNumAIUnits(UNITAI_SUBDUED_ANIMAL)) / std::max(1, getNumCities());
 				break;
 
 			case UNITAI_HUNTER:
@@ -23763,8 +23766,8 @@ void CvPlayerAI::AI_calculateAverages() const
 		}
 		m_iAverageGreatPeopleMultiplier = 0;
 
-		int64_t sumBaseCommerce[NUM_COMMERCE_TYPES];
-		int64_t sumFinalCommerce[NUM_COMMERCE_TYPES];
+		int64_t sumBaseCommerce[NUM_COMMERCE_TYPES] = {};
+        int64_t sumFinalCommerce[NUM_COMMERCE_TYPES] = {};
 		{
 			int iTotalPopulation = 0;
 
@@ -26313,7 +26316,7 @@ CvCity* CvPlayerAI::getReligiousVictoryTarget(const CvUnit* pUnit, const bool bN
 		const CvTeam& kLoopTeam = GET_TEAM(kLoopPlayer.getTeam());
 
 		if (kLoopPlayer.isAlive()
-			&& (TeamTypes(kLoopPlayer.getTeam()) == getTeam() || kLoopTeam.isVassal((TeamTypes)kLoopPlayer.getTeam()))
+			&& (TeamTypes(kLoopPlayer.getTeam()) == getTeam() || kLoopTeam.isVassal(getTeam()))
 			&& pUnitPlot->isHasPathToPlayerCity(getTeam(), PlayerTypes(iI))
 			)
 		{
@@ -26330,7 +26333,7 @@ CvCity* CvPlayerAI::getReligiousVictoryTarget(const CvUnit* pUnit, const bool bN
 					{
 						tempCityValue *= 2;
 					}
-					if (kLoopTeam.isVassal((TeamTypes)kLoopPlayer.getTeam()))
+					if (kLoopTeam.isVassal(getTeam()))
 					{
 						tempCityValue -= 12;
 					}
@@ -26949,11 +26952,21 @@ int CvPlayerAI::AI_militaryUnitTradeVal(const CvUnit* pUnit) const
 		}
 		else
 		{
-			const int iBestUnitAIValue = AI_unitValue(eBestUnit, GC.getUnitInfo(eUnit).getDefaultUnitAIType(), getCapitalCity()->area());
-			const int iThisUnitAIValue = AI_unitValue(eUnit, GC.getUnitInfo(eUnit).getDefaultUnitAIType(), getCapitalCity()->area());
+			CvCity* pCapital = getCapitalCity();
+            if (pCapital == NULL)
+            {
+                // Capital-less civ (bestBuildableUnitForAIType can still succeed via firstCity);
+                // no area to scale against, so fall back to the unit's production cost.
+                iValue = GC.getUnitInfo(eUnit).getProductionCost();
+            }
+            else
+            {
+                const int iBestUnitAIValue = AI_unitValue(eBestUnit, GC.getUnitInfo(eUnit).getDefaultUnitAIType(), pCapital->area());
+                const int iThisUnitAIValue = AI_unitValue(eUnit, GC.getUnitInfo(eUnit).getDefaultUnitAIType(), pCapital->area());
 
-			//	Value as cost of production of the unit we can build scaled by their relative AI value
-			iValue = (iThisUnitAIValue * GC.getUnitInfo(eBestUnit).getProductionCost()) / std::max(1, iBestUnitAIValue);
+                //	Value as cost of production of the unit we can build scaled by their relative AI value
+                iValue = (iThisUnitAIValue * GC.getUnitInfo(eBestUnit).getProductionCost()) / std::max(1, iBestUnitAIValue);
+            }
 		}
 
 		//	Normalise for game speed, and double as approximate hammer->gold conversion
@@ -27318,7 +27331,7 @@ int CvPlayerAI::AI_militaryBonusVal(BonusTypes eBonus)
 			if (bFound)
 			{
 				iValue += 300;
-				iValue /= iHasOrBonusCount;
+				iValue /= std::max(1, iHasOrBonusCount);
 			}
 		}
 	}
@@ -27724,7 +27737,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 			else iTemp += 2;
 		}
 		iValue += iTemp;
-
+		iTemp = 0;
 		if (kPromotion.isPillageMarauder())
 		{
 			if (pUnit)
@@ -27763,7 +27776,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 			else iTemp += 2;
 		}
 		iValue += iTemp;
-
+		iTemp = 0;
 		if (kPromotion.isPillageOnMove())
 		{
 			if (pUnit)
@@ -27786,7 +27799,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 			else iTemp++;
 		}
 		iValue += iTemp;
-
+		iTemp = 0;
 		if (kPromotion.isPillageOnVictory())
 		{
 			if (pUnit)
@@ -27809,7 +27822,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 			else iTemp += 4;
 		}
 		iValue += iTemp;
-
+		iTemp = 0;
 		if (kPromotion.isPillageResearch())
 		{
 			if (pUnit)
@@ -31783,7 +31796,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 		}
 		for (int iI = 0; iI < kPromotion.getNumVisibleImprovementRangeChanges(); iI++)
 		{
-			iTemp = kPromotion.getVisibleImprovementChange(iI).iIntensity;
+			iTemp = kPromotion.getVisibleImprovementRangeChange(iI).iIntensity;
 
 			if (iTemp != 0)
 			{
@@ -31936,7 +31949,7 @@ int CvPlayerAI::AI_promotionValue(PromotionTypes ePromotion, UnitTypes eUnit, co
 		}
 		else
 		{
-			if (!pUnit->isHasUnitCombat((UnitCombatTypes)kPromotion.getRemovesUnitCombatType(iI)))
+			if (pUnit->isHasUnitCombat((UnitCombatTypes)kPromotion.getRemovesUnitCombatType(iI)))
 			{
 				iValue -= AI_unitCombatValue((UnitCombatTypes)kPromotion.getRemovesUnitCombatType(iI), eUnit, pUnit, eUnitAI);
 			}

--- a/Sources/CvPlot.cpp
+++ b/Sources/CvPlot.cpp
@@ -2798,7 +2798,7 @@ bool CvPlot::canSeeDisplacementPlot(TeamTypes eTeam, int dx, int dy, int dx0, in
 				return false;
 			}
 		}
-		else if (seePlot->getElevationLevel() < iTopElevation && 2*iTopElevationDistance >= std::max(dx0, dy0))
+		else if (seePlot->getElevationLevel() < iTopElevation && 2*iTopElevationDistance >= std::max(abs(dx0), abs(dy0)))
 		{
 			return false;
 		}
@@ -4994,7 +4994,7 @@ int CvPlot::plotCount(ConstPlotUnitFunc funcA, int iData1A, int iData2A, const C
 
 int CvPlot::plotStrength(UnitValueFlags eFlags, ConstPlotUnitFunc funcA, int iData1A, int iData2A, PlayerTypes eOwner, TeamTypes eTeam, ConstPlotUnitFunc funcB, int iData1B, int iData2B, int iRange) const
 {
-	return plotStrengthTimes100(eFlags, funcA, iData1A, iData1B, eOwner, eTeam, funcB, iData1B, iData2B, iRange) / 100;
+	return plotStrengthTimes100(eFlags, funcA, iData1A, iData2A, eOwner, eTeam, funcB, iData1B, iData2B, iRange) / 100;
 }
 
 int CvPlot::plotStrengthTimes100(UnitValueFlags eFlags, ConstPlotUnitFunc funcA, int iData1A, int iData2A, PlayerTypes eOwner, TeamTypes eTeam, ConstPlotUnitFunc funcB, int iData1B, int iData2B, int iRange) const
@@ -9920,7 +9920,7 @@ bool CvPlot::changeBuildProgress(BuildTypes eBuild, int iChange, TeamTypes eTeam
 					const int iPossible = std::max((int)m_aBonusResult.size(), 100);
 					const uint32_t iResult = GC.getGame().getSorenRandNum(iPossible, "Select Bonus Placement Type");
 
-					if (iResult > m_aBonusResult.size())
+					if (iResult >= m_aBonusResult.size())
 					{
 						eBonusPlaced = NO_BONUS;
 					}
@@ -12106,14 +12106,11 @@ int CvPlot::getYieldWithBuild(BuildTypes eBuild, YieldTypes eYield, bool bWithUp
 		eImprovement = getImprovementType();
 		if (eImprovement != NO_IMPROVEMENT)
 		{
-			for (int iI = 0; iI < NUM_YIELD_TYPES; iI++)
-			{
-				iYield += GC.getImprovementInfo(eImprovement).getRouteYieldChanges(eRoute, iI);
-				if (getRouteType() != NO_ROUTE)
-				{
-					iYield -= GC.getImprovementInfo(eImprovement).getRouteYieldChanges(getRouteType(), iI);
-				}
-			}
+            iYield += GC.getImprovementInfo(eImprovement).getRouteYieldChanges(eRoute, eYield);
+            if (getRouteType() != NO_ROUTE)
+            {
+                iYield -= GC.getImprovementInfo(eImprovement).getRouteYieldChanges(getRouteType(), eYield);
+            }
 		}
 	}
 
@@ -13230,7 +13227,10 @@ bool CvPlot::isInUnitZoneOfControl(PlayerTypes ePlayer) const
 		foreach_(const CvUnit* pLoopUnit, pAdjacentPlot->units()
 		| filtered(bind(CvUnit::isZoneOfControl, _1)))
 		{
-			return GET_TEAM(pLoopUnit->getTeam()).isAtWar(GET_PLAYER(ePlayer).getTeam());
+			if (GET_TEAM(pLoopUnit->getTeam()).isAtWar(GET_PLAYER(ePlayer).getTeam()))
+            {
+                return true;
+            }
 		}
 	}
 	return false;
@@ -13568,10 +13568,16 @@ void CvPlot::unitGameStateCorrections()
 		{
 			if (!pLoopUnit->atPlot(this))
 			{
-				removeUnit(pLoopUnit);
-				bUpdate = true;
+				// removeUnit() deletes this unit's node from m_units, so capture the next node first.
+                CLLNode<IDInfo>* pNextNode = nextUnitNode(pUnitNode);
+                removeUnit(pLoopUnit);
+                bUpdate = true;
+                pUnitNode = pNextNode;
 			}
-			pUnitNode = nextUnitNode(pUnitNode);
+			else
+            {
+                pUnitNode = nextUnitNode(pUnitNode);
+            }
 		}
 	}
 

--- a/Sources/CvSelectionGroup.cpp
+++ b/Sources/CvSelectionGroup.cpp
@@ -1430,19 +1430,22 @@ bool CvSelectionGroup::startMission()
 						}
 						iMovesLeft /= 100;
 
-						iMovesLeft = std::max(iMaxMovesLeft, iMovesLeft);
-
-						if (iMovesLeft >= iMaxMovesLeft && pLoopUnit->pillage())
-						{
-							bAction = true;
-							if( isHuman() || canAllMove() )
-							{
-								bDidPillage = true;
-								iMovesLeft -= 1;
-								break;
-							}
-						}
-						iNextMaxMovesLeft = std::min( iNextMaxMovesLeft, iMovesLeft );
+						if (iMovesLeft >= iMaxMovesLeft)
+                        {
+                            if (pLoopUnit->pillage())
+                            {
+                                bAction = true;
+                                if( isHuman() || canAllMove() )
+                                {
+                                    bDidPillage = true;
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            iNextMaxMovesLeft = std::max( iNextMaxMovesLeft, iMovesLeft );
+                        }
 					}
 				}
 
@@ -2342,6 +2345,7 @@ bool CvSelectionGroup::continueMission(int iSteps)
 				if (!isHuman() || missionNode->m_data.eMissionType != MISSION_MOVE_TO)
 				{
 					deleteMissionQueueNode(missionNode);
+					missionNode = NULL;
 
 					// We executed this one ok but if we have no moves left don't leave
 					//	it with ACTIVITY_AWAKE as its state as that'll just cause the AI to spin wheels.
@@ -2744,9 +2748,9 @@ bool CvSelectionGroup::canDoInterfaceModeAt(InterfaceModeTypes eInterfaceMode, C
 			}
 			case INTERFACEMODE_SHADOW_UNIT:
 			{
-				foreach_(CvUnit* pLoopUnit, pPlot->units())
+				foreach_(CvUnit* pPlotUnit, pPlot->units())
 				{
-					if (pLoopUnit->canShadowAt(pPlot, pLoopUnit))
+					if (pLoopUnit->canShadowAt(pPlot, pPlotUnit))
 					{
 						return true;
 					}
@@ -3102,10 +3106,13 @@ int CvSelectionGroup::getMinimumRBombardRange() const
 	int iLowest = MAX_INT;
 	foreach_(const CvUnit* pLoopUnit, units())
 	{
-		const int iTemp = pLoopUnit->rBombardDamageLimit();
-		if (iTemp > 0 && iTemp < iLowest)
+		if (pLoopUnit->rBombardDamageLimit() > 0)
 		{
-			iLowest = pLoopUnit->getDCMBombRange();
+			const int iRange = pLoopUnit->getDCMBombRange();
+			if (iRange < iLowest)
+			{
+				iLowest = iRange;
+			}
 		}
 	}
 
@@ -4996,7 +5003,7 @@ int	CvSelectionGroup::getWorstDamagePercent(UnitCombatTypes eIgnoreUnitCombat) c
 	{
 		if (eIgnoreUnitCombat == NO_UNITCOMBAT || !pLoopUnit->isHasUnitCombat(eIgnoreUnitCombat))
 		{
-			if (pLoopUnit->getDamage() > iWorstDamage)
+			if (pLoopUnit->getDamagePercent() > iWorstDamage)
 			{
 				iWorstDamage = pLoopUnit->getDamagePercent();
 			}

--- a/Sources/CvSelectionGroupAI.cpp
+++ b/Sources/CvSelectionGroupAI.cpp
@@ -466,6 +466,10 @@ int CvSelectionGroupAI::AI_attackOdds(const CvPlot* pPlot, bool bPotentialEnemy,
 		{
 			//	There was no attacker in the first place!
 			iResult = 0;
+			if ( bWin != NULL )
+            {
+                *bWin = false;
+            }
 		}
 		else
 		{

--- a/Sources/CvTeam.cpp
+++ b/Sources/CvTeam.cpp
@@ -1374,7 +1374,7 @@ void CvTeam::declareWar(TeamTypes eTeam, bool bNewDiplo, WarPlanTypes eWarPlan)
 						for (int iJ = 0; iJ < MAX_PC_PLAYERS; iJ++)
 						{
 							// Player is not on our team nor on the team we declared war on.
-							if (GET_PLAYER((PlayerTypes)iI).isAliveAndTeam(getID(), false) && GET_PLAYER((PlayerTypes)iJ).getTeam() != eTeam
+							if (GET_PLAYER((PlayerTypes)iJ).isAliveAndTeam(getID(), false) && GET_PLAYER((PlayerTypes)iJ).getTeam() != eTeam
 							// Friends with the leader of the team we declared war on
 							&& GET_PLAYER((PlayerTypes)iJ).AI_getAttitude(teamFoe.getLeaderID()) >= ATTITUDE_PLEASED)
 							{
@@ -2660,7 +2660,7 @@ int CvTeam::getResearchCost(TechTypes eTech) const
 
 	if (!isNPC() && !isHuman(true))
 	{
-		iMod =
+		iMod +=
 			(
 				GC.getHandicapInfo(GC.getGame().getHandicapType()).getAIResearchPercent() - 100
 				+

--- a/Sources/CvTeamAI.cpp
+++ b/Sources/CvTeamAI.cpp
@@ -937,9 +937,9 @@ int CvTeamAI::AI_chooseElection(const VoteSelectionData& kVoteSelectionData) con
 			{
 				if (GET_PLAYER((PlayerTypes)iJ).isAliveAndTeam(getID()))
 				{
-					const PlayerVoteTypes eVote = GET_PLAYER((PlayerTypes)iJ).AI_diploVote(kVoteSelectionData.aVoteOptions[iI], eVoteSource, true);
+					const PlayerVoteTypes ePlayerVote = GET_PLAYER((PlayerTypes)iJ).AI_diploVote(kVoteSelectionData.aVoteOptions[iI], eVoteSource, true);
 
-					if (eVote != PLAYER_VOTE_YES || eVote == GC.getGame().getVoteOutcome((VoteTypes)iI))
+					if (ePlayerVote != PLAYER_VOTE_YES || ePlayerVote == GC.getGame().getVoteOutcome(eVote))
 					{
 						bValid = false;
 						break;
@@ -2586,7 +2586,7 @@ DenialTypes CvTeamAI::AI_makePeaceTrade(TeamTypes ePeaceTeam, TeamTypes eTeam) c
 		return DENIAL_CONTACT_THEM;
 	}
 
-	int iLandRatio = ((getTotalLand(true) * 100) / std::max(20, GET_TEAM(eTeam).getTotalLand(true)));
+	int iLandRatio = ((getTotalLand(true) * 100) / std::max(20, GET_TEAM(ePeaceTeam).getTotalLand(true)));
 	if (iLandRatio > 250)
 	{
 		return DENIAL_VICTORY;

--- a/Sources/CvUnit.cpp
+++ b/Sources/CvUnit.cpp
@@ -6706,6 +6706,7 @@ bool CvUnit::canAutomate(AutomateTypes eAutomate) const
 		{
 			return false;
 		}
+		break;
 	case AUTOMATE_AIR_RECON:
 		if (!canRecon())
 		{
@@ -20468,22 +20469,15 @@ bool CvUnit::isPromotionValid(PromotionTypes ePromotion, bool bFree, bool bKeepC
 			}
 		}
 		if (promo.getPromotionLine() != NO_PROMOTIONLINE)
-		{
-			for (int iI = 0; iI < GC.getPromotionLineInfo(promo.getPromotionLine()).getNumNotOnGameOptions(); iI++)
-			{
-				if (GC.getGame().isOption((GameOptionTypes)GC.getPromotionLineInfo(promo.getPromotionLine()).getNotOnGameOption(iI)))
-				{
-					return false;
-				}
-			}
-			for (int iI = 0; iI < GC.getPromotionLineInfo(promo.getPromotionLine()).getNumNotOnGameOptions(); iI++)
-			{
-				if (!GC.getGame().isOption((GameOptionTypes)GC.getPromotionLineInfo(promo.getPromotionLine()).getNotOnGameOption(iI)))
-				{
-					return false;
-				}
-			}
-		}
+        {
+            for (int iI = 0; iI < GC.getPromotionLineInfo(promo.getPromotionLine()).getNumNotOnGameOptions(); iI++)
+            {
+                if (GC.getGame().isOption((GameOptionTypes)GC.getPromotionLineInfo(promo.getPromotionLine()).getNotOnGameOption(iI)))
+                {
+                    return false;
+                }
+            }
+        }
 	}
 	// Very few reasons to deny a unit promotions that are specifically set to be a free for it.
 	if (m_pUnitInfo->getFreePromotions(ePromotion) || GET_PLAYER(getOwner()).isFreePromotion(getUnitType(), ePromotion))
@@ -32990,7 +32984,7 @@ int CvUnit::flankingStrengthbyUnitCombatTotal(UnitCombatTypes eCombatType) const
 		std::max(
 			0,
 			m_pUnitInfo->getFlankingStrengthbyUnitCombatType(eCombatType)
-			+ getExtraFlankingStrengthbyUnitCombatType(eCombatType, isCommander(), isCommodore)
+			+ getExtraFlankingStrengthbyUnitCombatType(eCombatType, isCommander(), isCommodore())
 		)
 	);
 }
@@ -35928,7 +35922,7 @@ int CvUnit::getPowerValueTotal() const
 void CvUnit::setSMPowerValue(bool bForLoad)
 {
 	const int oldSMPowerValue = m_iSMPowerValue;
-	const int m_iSMPowerValue = applySMRank(m_pUnitInfo->getPowerValue(), getSizeMattersOffsetValue(), GC.getSIZE_MATTERS_MOST_MULTIPLIER());
+	m_iSMPowerValue = applySMRank(m_pUnitInfo->getPowerValue(), getSizeMattersOffsetValue(), GC.getSIZE_MATTERS_MOST_MULTIPLIER());
 	FASSERT_NOT_NEGATIVE(m_iSMPowerValue);
 	if (!bForLoad)
 	{

--- a/Sources/CvUnitAI.cpp
+++ b/Sources/CvUnitAI.cpp
@@ -3235,7 +3235,7 @@ void CvUnitAI::AI_attackCityMove()
 
 	bool bHuntBarbs = false;
 
-	if (!isNPC() && area()->getCitiesPerPlayer(BARBARIAN_PLAYER) > 0 || area()->getCitiesPerPlayer(NEANDERTHAL_PLAYER) > 0)
+	if (!isNPC() && (area()->getCitiesPerPlayer(BARBARIAN_PLAYER) > 0 || area()->getCitiesPerPlayer(NEANDERTHAL_PLAYER) > 0))
 	{
 		if ((eAreaAIType != AREAAI_OFFENSIVE) && (eAreaAIType != AREAAI_DEFENSIVE) && !bAlert1 && !bTurtle)
 		{
@@ -3473,7 +3473,6 @@ void CvUnitAI::AI_attackCityMove()
 						{
 							iNeedSupportCount++;
 						}
-						iNeedSupportCount /= 4;
 						if (pLoopUnit->isHealsUnitCombat(eHealType))
 						{
 							iNeedSupportCount -= pLoopUnit->getNumHealSupportTotal();
@@ -3483,6 +3482,7 @@ void CvUnitAI::AI_attackCityMove()
 							}
 						}
 					}
+					iNeedSupportCount /= 4;
 					if (iNeedSupportCount > 0 && iNeedSupportCount > iMostNeededSupportCount)
 					{
 						iMostNeededSupportCount = iNeedSupportCount;
@@ -4674,41 +4674,11 @@ void CvUnitAI::AI_reserveMove()
 		return;
 	}
 
-	//Check for Properties :
-	int iMaxPropertyUnitsPercent = 20;
-	const PlayerTypes eOwner = getOwner();
-	CvPlayerAI& player = GET_PLAYER(eOwner);
-	const CvArea* pArea = area();
-	int iPropControlInArea = player.AI_totalAreaUnitAIs(pArea, UNITAI_PROPERTY_CONTROL);
-	int iUnitsInArea = player.getNumUnits();
-	if ((iPropControlInArea * 100 / (iUnitsInArea + 1)) < iMaxPropertyUnitsPercent)
-	{
-		for (int iI = 0; iI < GC.getNumPropertyInfos(); iI++)
-		{
-			const PropertyTypes pProperty = (PropertyTypes)iI;
-			if (GC.getPropertyInfo(pProperty).getAIWeight() != 0)
-			{
-				int iCurrentValue = getPropertiesConst()->getValueByProperty(pProperty);
-				if (iCurrentValue > 0)
-				{   //it has properties control 
-					AI_setUnitAIType(UNITAI_PROPERTY_CONTROL);
-					getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, NO_MISSIONAI);
-					CvWString StrunitAIType;
-					CvWString StrUnitName;
-					if (gUnitLogLevel > 2)
-					{
-						StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
-						StrUnitName = m_szName;
-						if (StrUnitName.length() == 0)
-						{
-							StrUnitName = getName(0).GetCString();
-						}
-						logAiEvaluations(3, "	Player %S Unit %S of type %S - Set form Reserve to property Contr., it has prop. found", GET_PLAYER(getOwner()).getCivilizationDescription(0), StrUnitName.GetCString(), StrunitAIType.GetCString());
-					}
-				}
-			}
-		}
-	}
+	// NB: a RESERVE unit is no longer flipped to UNITAI_PROPERTY_CONTROL here. Property-control
+    // units are produced as that role from creation by the need-based path in
+    // CvCityAI::AI_chooseProduction (and the capability-checked AI_guardCity ejection); poaching
+    // general reserve units caused a RESERVE<->PROPERTY_CONTROL oscillation (the handler bounced
+    // non-capable / not-currently-needed units straight back). See AI_fulfillPropertyControlNeed.
 
 	if (!plot()->isOwned())
 	{
@@ -12385,59 +12355,15 @@ bool CvUnitAI::AI_guardCity(bool bLeave, bool bSearch, int iMaxPath)
 
 			if (pCity != NULL && plotSet.find(pPlot) != plotSet.end())
 			{
-				//	Check property control attributes first - they may cause us to defend in the city
-				//	regardless of other conditions
-				#define MAX_PROPCONTROL_PERCENT_TO_JOIN 20 //Calvitix Add a limit to the Join to PropControl Team (when already too much units)
-				const PlayerTypes eOwner = getOwner();
-				CvPlayerAI& player = GET_PLAYER(eOwner);
-				const CvArea* pArea = area();
-				int iPropControlInArea = player.AI_totalAreaUnitAIs(pArea, UNITAI_PROPERTY_CONTROL);
-				int iUnitsInArea = player.getNumUnits();
-				if ((iPropControlInArea * 100 / iUnitsInArea) < MAX_PROPCONTROL_PERCENT_TO_JOIN)
-				{
-
-					if (getGroup()->AI_hasBeneficialPropertyEffectForCity(pCity, NO_PROPERTY))
-					{
-						//	We have at least one unit that can help the ciy's property control (aka crime usually)
-						//	Split ou he best such unit and have it defend in the city
-						CvSelectionGroup* pOldGroup = getGroup();
-						CvUnit* pEjectedUnit = getGroup()->AI_ejectBestPropertyManipulator(pCity);
-
-						FAssert(pEjectedUnit != NULL);
-						pEjectedUnit->AI_setUnitAIType(UNITAI_PROPERTY_CONTROL);
-
-						if (gUnitLogLevel > 2)
-						{
-							const CvWString StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
-							CvWString StrUnitName = m_szName;
-							if (StrUnitName.length() == 0)
-							{
-								StrUnitName = getName(0).GetCString();
-							}
-							logAiEvaluations(3, "	Player %S Unit %S of type %S - is ejected from group To Maintain Prop Control in %S", GET_PLAYER(getOwner()).getCivilizationDescription(0), StrUnitName.GetCString(), StrunitAIType.GetCString(), pCity->getName().GetCString());
-						}
-
-						if (atPlot(pCity->plot()))
-						{
-							//	Mark the ejected unit as part of the city garrison
-							pEjectedUnit->getGroup()->AI_setAsGarrison(pCity);
-							pEjectedUnit->getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, MISSIONAI_GUARD_CITY, NULL);
-							return (pEjectedUnit->getGroup() == pOldGroup || pEjectedUnit == this);
-						}
-						else if (pEjectedUnit->generatePath(pCity->plot(), 0, true))
-						{
-							//	Mark the ejected unit as part of the city garrison
-							pEjectedUnit->getGroup()->AI_setAsGarrison(pCity);
-							pEjectedUnit->getGroup()->pushMission(MISSION_MOVE_TO, pCity->getX(), pCity->getY(), 0, false, false, MISSIONAI_GUARD_CITY, NULL);
-							return (pEjectedUnit->getGroup() == pOldGroup || pEjectedUnit == this);
-						}
-						else
-						{
-							//	If we can't move after all regroup and continue regular defensive processing
-							pEjectedUnit->joinGroup(pOldGroup);
-						}
-					}
-				}
+				// NB: removed the property-control ejection/flip that used to re-type a garrisoned
+                // unit to UNITAI_PROPERTY_CONTROL here. It used a broad capability test
+                // (AI_hasBeneficialPropertyEffectForCity) that disagreed with the handler's narrow
+                // one (getPropertyManipulators), so non-base-manipulator units got flipped and then
+                // bounced straight back -> RESERVE<->PROPERTY_CONTROL oscillation. It also masked
+                // the real need: flipped units made the property "getting better" and filled the 20%
+                // quota, which blocked the need-based production path (CvCityAI::AI_chooseProduction
+                // ~14458). Property-control units now come ONLY from that production path, assigned
+                // the role at creation and never flipped.
 
 				const int iPlotDanger2 = GET_PLAYER(getOwner()).AI_getPlotDanger(pPlot, 2);
 
@@ -12679,7 +12605,7 @@ bool CvUnitAI::AI_guardCity(bool bLeave, bool bSearch, int iMaxPath)
 				{
 					continue;
 				}
-				if (!(pLoopCity->AI_isDefended((!AI_isCityAIType()) ? pLoopCity->plot()->plotStrength(UNITVALUE_FLAGS_DEFENSIVE, PUF_canDefendGroupHead, -1, -1, getOwner(), NO_TEAM, PUF_isNotCityAIType) : 0), 2) ||
+				if (!(pLoopCity->AI_isDefended((!AI_isCityAIType()) ? pLoopCity->plot()->plotStrength(UNITVALUE_FLAGS_DEFENSIVE, PUF_canDefendGroupHead, -1, -1, getOwner(), NO_TEAM, PUF_isNotCityAIType) : 0, 2)) ||
 					(isMilitaryHappiness() && !(pLoopCity->AI_isAdequateHappinessMilitary())))
 				{
 					if (!pLoopCity->plot()->isVisibleEnemyUnit(this))
@@ -16162,7 +16088,11 @@ bool CvUnitAI::AI_seaAreaAttack()
 	for (CvReachablePlotSet::const_iterator itr = plotSet.begin(); itr != plotSet.end(); ++itr)
 	{
 		CvPlot* pLoopPlot = itr.plot();
-		if (pLoopPlot->area() == area() && pLoopPlot->isVisible(getTeam(), false) && pLoopPlot->getOwner() == getOwner())
+		// Relaxed (#sea-ai): pursue visible enemy ships anywhere in the sea area, not only within
+        // plots we own. The generatePath() below still blocks entering territory we'd have to declare
+        // war on, so this stays peace-safe while letting attack-sea units (incl. human-automated) leave
+        // friendly waters to engage. Was: ... && pLoopPlot->getOwner() == getOwner().
+		if (pLoopPlot->area() == area() && pLoopPlot->isVisible(getTeam(), false))
 		{
 			int iCount = pLoopPlot->plotCount(PUF_isEnemy, getOwner(), 0, NULL, NO_PLAYER, NO_TEAM, PUF_isVisible, getOwner());
 
@@ -16280,7 +16210,7 @@ bool CvUnitAI::AI_patrol(bool bIgnoreDanger)
 				}
 			}
 
-			if (iValue > iBestValue && !bIgnoreDanger && exposedToDanger(pAdjacentPlot, 60))
+			if (iValue > iBestValue && (bIgnoreDanger || !exposedToDanger(pAdjacentPlot, 60)))
 			{
 				iBestValue = iValue;
 				pBestPlot = pAdjacentPlot;
@@ -17880,7 +17810,7 @@ bool CvUnitAI::AI_goToTargetCity(int iFlags, int iMaxPathTurns, const CvCity* pT
 
 					if (pPathPlot->isVisibleEnemyUnit(getOwner()))
 					{
-						bool bWin;
+						bool bWin = false;
 						int iExpectedGainOdds = getGroup()->AI_attackOdds(pPathPlot, true, false, &bWin);
 
 						if (iExpectedGainOdds < 50)
@@ -21784,7 +21714,7 @@ bool CvUnitAI::AI_irrigateTerritory()
 				if ((eImprovement == NO_IMPROVEMENT || eNonObsoleteBonus == NO_BONUS || !GC.getImprovementInfo(eImprovement).isImprovementBonusTrade(eNonObsoleteBonus))
 				&& pLoopPlot->isIrrigationAvailable(true))
 				{
-					int iBestTempBuildValue = MAX_INT;
+					int iBestTempBuildValue = 0;
 					BuildTypes eBestTempBuild = NO_BUILD;
 
 					for (int iJ = 0; iJ < GC.getNumBuildInfos(); iJ++)
@@ -21797,7 +21727,7 @@ bool CvUnitAI::AI_irrigateTerritory()
 						{
 							const int iValue = 10000 / (GC.getBuildInfo(eBuild).getTime() + 1);
 
-							if (iValue < iBestTempBuildValue)
+							if (iValue > iBestTempBuildValue)
 							{
 								iBestTempBuildValue = iValue;
 								eBestTempBuild = eBuild;
@@ -30055,20 +29985,13 @@ bool CvUnitAI::AI_fulfillPropertyControlNeed()
 
 			if (iNbControlForces > MAX_TARGET_CONTROL_MAINTAIN)
 			{
-				AI_setUnitAIType(UNITAI_RESERVE);
-				getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, NO_MISSIONAI);
-				if (gUnitLogLevel > 2)
-				{
-					const CvWString StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
-					CvWString StrUnitName = m_szName;
-					if (StrUnitName.length() == 0)
-					{
-						StrUnitName = getName(0).GetCString();
-					}
-					logAiEvaluations(3, "	Player %S Unit %S of type %S - City that need the most Prop Control Help : %S has a low Value and already > 10 PropControl Units- Set to UNITAI_RESERVE   (Value %d)", GET_PLAYER(getOwner()).getCivilizationDescription(0), StrUnitName.GetCString(), StrunitAIType.GetCString(), bestCity->getName().GetCString(), bestCityScore.result.score);
-				}
-				return false;
-			}
+                // Not needed right now: hold in place AS a property-control unit (the dedicated
+                // pool waits in-role) instead of flipping to RESERVE. That flip, paired with the
+                // (now removed) reserve-side conversion, caused the RESERVE<->PROPERTY_CONTROL
+                // oscillation. Property units keep their role from creation and are never flipped.
+                getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, MISSIONAI_PROPERTY_CONTROL_MAINTAIN, plot());
+                return true;
+            }
 
 
 		}
@@ -30128,21 +30051,11 @@ bool CvUnitAI::AI_fulfillPropertyControlNeed()
 		}
 	}
 	else
-	{   //No city found
-		AI_setUnitAIType(UNITAI_RESERVE);
-		getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, NO_MISSIONAI);
-		if (gUnitLogLevel > 2)
-		{
-			const CvWString StrunitAIType = GC.getUnitAIInfo(AI_getUnitAIType()).getType();
-			CvWString StrUnitName = m_szName;
-			if (StrUnitName.length() == 0)
-			{
-				StrUnitName = getName(0).GetCString();
-			}
-			logBBAI("	Player %S Unit %S of type %S - No city found to assign - Set to UNITAI_RESERVE", GET_PLAYER(getOwner()).getCivilizationDescription(0), StrUnitName.GetCString(), StrunitAIType.GetCString());
-		}
-
-	}
+	{   //No city needs control right now: hold in place as a property-control unit (the dedicated
+        //pool waits in-role); do NOT flip to RESERVE (that caused the oscillation).
+        getGroup()->pushMission(MISSION_SKIP, -1, -1, 0, false, false, MISSIONAI_PROPERTY_CONTROL_MAINTAIN, plot());
+        return true;
+    }
 	return false;
 }
 


### PR DESCRIPTION
-Update ai to handle property better by removing arbitrary property check and units flipping roles.
-Removed 2 usless asserts
-Size matter power now correctly calculated by ai
-Fixed conscription sometimes consuming a pop and not making a unit
-Removed false callback check for units having plot properties
-Bunch of small one line fixes of missed commas etc...
-Bombers without recon can now automate airbombing
-Patrol units can now move outside of danger instead of aways going towards danger
-Now if ai wants to irigate a territory chooses the fastest version not the slowest
-Healer supports contracts can actually trigger for stacks so ai can take healers in army
-Reduced incorrect info on multi-commerce specialists
-Ai should now be able to do a better multi-building queue loop
-Ai now calculates culture pressure in a plot not a wrong value
-Added a null guard after ai completes a mission to prevent infinity loop
-Corporation maintenance was massively overcharged now it properly calculates its upkeep costs
-Fixed bug in calculation of minimum bombard range
-Fix ai looting
-Leader trait culture percent in bug menu now persist on save and load
-Updated CvMapGenerator for fractal map gen, with correct height and Y scores that wrongly used X and width
-Diplomacy will now show properly when you filter for equal power
-Fixed a bug with capital events in revolutions with assimilation
-Reduced the insane anarchy when capturing enemy capital to 1/5 of what it was aka from 100 to 20 turns
-Removed some dead code
-Fixed world trade routes not being assigned to all players
-Fixed NPC guard from using civics to not be too strict
-Fixed specialist wrong percentage yield changes
-Fixed free xp, bonus production and research where not removed when removing a trait so they stayed functioning in the back now are properly cleared on revoking a trait.
-Fixed a bug for corps HQ founding
-Fixed a bug in cutting edge cost option where ai did not get the same cost differences for tech as human player
-Fixed a bug with seeing plots
-Fixed a bug with zone of control being disabled when friendly unit walks in before hostile
-Fixed a bug where spreading a corp didnt always require the HQ to exists
-Fixed a bug in vasal-master loop when iterating teams for being able to do resolutions
-Few ai fixes in targeting tech selection, target selection, buying tech now ai will more often buy more then 1 tech, and ai will give more value to pillaging
-Added some crash guards and log guards
-update to ai attack ods calculation when being blockaded
-Fixed bug with unit state on plot
-Fixed bug cylinder map
-Fixed bug with info who surendered to who in surender trade deal
-Fixed a bug when building projects that had no tech prereq not having their cost calculated corectly
-Attack sea order will now pursue enemies even beyond our borders